### PR TITLE
fix: liquidation & liquidation_redeem

### DIFF
--- a/crates/vault-registry/src/tests.rs
+++ b/crates/vault-registry/src/tests.rs
@@ -643,8 +643,9 @@ fn liquidate_succeeds() {
             VaultStatus::Liquidated
         ));
 
-        let moved_collateral =
-            (collateral_before * (issued_tokens - to_be_redeemed_tokens)) / issued_tokens;
+        let moved_collateral = (collateral_before
+            * (issued_tokens + to_be_issued_tokens - to_be_redeemed_tokens))
+            / (issued_tokens + to_be_issued_tokens);
 
         // check liquidation_vault tokens & collateral
         assert_eq!(
@@ -734,8 +735,9 @@ fn liquidate_at_most_secure_threshold() {
             VaultStatus::Liquidated
         ));
 
-        let moved_collateral =
-            (used_collateral * (issued_tokens - to_be_redeemed_tokens)) / issued_tokens;
+        let moved_collateral = (used_collateral
+            * (issued_tokens + to_be_issued_tokens - to_be_redeemed_tokens))
+            / (to_be_issued_tokens + issued_tokens);
 
         // check liquidation_vault tokens & collateral
         assert_eq!(

--- a/crates/vault-registry/src/tests.rs
+++ b/crates/vault-registry/src/tests.rs
@@ -463,7 +463,8 @@ fn redeem_tokens_liquidation_succeeds() {
             MockResult::Return(Ok(()))
         });
 
-        ext::oracle::btc_to_dots::<Test>.mock_safe(|amount| MockResult::Return(Ok(amount)));
+        // liquidation vault collateral
+        ext::collateral::for_account::<Test>.mock_safe(|_| MockResult::Return(1000u32.into()));
 
         assert_ok!(liquidation_vault.force_increase_to_be_issued(50));
         assert_ok!(liquidation_vault.force_issue_tokens(50));
@@ -471,7 +472,7 @@ fn redeem_tokens_liquidation_succeeds() {
         assert_ok!(VaultRegistry::redeem_tokens_liquidation(&user_id, 50));
         let liquidation_vault = VaultRegistry::get_rich_liquidation_vault();
         assert_eq!(liquidation_vault.data.issued_tokens, 0);
-        assert_emitted!(Event::RedeemTokensLiquidation(user_id, 50, 50));
+        assert_emitted!(Event::RedeemTokensLiquidation(user_id, 50, 500));
     });
 }
 
@@ -488,7 +489,8 @@ fn redeem_tokens_liquidation_does_not_call_recover_when_unnecessary() {
             MockResult::Return(Ok(()))
         });
 
-        ext::oracle::btc_to_dots::<Test>.mock_safe(|amount| MockResult::Return(Ok(amount)));
+        // liquidation vault collateral
+        ext::collateral::for_account::<Test>.mock_safe(|_| MockResult::Return(1000u32.into()));
 
         assert_ok!(liquidation_vault.force_increase_to_be_issued(25));
         assert_ok!(liquidation_vault.force_issue_tokens(25));
@@ -496,7 +498,11 @@ fn redeem_tokens_liquidation_does_not_call_recover_when_unnecessary() {
         assert_ok!(VaultRegistry::redeem_tokens_liquidation(&user_id, 10));
         let liquidation_vault = VaultRegistry::get_rich_liquidation_vault();
         assert_eq!(liquidation_vault.data.issued_tokens, 15);
-        assert_emitted!(Event::RedeemTokensLiquidation(user_id, 10, 10));
+        assert_emitted!(Event::RedeemTokensLiquidation(
+            user_id,
+            10,
+            (1000 * 10) / 50
+        ));
     });
 }
 

--- a/crates/vault-registry/src/types.rs
+++ b/crates/vault-registry/src/types.rs
@@ -607,6 +607,24 @@ pub(crate) struct RichSystemVault<T: Config> {
     pub(crate) data: DefaultSystemVault<T>,
 }
 
