### PR TITLE
fix: only use backing collateral for get_total_collateralization

### DIFF
--- a/crates/vault-registry/src/ext.rs
+++ b/crates/vault-registry/src/ext.rs
@@ -6,10 +6,6 @@ pub(crate) mod collateral {
     use crate::types::DOT;
     use frame_support::dispatch::DispatchResult;
 
-    pub fn total_locked<T: collateral::Config>() -> DOT<T> {
-        <collateral::Module<T>>::get_total_collateral()
-    }
-
     pub fn transfer<T: collateral::Config>(
         source: &T::AccountId,
         destination: &T::AccountId,

--- a/crates/vault-registry/src/tests.rs
+++ b/crates/vault-registry/src/tests.rs
@@ -1493,6 +1493,36 @@ fn setup_blocks(blocks: u64) {
 }
 
 #[test]
+fn runtime_upgrade_succeeds() {
+    run_test(|| {
+        Vaults::<Test>::insert(
+            0,
+            Vault {
+                backing_collateral: 10,
+                ..Default::default()
+            },
+        );
+        Vaults::<Test>::insert(
+            1,
+            Vault {
+                backing_collateral: 20,
+                ..Default::default()
+            },
+        );
+        Vaults::<Test>::insert(
+            2,
+            Vault {
+                backing_collateral: 30,
+                ..Default::default()
+            },
+        );
+        assert_eq!(0, VaultRegistry::get_total_backing_collateral().unwrap());
+        VaultRegistry::_on_runtime_upgrade();
+        assert_eq!(60, VaultRegistry::get_total_backing_collateral().unwrap());
+    })
+}
+
+#[test]
 fn get_first_vault_with_sufficient_tokens_returns_different_vaults_for_different_amounts() {
     run_test(|| {
         setup_blocks(100);

--- a/crates/vault-registry/src/types.rs
+++ b/crates/vault-registry/src/types.rs
@@ -316,6 +316,7 @@ impl<T: Config> RichVault<T> {
                 .ok_or(Error::<T>::ArithmeticOverflow)?;
             Ok(())
         })?;
+        Module::<T>::increase_total_backing_collateral(collateral)?;
         ext::collateral::lock::<T>(&self.data.id, collateral)
     }
 
@@ -327,6 +328,7 @@ impl<T: Config> RichVault<T> {
                 .ok_or(Error::<T>::ArithmeticUnderflow)?;
             Ok(())
         })?;
+        Module::<T>::decrease_total_backing_collateral(collateral)?;
         ext::collateral::release_collateral::<T>(&self.data.id, collateral)
     }
 

--- a/parachain/runtime/src/lib.rs
+++ b/parachain/runtime/src/lib.rs
@@ -137,7 +137,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("btc-parachain"),
     impl_name: create_runtime_str!("btc-parachain"),
     authoring_version: 1,
-    spec_version: 3,
+    spec_version: 4,
     impl_version: 1,
     transaction_version: 1,
     apis: RUNTIME_API_VERSIONS,


### PR DESCRIPTION
requires storage migration