### PR TITLE
refactor: vault token forwarding to liquidation vault

### DIFF
--- a/crates/issue/src/benchmarking.rs
+++ b/crates/issue/src/benchmarking.rs
@@ -108,7 +108,7 @@ benchmarks! {
         ExchangeRateOracle::<T>::_set_exchange_rate(<T as exchange_rate_oracle::Config>::UnsignedFixedPoint::one()).unwrap();
         VaultRegistry::<T>::_register_vault(&vault_id, 100000000u32.into(), dummy_public_key()).unwrap();
 
-        VaultRegistry::<T>::increase_to_be_issued_tokens(&vault_id, value.into()).unwrap();
+        VaultRegistry::<T>::try_increase_to_be_issued_tokens(&vault_id, value.into()).unwrap();
         let secure_id = Security::<T>::get_secure_id(&vault_id);
         VaultRegistry::<T>::register_deposit_address(&vault_id, secure_id).unwrap();
     }: _(RawOrigin::Signed(origin), issue_id, tx_id, proof, raw_tx)

--- a/crates/issue/src/ext.rs
+++ b/crates/issue/src/ext.rs
@@ -56,11 +56,11 @@ pub(crate) mod vault_registry {
         <vault_registry::Module<T>>::get_active_vault_from_id(vault_id)
     }
 