+#[cfg_attr(test, mockable)]
+impl<T: Config> RichSystemVault<T> {
+    pub(crate) fn redeemable_tokens(&self) -> Result<PolkaBTC<T>, DispatchError> {
+        Ok(self
+            .data
+            .issued_tokens
+            .checked_sub(&self.data.to_be_redeemed_tokens)
+            .ok_or(Error::<T>::ArithmeticUnderflow)?)
+    }
+    pub(crate) fn backed_tokens(&self) -> Result<PolkaBTC<T>, DispatchError> {
+        Ok(self
+            .data
+            .issued_tokens
+            .checked_add(&self.data.to_be_issued_tokens)
+            .ok_or(Error::<T>::ArithmeticOverflow)?)
+    }
+}
+
 impl<T: Config> UpdatableVault<T> for RichSystemVault<T> {
     fn id(&self) -> T::AccountId {
         self.data.id.clone()

--- a/parachain/runtime/tests/test_redeem.rs
+++ b/parachain/runtime/tests/test_redeem.rs
@@ -232,7 +232,7 @@ fn integration_test_redeem_polka_btc_liquidation_redeem() {
         // create tokens for the vault and user
         drop_exchange_rate_and_liquidate(VAULT);
 
-        let slashed_collateral = 10_000 - (10000 * to_be_redeemed) / (issued + 0);
+        let slashed_collateral = 10_000 - (10000 * to_be_redeemed) / (issued + to_be_issued);
 
         assert_eq!(
             CoreVaultData::liquidation_vault(),

--- a/parachain/runtime/tests/test_replace.rs
+++ b/parachain/runtime/tests/test_replace.rs
@@ -685,7 +685,7 @@ fn integration_test_replace_execute_replace_new_vault_liquidated() {
                 to_be_issued: replace_tokens,
                 backing_collateral: DEFAULT_COLLATERAL,
                 issued: 500,         // new
-                to_be_redeemed: 200, // new
+                to_be_redeemed: 150, // new
                 ..Default::default()
             },
         );
@@ -706,8 +706,8 @@ fn integration_test_replace_execute_replace_new_vault_liquidated() {
         assert_eq!(
             new_vault,
             CoreVaultData {
-                to_be_redeemed: 200,
-                backing_collateral: (DEFAULT_COLLATERAL * 200) / 500,
+                to_be_redeemed: 150,
+                backing_collateral: (DEFAULT_COLLATERAL * 150) / (replace_tokens + 500),
                 ..Default::default()
             }
         );
@@ -756,7 +756,7 @@ fn integration_test_replace_execute_replace_both_vaults_liquidated() {
                 to_be_issued: replace_tokens,
                 backing_collateral: DEFAULT_COLLATERAL,
                 issued: 500,         // new
-                to_be_redeemed: 100, // new
+                to_be_redeemed: 150, // new
                 ..Default::default()
             },
         );
@@ -780,8 +780,8 @@ fn integration_test_replace_execute_replace_both_vaults_liquidated() {
         assert_eq!(
             new_vault,
             CoreVaultData {
-                to_be_redeemed: 100,
-                backing_collateral: (DEFAULT_COLLATERAL * 100) / 500,
+                to_be_redeemed: 150,
+                backing_collateral: (DEFAULT_COLLATERAL * 150) / (replace_tokens + 500),
                 ..Default::default()
             }
         );
@@ -959,7 +959,7 @@ fn integration_test_replace_cancel_replace_new_vault_liquidated() {
                 to_be_issued: replace_tokens,
                 backing_collateral: DEFAULT_COLLATERAL,
                 issued: 500,         // new
-                to_be_redeemed: 200, // new
+                to_be_redeemed: 150, // new
                 ..Default::default()
             },
         );
@@ -981,8 +981,8 @@ fn integration_test_replace_cancel_replace_new_vault_liquidated() {
         assert_eq!(
             new_vault,
             CoreVaultData {
-                to_be_redeemed: 200,
-                backing_collateral: (DEFAULT_COLLATERAL * 200) / 500,
+                to_be_redeemed: 150,
+                backing_collateral: (DEFAULT_COLLATERAL * 150) / (500 + replace_tokens),
                 free_balance: DEFAULT_GRIEFING_COLLATERAL,
                 ..Default::default()
             }
@@ -1031,7 +1031,7 @@ fn integration_test_replace_cancel_replace_both_vaults_liquidated() {
                 to_be_issued: replace_tokens,
                 backing_collateral: DEFAULT_COLLATERAL,
                 issued: 500,         // new
-                to_be_redeemed: 100, // new
+                to_be_redeemed: 150, // new
                 ..Default::default()
             },
         );
@@ -1053,8 +1053,8 @@ fn integration_test_replace_cancel_replace_both_vaults_liquidated() {
         assert_eq!(
             new_vault,
             CoreVaultData {
-                to_be_redeemed: 100,
-                backing_collateral: (DEFAULT_COLLATERAL * 100) / 500,
+                to_be_redeemed: 150,
+                backing_collateral: (DEFAULT_COLLATERAL * 150) / (500 + replace_tokens),
                 free_balance: DEFAULT_GRIEFING_COLLATERAL,
                 ..Default::default()
             }


### PR DESCRIPTION
Two distinct changes, but since they overlap I made it into 1 PR. I suggest to look at the individual commits.

First change is a change to how liquidation works. We discussed earlier that we keep `collateral * (to-be-redeem /  issued)` in the vault, and slash the rest to the liquidation vault. However, I think it changed it to `collateral * (to-be-redeem /  (issued + to-be-issued)`, since at the time of slashing, the collateral is used to potentially back `issued + to-be-issued` tokens.

The second change fixes liquidation_redeem according to the discussions.