-    pub fn increase_to_be_issued_tokens<T: vault_registry::Config>(
+    pub fn try_increase_to_be_issued_tokens<T: vault_registry::Config>(
         vault_id: &T::AccountId,
         amount: PolkaBTC<T>,
     ) -> Result<(), DispatchError> {
-        <vault_registry::Module<T>>::increase_to_be_issued_tokens(vault_id, amount)
+        <vault_registry::Module<T>>::try_increase_to_be_issued_tokens(vault_id, amount)
     }
 
     pub fn register_deposit_address<T: vault_registry::Config>(
@@ -82,18 +82,6 @@ pub(crate) mod vault_registry {
         height: T::BlockNumber,
     ) -> DispatchResult {
         <vault_registry::Module<T>>::_ensure_not_banned(vault, height)
-    }
-
-    pub fn decrease_liquidation_vault_to_be_issued_tokens<T: vault_registry::Config>(
-        amount: PolkaBTC<T>,
-    ) -> DispatchResult {
-        <vault_registry::Module<T>>::decrease_liquidation_vault_to_be_issued_tokens(amount)
-    }
-
-    pub fn increase_liquidation_vault_issued_tokens<T: vault_registry::Config>(
-        amount: PolkaBTC<T>,
-    ) -> DispatchResult {
-        <vault_registry::Module<T>>::increase_liquidation_vault_issued_tokens(amount)
     }
 
     pub fn decrease_to_be_issued_tokens<T: vault_registry::Config>(

--- a/crates/issue/src/tests.rs
+++ b/crates/issue/src/tests.rs
@@ -24,7 +24,7 @@ fn request_issue(
 
     ext::security::get_secure_id::<Test>.mock_safe(|_| MockResult::Return(get_dummy_request_id()));
 
-    ext::vault_registry::increase_to_be_issued_tokens::<Test>
+    ext::vault_registry::try_increase_to_be_issued_tokens::<Test>
         .mock_safe(|_, _| MockResult::Return(Ok(())));
     ext::vault_registry::register_deposit_address::<Test>
         .mock_safe(|_, _| MockResult::Return(Ok(BtcAddress::default())));
@@ -45,7 +45,7 @@ fn request_issue_ok(
 
     ext::security::get_secure_id::<Test>.mock_safe(|_| MockResult::Return(get_dummy_request_id()));
 
-    ext::vault_registry::increase_to_be_issued_tokens::<Test>
+    ext::vault_registry::try_increase_to_be_issued_tokens::<Test>
         .mock_safe(|_, _| MockResult::Return(Ok(())));
     ext::vault_registry::register_deposit_address::<Test>
         .mock_safe(|_, _| MockResult::Return(Ok(BtcAddress::default())));
@@ -248,7 +248,7 @@ fn test_execute_issue_overpayment_succeeds() {
             let mut increase_tokens_called = false;
             let mut refund_called = false;
 
-            ext::vault_registry::increase_to_be_issued_tokens::<Test>.mock_raw(|_, amount| {
+            ext::vault_registry::try_increase_to_be_issued_tokens::<Test>.mock_raw(|_, amount| {
                 increase_tokens_called = true;
                 assert_eq!(amount, 2);
                 MockResult::Return(Ok(()))
@@ -287,7 +287,7 @@ fn test_execute_issue_refund_succeeds() {
             .mock_safe(|_, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 103))));
 
         // return some arbitrary error
-        ext::vault_registry::increase_to_be_issued_tokens::<Test>.mock_safe(|_, amount| {
+        ext::vault_registry::try_increase_to_be_issued_tokens::<Test>.mock_safe(|_, amount| {
             assert_eq!(amount, 100);
             MockResult::Return(Err(TestError::IssueCompleted.into()))
         });

--- a/crates/redeem/src/ext.rs
+++ b/crates/redeem/src/ext.rs
@@ -70,11 +70,11 @@ pub(crate) mod vault_registry {
         <vault_registry::Module<T>>::get_vault_from_id(vault_id)
     }
 
-    pub fn increase_to_be_redeemed_tokens<T: vault_registry::Config>(
+    pub fn try_increase_to_be_redeemed_tokens<T: vault_registry::Config>(
         vault_id: &T::AccountId,
         amount: PolkaBTC<T>,
     ) -> DispatchResult {
-        <vault_registry::Module<T>>::increase_to_be_redeemed_tokens(vault_id, amount)
+        <vault_registry::Module<T>>::try_increase_to_be_redeemed_tokens(vault_id, amount)
     }
 
     pub fn redeem_tokens<T: vault_registry::Config>(

--- a/crates/redeem/src/lib.rs
+++ b/crates/redeem/src/lib.rs
@@ -264,7 +264,7 @@ impl<T: Config> Module<T> {
             Error::<T>::AmountBelowDustAmount
         );
 
-        ext::vault_registry::increase_to_be_redeemed_tokens::<T>(
+        ext::vault_registry::try_increase_to_be_redeemed_tokens::<T>(
             &vault_id,
             redeem_amount_polka_btc,
         )?;

--- a/crates/redeem/src/tests.rs
+++ b/crates/redeem/src/tests.rs
@@ -105,7 +105,7 @@ fn test_request_redeem_fails_with_amount_below_minimum() {
         let redeemer = ALICE;
         let amount = 9;
 
-        ext::vault_registry::increase_to_be_redeemed_tokens::<Test>.mock_safe(
+        ext::vault_registry::try_increase_to_be_redeemed_tokens::<Test>.mock_safe(
             move |vault_id, amount_btc| {
                 assert_eq!(vault_id, &BOB);
                 assert_eq!(amount_btc, amount);
@@ -238,7 +238,7 @@ fn test_request_redeem_succeeds_with_normal_redeem() {
         let amount = 9;
         let redeem_fee = 5;
 
-        ext::vault_registry::increase_to_be_redeemed_tokens::<Test>.mock_safe(
+        ext::vault_registry::try_increase_to_be_redeemed_tokens::<Test>.mock_safe(
             move |vault_id, amount_btc| {
                 assert_eq!(vault_id, &BOB);
                 assert_eq!(amount_btc, amount - redeem_fee);

--- a/crates/refund/src/ext.rs
+++ b/crates/refund/src/ext.rs
@@ -73,11 +73,11 @@ pub(crate) mod vault_registry {
     use crate::types::PolkaBTC;
     use frame_support::dispatch::{DispatchError, DispatchResult};
 
-    pub fn increase_to_be_issued_tokens<T: vault_registry::Config>(
+    pub fn try_increase_to_be_issued_tokens<T: vault_registry::Config>(
         vault_id: &T::AccountId,
         amount: PolkaBTC<T>,
     ) -> Result<(), DispatchError> {
-        <vault_registry::Module<T>>::increase_to_be_issued_tokens(vault_id, amount)
+        <vault_registry::Module<T>>::try_increase_to_be_issued_tokens(vault_id, amount)
     }
 
     pub fn issue_tokens<T: vault_registry::Config>(

--- a/crates/refund/src/lib.rs
+++ b/crates/refund/src/lib.rs
@@ -197,7 +197,7 @@ impl<T: Config> Module<T> {
         )?;
 
         // mint polkabtc corresponding to the fee. Note that this can fail
-        ext::vault_registry::increase_to_be_issued_tokens::<T>(&request.vault, request.fee)?;
+        ext::vault_registry::try_increase_to_be_issued_tokens::<T>(&request.vault, request.fee)?;
         ext::vault_registry::issue_tokens::<T>(&request.vault, request.fee)?;
         ext::treasury::mint::<T>(request.vault.clone(), request.fee);
 

--- a/crates/refund/src/tests.rs
+++ b/crates/refund/src/tests.rs
@@ -12,7 +12,7 @@ use sp_core::H160;
 fn test_refund_succeeds() {
     run_test(|| {
         ext::fee::get_refund_fee_from_total::<Test>.mock_safe(|_| MockResult::Return(Ok(5)));
-        ext::vault_registry::increase_to_be_issued_tokens::<Test>
+        ext::vault_registry::try_increase_to_be_issued_tokens::<Test>
             .mock_safe(|_, _| MockResult::Return(Ok(())));
         ext::vault_registry::issue_tokens::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
         ext::btc_relay::verify_transaction_inclusion::<Test>

--- a/crates/replace/src/benchmarking.rs
+++ b/crates/replace/src/benchmarking.rs
@@ -75,9 +75,9 @@ benchmarks! {
 
         VaultRegistry::<T>::_register_vault(&old_vault_id, 100000000u32.into(), dummy_public_key()).unwrap();
 
-        VaultRegistry::<T>::increase_to_be_issued_tokens(&old_vault_id, amount.into()).unwrap();
+        VaultRegistry::<T>::try_increase_to_be_issued_tokens(&old_vault_id, amount.into()).unwrap();
         VaultRegistry::<T>::issue_tokens(&old_vault_id, amount.into()).unwrap();
-        VaultRegistry::<T>::increase_to_be_replaced_tokens(&old_vault_id, amount.into()).unwrap();
+        VaultRegistry::<T>::try_increase_to_be_replaced_tokens(&old_vault_id, amount.into()).unwrap();
 
         VaultRegistry::<T>::_register_vault(&new_vault_id, 100000000u32.into(), dummy_public_key()).unwrap();
 
@@ -105,7 +105,7 @@ benchmarks! {
         VaultRegistry::<T>::set_secure_collateral_threshold(<T as vault_registry::Config>::UnsignedFixedPoint::checked_from_rational(1, 100000).unwrap()); // 0.001%
         VaultRegistry::<T>::set_auction_collateral_threshold(<T as vault_registry::Config>::UnsignedFixedPoint::checked_from_rational(10000, 100).unwrap()); // 10000%
 
-        VaultRegistry::<T>::increase_to_be_issued_tokens(&old_vault_id, btc_amount.into()).unwrap();
+        VaultRegistry::<T>::try_increase_to_be_issued_tokens(&old_vault_id, btc_amount.into()).unwrap();
         VaultRegistry::<T>::issue_tokens(&old_vault_id, btc_amount.into()).unwrap();
     }: _(RawOrigin::Signed(new_vault_id), old_vault_id, btc_amount.into(), collateral.into(), new_vault_btc_address)
 
@@ -211,12 +211,12 @@ benchmarks! {
         ExchangeRateOracle::<T>::_set_exchange_rate(<T as exchange_rate_oracle::Config>::UnsignedFixedPoint::one()).unwrap();
 
         VaultRegistry::<T>::_register_vault(&old_vault_id, 100000000u32.into(), dummy_public_key()).unwrap();
-        VaultRegistry::<T>::increase_to_be_issued_tokens(&old_vault_id, amount.into()).unwrap();
+        VaultRegistry::<T>::try_increase_to_be_issued_tokens(&old_vault_id, amount.into()).unwrap();
         VaultRegistry::<T>::issue_tokens(&old_vault_id, amount.into()).unwrap();
-        VaultRegistry::<T>::increase_to_be_redeemed_tokens(&old_vault_id, amount.into()).unwrap();
+        VaultRegistry::<T>::try_increase_to_be_redeemed_tokens(&old_vault_id, amount.into()).unwrap();
 
         VaultRegistry::<T>::_register_vault(&new_vault_id, 100000000u32.into(), dummy_public_key()).unwrap();
-        VaultRegistry::<T>::increase_to_be_issued_tokens(&new_vault_id, amount.into()).unwrap();
+        VaultRegistry::<T>::try_increase_to_be_issued_tokens(&new_vault_id, amount.into()).unwrap();
 
     }: _(RawOrigin::Signed(new_vault_id), replace_id)
 

--- a/crates/replace/src/ext.rs
+++ b/crates/replace/src/ext.rs
@@ -67,12 +67,6 @@ pub(crate) mod vault_registry {
         <vault_registry::Module<T>>::is_vault_liquidated(vault_id)
     }
 
-    pub fn get_required_collateral_for_vault<T: vault_registry::Config>(
-        vault_id: &T::AccountId,
-    ) -> Result<DOT<T>, DispatchError> {
-        <vault_registry::Module<T>>::get_required_collateral_for_vault(vault_id.clone())
-    }
-
     pub fn get_active_vault_from_id<T: vault_registry::Config>(
         vault_id: &T::AccountId,
     ) -> Result<
@@ -88,11 +82,11 @@ pub(crate) mod vault_registry {
         <vault_registry::Module<T>>::get_backing_collateral(vault_id)
     }
 
-    pub fn increase_to_be_redeemed_tokens<T: vault_registry::Config>(
+    pub fn try_increase_to_be_redeemed_tokens<T: vault_registry::Config>(
         vault_id: &T::AccountId,
         tokens: PolkaBTC<T>,
     ) -> DispatchResult {
-        <vault_registry::Module<T>>::increase_to_be_redeemed_tokens(vault_id, tokens)
+        <vault_registry::Module<T>>::try_increase_to_be_redeemed_tokens(vault_id, tokens)
     }
 
     pub fn is_over_minimum_collateral<T: vault_registry::Config>(collateral: DOT<T>) -> bool {
@@ -119,18 +113,18 @@ pub(crate) mod vault_registry {
         <vault_registry::Module<T>>::insert_vault_deposit_address(vault_id, btc_address)
     }
 
-    pub fn increase_to_be_issued_tokens<T: vault_registry::Config>(
+    pub fn try_increase_to_be_issued_tokens<T: vault_registry::Config>(
         vault_id: &T::AccountId,
         amount: PolkaBTC<T>,
     ) -> Result<(), DispatchError> {
-        <vault_registry::Module<T>>::increase_to_be_issued_tokens(vault_id, amount)
+        <vault_registry::Module<T>>::try_increase_to_be_issued_tokens(vault_id, amount)
     }
 
-    pub fn increase_to_be_replaced_tokens<T: vault_registry::Config>(
+    pub fn try_increase_to_be_replaced_tokens<T: vault_registry::Config>(
         vault_id: &T::AccountId,
         amount: PolkaBTC<T>,
     ) -> Result<(), DispatchError> {
-        <vault_registry::Module<T>>::increase_to_be_replaced_tokens(vault_id, amount)
+        <vault_registry::Module<T>>::try_increase_to_be_replaced_tokens(vault_id, amount)
     }
 
     pub fn decrease_to_be_replaced_tokens<T: vault_registry::Config>(
@@ -140,18 +134,25 @@ pub(crate) mod vault_registry {
         <vault_registry::Module<T>>::decrease_to_be_replaced_tokens(vault_id, amount)
     }
 
-    pub fn _lock_additional_collateral<T: vault_registry::Config>(
+    pub fn try_lock_additional_collateral<T: vault_registry::Config>(
         vault_id: &T::AccountId,
         amount: DOT<T>,
     ) -> Result<(), DispatchError> {
-        <vault_registry::Module<T>>::_lock_additional_collateral(vault_id, amount)
+        <vault_registry::Module<T>>::try_lock_additional_collateral(vault_id, amount)
     }
 
-    pub fn _withdraw_collateral<T: vault_registry::Config>(
+    pub fn force_withdraw_collateral<T: vault_registry::Config>(
         vault_id: &T::AccountId,
         amount: DOT<T>,
     ) -> Result<(), DispatchError> {
-        <vault_registry::Module<T>>::_withdraw_collateral(vault_id, amount)
+        <vault_registry::Module<T>>::force_withdraw_collateral(vault_id, amount)
+    }
+
+    pub fn is_allowed_to_withdraw_collateral<T: vault_registry::Config>(
+        vault_id: &T::AccountId,
+        amount: DOT<T>,
+    ) -> Result<bool, DispatchError> {
+        <vault_registry::Module<T>>::is_allowed_to_withdraw_collateral(vault_id, amount)
     }
 }
 

--- a/crates/replace/src/lib.rs
+++ b/crates/replace/src/lib.rs
@@ -24,7 +24,6 @@ use frame_system::{ensure_root, ensure_signed};
 #[cfg(test)]
 use mocktopus::macros::mockable;
 use primitive_types::H256;
-use sp_runtime::traits::CheckedSub;
 use sp_runtime::ModuleId;
 use sp_std::convert::TryInto;
 use sp_std::vec::Vec;
@@ -316,7 +315,10 @@ impl<T: Config> Module<T> {
         ext::collateral::lock_collateral::<T>(vault_id.clone(), griefing_collateral)?;
 
         // increase to-be-replaced tokens. This will fail if the vault does not have enough tokens available
-        ext::vault_registry::increase_to_be_replaced_tokens::<T>(&vault_id, amount_btc.clone())?;
+        ext::vault_registry::try_increase_to_be_replaced_tokens::<T>(
+            &vault_id,
+            amount_btc.clone(),
+        )?;
 
         // Generate a replaceId by hashing a random seed, a nonce, and the address of the Requester.
         let replace_id = ext::security::get_secure_id::<T>(&vault_id);
@@ -411,20 +413,20 @@ impl<T: Config> Module<T> {
         ext::vault_registry::ensure_not_banned::<T>(&new_vault_id, height)?;
 
         // Lock the new-vault's additional collateral
-        ext::vault_registry::_lock_additional_collateral::<T>(&new_vault_id, collateral)?;
+        ext::vault_registry::try_lock_additional_collateral::<T>(&new_vault_id, collateral)?;
 
         // decrease old-vault's to-be-replaced tokens; turn them into to-be-redeemed tokens
         ext::vault_registry::decrease_to_be_replaced_tokens::<T>(
             &replace.old_vault,
             replace.amount.clone(),
         )?;
-        ext::vault_registry::increase_to_be_redeemed_tokens::<T>(
+        ext::vault_registry::try_increase_to_be_redeemed_tokens::<T>(
             &replace.old_vault,
             replace.amount.clone(),
         )?;
 
         // increase to-be-issued tokens - this will fail if there is insufficient collateral
-        ext::vault_registry::increase_to_be_issued_tokens::<T>(&new_vault_id, replace.amount)?;
+        ext::vault_registry::try_increase_to_be_issued_tokens::<T>(&new_vault_id, replace.amount)?;
 
         // Update the ReplaceRequest entry
         replace.add_new_vault(new_vault_id.clone(), height, collateral, btc_address);
@@ -466,7 +468,7 @@ impl<T: Config> Module<T> {
         );
 
         // Lock the new-vault's additional collateral
-        ext::vault_registry::_lock_additional_collateral::<T>(&new_vault_id, collateral)?;
+        ext::vault_registry::try_lock_additional_collateral::<T>(&new_vault_id, collateral)?;
 
         // claim auctioning fee that is proportional to replace amount
         let dot_amount = ext::oracle::btc_to_dots::<T>(btc_amount)?;
@@ -478,10 +480,10 @@ impl<T: Config> Module<T> {
         )?;
 
         // increase to-be-issued tokens - this will fail if there is insufficient collateral
-        ext::vault_registry::increase_to_be_issued_tokens::<T>(&new_vault_id, btc_amount)?;
+        ext::vault_registry::try_increase_to_be_issued_tokens::<T>(&new_vault_id, btc_amount)?;
 
         // Call the increaseToBeRedeemedTokens function with the oldVault and the btcAmount
-        ext::vault_registry::increase_to_be_redeemed_tokens::<T>(&old_vault_id, btc_amount)?;
+        ext::vault_registry::try_increase_to_be_redeemed_tokens::<T>(&old_vault_id, btc_amount)?;
 
         // Griefing collateral is zero because the an auction fee has already been transfered to the new-vault
         let griefing_collateral = 0u32.into();
@@ -638,16 +640,14 @@ impl<T: Config> Module<T> {
         // if the new_vault locked additional collateral especially for this replace,
         // release it if it does not cause him to be undercollateralized
         if !ext::vault_registry::is_vault_liquidated::<T>(&new_vault_id)? {
-            let new_collateral = ext::vault_registry::get_backing_collateral::<T>(&new_vault_id)?
-                .checked_sub(&replace.collateral)
-                .ok_or(Error::<T>::ArithmeticUnderflow)?;
-
-            let required_collateral =
-                ext::vault_registry::get_required_collateral_for_vault::<T>(&new_vault_id)?;
-
-            if new_collateral >= required_collateral {
-                // Release the newVault's collateral associated with this ReplaceRequests
-                ext::vault_registry::_withdraw_collateral::<T>(&new_vault_id, replace.collateral)?;
+            if ext::vault_registry::is_allowed_to_withdraw_collateral::<T>(
+                &new_vault_id,
+                replace.collateral,
+            )? {
+                ext::vault_registry::force_withdraw_collateral::<T>(
+                    &new_vault_id,
+                    replace.collateral,
+                )?;
             }
         }
 

--- a/crates/replace/src/tests.rs
+++ b/crates/replace/src/tests.rs
@@ -415,15 +415,15 @@ fn test_accept_replace_insufficient_collateral_fails() {
             vault.banned_until = None;
             MockResult::Return(Ok(vault))
         });
-        ext::vault_registry::_lock_additional_collateral::<Test>
+        ext::vault_registry::try_lock_additional_collateral::<Test>
             .mock_safe(|_, _| MockResult::Return(Ok(())));
         ext::vault_registry::insert_vault_deposit_address::<Test>
             .mock_safe(|_, _| MockResult::Return(Ok(())));
         ext::vault_registry::decrease_to_be_replaced_tokens::<Test>
             .mock_safe(|_, _| MockResult::Return(Ok(())));
-        ext::vault_registry::increase_to_be_redeemed_tokens::<Test>
+        ext::vault_registry::try_increase_to_be_redeemed_tokens::<Test>
             .mock_safe(|_, _| MockResult::Return(Ok(())));
-        ext::vault_registry::increase_to_be_issued_tokens::<Test>.mock_safe(|_, _| {
+        ext::vault_registry::try_increase_to_be_issued_tokens::<Test>.mock_safe(|_, _| {
             MockResult::Return(Err(VaultRegistryError::ExceedingVaultLimit.into()))
         });
 
@@ -604,7 +604,7 @@ fn test_request_replace_with_amount_exceed_vault_issued_tokens_succeeds() {
         ext::vault_registry::is_over_minimum_collateral::<Test>
             .mock_safe(|_| MockResult::Return(true));
         ext::collateral::lock_collateral::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
-        ext::vault_registry::increase_to_be_replaced_tokens::<Test>
+        ext::vault_registry::try_increase_to_be_replaced_tokens::<Test>
             .mock_safe(|_, _| MockResult::Return(Ok(())));
         ext::security::get_secure_id::<Test>.mock_safe(|_| MockResult::Return(H256::zero()));
         ext::vault_registry::get_backing_collateral::<Test>
@@ -638,7 +638,7 @@ fn test_request_replace_with_amount_less_than_vault_issued_tokens_succeeds() {
             .mock_safe(|_| MockResult::Return(true));
         ext::collateral::lock_collateral::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
 
-        ext::vault_registry::increase_to_be_replaced_tokens::<Test>
+        ext::vault_registry::try_increase_to_be_replaced_tokens::<Test>
             .mock_safe(|_, _| MockResult::Return(Ok(())));
         ext::security::get_secure_id::<Test>.mock_safe(|_| MockResult::Return(H256::zero()));
         ext::vault_registry::get_backing_collateral::<Test>
@@ -698,16 +698,16 @@ fn test_accept_replace_succeeds() {
 
         ext::vault_registry::ensure_not_banned::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
 
-        ext::vault_registry::_lock_additional_collateral::<Test>
+        ext::vault_registry::try_lock_additional_collateral::<Test>
             .mock_safe(|_, _| MockResult::Return(Ok(())));
 
         ext::vault_registry::decrease_to_be_replaced_tokens::<Test>
             .mock_safe(|_, _| MockResult::Return(Ok(())));
 
-        ext::vault_registry::increase_to_be_redeemed_tokens::<Test>
+        ext::vault_registry::try_increase_to_be_redeemed_tokens::<Test>
             .mock_safe(|_, _| MockResult::Return(Ok(())));
 
-        ext::vault_registry::increase_to_be_issued_tokens::<Test>
+        ext::vault_registry::try_increase_to_be_issued_tokens::<Test>
             .mock_safe(|_, _| MockResult::Return(Ok(())));
 
         ext::vault_registry::insert_vault_deposit_address::<Test>
@@ -757,10 +757,10 @@ fn test_auction_replace_succeeds() {
             MockResult::Return(Ok(()))
         });
 
-        ext::vault_registry::_lock_additional_collateral::<Test>
+        ext::vault_registry::try_lock_additional_collateral::<Test>
             .mock_safe(|_, _| MockResult::Return(Ok(())));
 
-        ext::vault_registry::increase_to_be_redeemed_tokens::<Test>
+        ext::vault_registry::try_increase_to_be_redeemed_tokens::<Test>
             .mock_safe(|_, _| MockResult::Return(Ok(())));
 
         ext::security::get_secure_id::<Test>.mock_safe(|_| MockResult::Return(H256::zero()));
@@ -770,7 +770,7 @@ fn test_auction_replace_succeeds() {
         ext::fee::get_replace_griefing_collateral::<Test>
             .mock_safe(move |_| MockResult::Return(Ok(griefing_collateral)));
 
-        ext::vault_registry::increase_to_be_issued_tokens::<Test>
+        ext::vault_registry::try_increase_to_be_issued_tokens::<Test>
             .mock_safe(|_, _| MockResult::Return(Ok(())));
 
         Replace::current_height.mock_safe(move || MockResult::Return(height.clone()));
@@ -869,10 +869,8 @@ fn test_cancel_replace_succeeds() {
         Replace::remove_replace_request.mock_safe(|_, _| MockResult::Return(()));
         ext::vault_registry::slash_collateral::<Test>
             .mock_safe(|_, _, _| MockResult::Return(Ok(())));
-        ext::vault_registry::get_required_collateral_for_vault::<Test>
-            .mock_safe(|_| MockResult::Return(Ok(1000)));
-        ext::vault_registry::get_backing_collateral::<Test>
-            .mock_safe(|_| MockResult::Return(Ok(500)));
+        ext::vault_registry::is_allowed_to_withdraw_collateral::<Test>
+            .mock_safe(|_, _| MockResult::Return(Ok(false)));
         assert_eq!(cancel_replace(new_vault_id, replace_id), Ok(()));
 
         let event =
@@ -985,7 +983,7 @@ fn test_withdraw_replace_parachain_not_running_succeeds() {
             .mock_safe(|_| MockResult::Return(Ok(test_vault())));
         ext::vault_registry::is_vault_below_auction_threshold::<Test>
             .mock_safe(|_| MockResult::Return(Ok(false)));
-        ext::vault_registry::increase_to_be_redeemed_tokens::<Test>
+        ext::vault_registry::try_increase_to_be_redeemed_tokens::<Test>
             .mock_safe(|_, _| MockResult::Return(Ok(())));
         ext::collateral::release_collateral::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
         ext::vault_registry::decrease_to_be_replaced_tokens::<Test>

--- a/parachain/runtime/tests/mock/mod.rs
+++ b/parachain/runtime/tests/mock/mod.rs
@@ -194,7 +194,7 @@ impl CoreVaultData {
 
         let current = CoreVaultData::vault(vault);
         if current.to_be_issued < state.to_be_issued {
-            assert_ok!(VaultRegistryModule::increase_to_be_issued_tokens(
+            assert_ok!(VaultRegistryModule::try_increase_to_be_issued_tokens(
                 &account_of(vault),
                 state.to_be_issued - current.to_be_issued
             ));
@@ -206,7 +206,7 @@ impl CoreVaultData {
         }
 
         if current.issued < state.issued {
-            assert_ok!(VaultRegistryModule::increase_to_be_issued_tokens(
+            assert_ok!(VaultRegistryModule::try_increase_to_be_issued_tokens(
                 &account_of(vault),
                 state.issued - current.issued
             ));
@@ -216,7 +216,7 @@ impl CoreVaultData {
                 state.issued - current.issued
             ));
         } else {
-            assert_ok!(VaultRegistryModule::increase_to_be_redeemed_tokens(
+            assert_ok!(VaultRegistryModule::try_increase_to_be_redeemed_tokens(
                 &account_of(vault),
                 current.issued - state.issued
             ));
@@ -228,7 +228,7 @@ impl CoreVaultData {
             ));
         }
         if current.to_be_redeemed < state.to_be_redeemed {
-            assert_ok!(VaultRegistryModule::increase_to_be_redeemed_tokens(
+            assert_ok!(VaultRegistryModule::try_increase_to_be_redeemed_tokens(
                 &account_of(vault),
                 state.to_be_redeemed - current.to_be_redeemed
             ));
@@ -334,7 +334,7 @@ pub fn force_issue_tokens(user: [u8; 32], vault: [u8; 32], collateral: u128, tok
     .dispatch(origin_of(account_of(vault))));
 
     // increase to be issued tokens
-    assert_ok!(VaultRegistryModule::increase_to_be_issued_tokens(
+    assert_ok!(VaultRegistryModule::try_increase_to_be_issued_tokens(
         &account_of(vault),
         tokens
     ));

--- a/parachain/runtime/tests/test_redeem.rs
+++ b/parachain/runtime/tests/test_redeem.rs
@@ -3,9 +3,6 @@ mod mock;
 use mock::redeem_testing_utils::*;
 use mock::*;
 
-use vault_registry::types::RichVault;
-use vault_registry::types::UpdatableVault;
-
 #[test]
 fn integration_test_redeem_should_fail_if_not_running() {
     ExtBuilder::build().execute_with(|| {


### PR DESCRIPTION
The vault type in `types.rs` is simplified - it no longer does any sort of checks like the secure threshold check. Its now just updating the vault data struct, and forwarding any changes to the liquidation vault if required. This last part allows us to simplify the code dealing with the liquidation vault tokens. Threshold checks are now done in lib.rs.

Blocked by #16