### PR TITLE
Fix: cancel_redeem. Also, refactor: IssueRequest & RedeemRequest

### DIFF
--- a/crates/issue/src/ext.rs
+++ b/crates/issue/src/ext.rs
@@ -185,10 +185,11 @@ pub(crate) mod fee {
 
 #[cfg_attr(test, mockable)]
 pub(crate) mod refund {
-    use crate::types::PolkaBTC;
+    use crate::{types::PolkaBTC, Vec};
     use btc_relay::BtcAddress;
     use frame_support::dispatch::DispatchError;
     use primitive_types::H256;
+    use refund::types::RefundRequest;
 
     pub fn request_refund<T: refund::Config>(
         total_amount_btc: PolkaBTC<T>,
@@ -198,5 +199,11 @@ pub(crate) mod refund {
         issue_id: H256,
     ) -> Result<Option<H256>, DispatchError> {
         <refund::Module<T>>::request_refund(total_amount_btc, vault_id, issuer, btc_address, issue_id)
+    }
+
+    pub fn get_refund_requests_for_account<T: refund::Config>(
+        account_id: T::AccountId,
+    ) -> Vec<(H256, RefundRequest<T::AccountId, PolkaBTC<T>>)> {
+        <refund::Module<T>>::get_refund_requests_for_account(account_id)
     }
 }

--- a/crates/issue/src/ext.rs
+++ b/crates/issue/src/ext.rs
@@ -196,7 +196,7 @@ pub(crate) mod refund {
         issuer: T::AccountId,
         btc_address: BtcAddress,
         issue_id: H256,
-    ) -> Result<(), DispatchError> {
+    ) -> Result<Option<H256>, DispatchError> {
         <refund::Module<T>>::request_refund(total_amount_btc, vault_id, issuer, btc_address, issue_id)
     }
 }

--- a/crates/issue/src/tests.rs
+++ b/crates/issue/src/tests.rs
@@ -212,7 +212,7 @@ fn test_execute_issue_overpayment_succeeds() {
             // check that request_refund is not called..
             ext::refund::request_refund::<Test>.mock_raw(|_, _, _, _, _| {
                 refund_called = true;
-                MockResult::Return(Ok(()))
+                MockResult::Return(Ok(None))
             });
 
             assert_ok!(execute_issue(ALICE, &issue_id));
@@ -256,7 +256,7 @@ fn test_execute_issue_refund_succeeds() {
             ext::refund::request_refund::<Test>.mock_raw(|amount, _, _, _, _| {
                 refund_called = true;
                 assert_eq!(amount, 100);
-                MockResult::Return(Ok(()))
+                MockResult::Return(Ok(None))
             });
             assert_ok!(execute_issue(ALICE, &issue_id));
             assert_eq!(refund_called, true);

--- a/crates/issue/src/types.rs
+++ b/crates/issue/src/types.rs
@@ -12,6 +12,8 @@ pub enum Version {
     V0,
     /// BtcAddress type with script format.
     V1,
+    /// IssueRequestStatus
+    V2,
 }
 
 pub(crate) type DOT<T> = <<T as collateral::Config>::DOT as Currency<<T as frame_system::Config>::AccountId>>::Balance;
@@ -60,6 +62,35 @@ pub struct IssueRequest<AccountId, BlockNumber, PolkaBTC, DOT> {
     pub btc_address: BtcAddress,
     pub btc_public_key: BtcPublicKey,
     pub status: IssueRequestStatus,
+}
+
+// Due to a known bug in serde we need to specify how u128 is (de)serialized.
+// See https://github.com/paritytech/substrate/issues/4641
+#[derive(Encode, Decode, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
+pub struct IssueRequestV1<AccountId, BlockNumber, PolkaBTC, DOT> {
+    pub vault: AccountId,
+    pub opentime: BlockNumber,
+    #[cfg_attr(feature = "std", serde(bound(deserialize = "DOT: std::str::FromStr")))]
+    #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
+    #[cfg_attr(feature = "std", serde(bound(serialize = "DOT: std::fmt::Display")))]
+    #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
+    pub griefing_collateral: DOT,
+    #[cfg_attr(feature = "std", serde(bound(deserialize = "PolkaBTC: std::str::FromStr")))]
+    #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
+    #[cfg_attr(feature = "std", serde(bound(serialize = "PolkaBTC: std::fmt::Display")))]
+    #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
+    pub amount: PolkaBTC,
+    #[cfg_attr(feature = "std", serde(bound(deserialize = "PolkaBTC: std::str::FromStr")))]
+    #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
+    #[cfg_attr(feature = "std", serde(bound(serialize = "PolkaBTC: std::fmt::Display")))]
+    #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
+    pub fee: PolkaBTC,
+    pub requester: AccountId,
+    pub btc_address: BtcAddress,
+    pub btc_public_key: BtcPublicKey,
+    pub completed: bool,
+    pub cancelled: bool,
 }
 
 #[cfg(feature = "std")]

--- a/crates/issue/src/types.rs
+++ b/crates/issue/src/types.rs
@@ -1,6 +1,7 @@
 use btc_relay::{BtcAddress, BtcPublicKey};
 use codec::{Decode, Encode};
 use frame_support::traits::Currency;
+use primitive_types::H256;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -17,6 +18,21 @@ pub(crate) type DOT<T> = <<T as collateral::Config>::DOT as Currency<<T as frame
 
 pub(crate) type PolkaBTC<T> =
     <<T as treasury::Config>::PolkaBTC as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+
+#[derive(Encode, Decode, Clone, PartialEq)]
+#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
+pub enum IssueRequestStatus {
+    Pending,
+    /// optional refund ID
+    Completed(Option<H256>),
+    Cancelled,
+}
+
+impl Default for IssueRequestStatus {
+    fn default() -> Self {
+        IssueRequestStatus::Pending
+    }
+}
 
 // Due to a known bug in serde we need to specify how u128 is (de)serialized.
 // See https://github.com/paritytech/substrate/issues/4641
@@ -43,8 +59,7 @@ pub struct IssueRequest<AccountId, BlockNumber, PolkaBTC, DOT> {
     pub requester: AccountId,
     pub btc_address: BtcAddress,
     pub btc_public_key: BtcPublicKey,
-    pub completed: bool,
-    pub cancelled: bool,
+    pub status: IssueRequestStatus,
 }
 
 #[cfg(feature = "std")]

--- a/crates/redeem/src/default_weights.rs
+++ b/crates/redeem/src/default_weights.rs
@@ -29,4 +29,10 @@ impl crate::WeightInfo for () {
     fn set_redeem_period() -> Weight {
         (3_376_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
     }
+    // note: placeholder value
+    fn mint_tokens_for_reimbursed_redeem() -> Weight {
+        (168_952_000 as Weight)
+            .saturating_add(DbWeight::get().reads(14 as Weight))
+            .saturating_add(DbWeight::get().writes(5 as Weight))
+    }
 }

--- a/crates/redeem/src/ext.rs
+++ b/crates/redeem/src/ext.rs
@@ -139,8 +139,9 @@ pub(crate) mod sla {
     pub fn calculate_slashed_amount<T: sla::Config>(
         vault_id: &T::AccountId,
         stake: DOT<T>,
+        reimburse: bool,
     ) -> Result<DOT<T>, DispatchError> {
-        <sla::Module<T>>::calculate_slashed_amount(vault_id, stake)
+        <sla::Module<T>>::calculate_slashed_amount(vault_id, stake, reimburse)
     }
 }
 

--- a/crates/redeem/src/ext.rs
+++ b/crates/redeem/src/ext.rs
@@ -75,19 +75,19 @@ pub(crate) mod vault_registry {
         <vault_registry::Module<T>>::redeem_tokens(vault_id, tokens, premium, redeemer_id)
     }
 
-    pub fn redeem_tokens_liquidation<T: vault_registry::Config>(
-        redeemer_id: &T::AccountId,
-        amount: PolkaBTC<T>,
-    ) -> DispatchResult {
-        <vault_registry::Module<T>>::redeem_tokens_liquidation(redeemer_id, amount)
-    }
-
     pub fn decrease_tokens<T: vault_registry::Config>(
         vault_id: &T::AccountId,
         user_id: &T::AccountId,
         tokens: PolkaBTC<T>,
     ) -> DispatchResult {
         <vault_registry::Module<T>>::decrease_tokens(vault_id, user_id, tokens)
+    }
+
+    pub fn redeem_tokens_liquidation<T: vault_registry::Config>(
+        redeemer_id: &T::AccountId,
+        amount: PolkaBTC<T>,
+    ) -> DispatchResult {
+        <vault_registry::Module<T>>::redeem_tokens_liquidation(redeemer_id, amount)
     }
 
     pub fn ban_vault<T: vault_registry::Config>(vault_id: T::AccountId) -> DispatchResult {
@@ -107,6 +107,12 @@ pub(crate) mod vault_registry {
         <vault_registry::Module<T>>::is_vault_below_premium_threshold(vault_id)
     }
 
+    pub fn is_vault_below_secure_threshold<T: vault_registry::Config>(
+        vault_id: &T::AccountId,
+    ) -> Result<bool, DispatchError> {
+        <vault_registry::Module<T>>::is_vault_below_secure_threshold(vault_id)
+    }
+
     pub fn decrease_to_be_redeemed_tokens<T: vault_registry::Config>(
         vault_id: &T::AccountId,
         tokens: PolkaBTC<T>,
@@ -120,6 +126,17 @@ pub(crate) mod vault_registry {
         denominator: PolkaBTC<T>,
     ) -> Result<DOT<T>, DispatchError> {
         <vault_registry::Module<T>>::calculate_collateral(collateral, numerator, denominator)
+    }
+
+    pub fn try_increase_to_be_issued_tokens<T: vault_registry::Config>(
+        vault_id: &T::AccountId,
+        amount: PolkaBTC<T>,
+    ) -> Result<(), DispatchError> {
+        <vault_registry::Module<T>>::try_increase_to_be_issued_tokens(vault_id, amount)
+    }
+
+    pub fn issue_tokens<T: vault_registry::Config>(vault_id: &T::AccountId, amount: PolkaBTC<T>) -> DispatchResult {
+        <vault_registry::Module<T>>::issue_tokens(vault_id, amount)
     }
 }
 
@@ -172,6 +189,10 @@ pub(crate) mod treasury {
         amount: PolkaBTC<T>,
     ) -> DispatchResult {
         <treasury::Module<T>>::unlock_and_transfer(source, destination, amount)
+    }
+
+    pub fn mint<T: treasury::Config>(requester: T::AccountId, amount: PolkaBTC<T>) {
+        <treasury::Module<T>>::mint(requester, amount)
     }
 }
 

--- a/crates/redeem/src/lib.rs
+++ b/crates/redeem/src/lib.rs
@@ -26,7 +26,7 @@ mod ext;
 pub mod types;
 
 #[doc(inline)]
-pub use crate::types::RedeemRequest;
+pub use crate::types::{RedeemRequest, RedeemRequestStatus};
 
 use crate::types::{PolkaBTC, Version, DOT};
 use bitcoin::types::H256Le;
@@ -52,6 +52,7 @@ pub trait WeightInfo {
     fn execute_redeem() -> Weight;
     fn cancel_redeem() -> Weight;
     fn set_redeem_period() -> Weight;
+    fn mint_tokens_for_reimbursed_redeem() -> Weight;
 }
 
 /// The pallet's configuration trait.
@@ -219,6 +220,27 @@ decl_module! {
             ensure_root(origin)?;
             <RedeemPeriod<T>>::set(period);
         }
+
+        /// Mint tokens for a redeem that was cancelled with reimburse=true. This is
+        /// only possible if at the time of the cancel_redeem, the vault did not have
+        /// sufficient collateral after being slashed to back the tokens that the user
+        /// used to hold.
+        ///
+        /// # Arguments
+        ///
+        /// * `origin` - the dispatch origin of this call (must be _Root_)
+        /// * `redeem_id` - identifier of redeem request as output from request_redeem
+        ///
+        /// # Weight: `O(1)`
+        #[weight = <T as Config>::WeightInfo::set_redeem_period()]
+        #[transactional]
+        fn mint_tokens_for_reimbursed_redeem(origin, redeem_id: H256)
+            -> DispatchResult
+        {
+            let redeemer = ensure_signed(origin)?;
+            Self::_mint_tokens_for_reimbursed_redeem(redeemer, redeem_id)?;
+            Ok(())
+        }
     }
 }
 
@@ -279,17 +301,13 @@ impl<T: Config> Module<T> {
             RedeemRequest {
                 vault: vault_id.clone(),
                 opentime: height,
-                amount_polka_btc: redeem_amount_polka_btc,
                 fee: fee_polka_btc,
                 amount_btc: redeem_amount_polka_btc,
                 // TODO: reimplement partial redeem for system liquidation
-                amount_dot: Self::u128_to_dot(0u128)?,
                 premium_dot,
                 redeemer: redeemer.clone(),
                 btc_address: btc_address.clone(),
-                completed: false,
-                cancelled: false,
-                reimburse: false,
+                status: RedeemRequestStatus::Pending,
             },
         );
 
@@ -353,27 +371,30 @@ impl<T: Config> Module<T> {
             Some(redeem_id.clone().as_bytes().to_vec()),
         )?;
 
-        let amount_polka_btc = redeem.amount_polka_btc;
-        let fee_polka_btc = redeem.fee;
-        // burn amount (minus fee)
-        ext::treasury::burn::<T>(redeem.redeemer.clone(), amount_polka_btc)?;
+        // burn amount (without fee)
+        ext::treasury::burn::<T>(redeem.redeemer.clone(), redeem.amount_btc)?;
 
         // send fees to pool
         ext::treasury::unlock_and_transfer::<T>(
             redeem.redeemer.clone(),
             ext::fee::fee_pool_account_id::<T>(),
-            fee_polka_btc,
+            redeem.fee,
         )?;
-        ext::fee::increase_polka_btc_rewards_for_epoch::<T>(fee_polka_btc);
+        ext::fee::increase_polka_btc_rewards_for_epoch::<T>(redeem.fee);
 
-        ext::vault_registry::redeem_tokens::<T>(&redeem.vault, amount_polka_btc, redeem.premium_dot, &redeem.redeemer)?;
+        ext::vault_registry::redeem_tokens::<T>(
+            &redeem.vault,
+            redeem.amount_btc,
+            redeem.premium_dot,
+            &redeem.redeemer,
+        )?;
 
-        Self::remove_redeem_request(redeem_id, false, false);
+        Self::set_redeem_status(redeem_id, RedeemRequestStatus::Completed);
         Self::deposit_event(<Event<T>>::ExecuteRedeem(
             redeem_id,
             redeem.redeemer,
-            amount_polka_btc,
-            fee_polka_btc,
+            redeem.amount_btc,
+            redeem.fee,
             redeem.vault,
         ));
         Ok(())
@@ -394,33 +415,6 @@ impl<T: Config> Module<T> {
 
         let amount_polka_btc_in_dot = ext::oracle::btc_to_dots::<T>(redeem.amount_btc)?;
         let punishment_fee_in_dot = ext::fee::get_punishment_fee::<T>(amount_polka_btc_in_dot)?;
-
-        // first update the polkabtc tokens; this logic is the same regardless of whether or not the vault is liquidated
-        if reimburse {
-            // decrease to_be_redeemed & issued
-            ext::vault_registry::decrease_tokens::<T>(&vault_id, &redeem.redeemer, redeem.amount_polka_btc)?;
-
-            // Transfer the transaction fee to the pool. Even though the redeem was not
-            // successful, the user receives a premium in DOT, so it's to take the fee.
-            ext::treasury::unlock_and_transfer::<T>(
-                redeem.redeemer.clone(),
-                ext::fee::fee_pool_account_id::<T>(),
-                redeem.fee,
-            )?;
-            ext::fee::increase_polka_btc_rewards_for_epoch::<T>(redeem.fee);
-
-            // burn user's PolkaBTC, excluding fee
-            ext::treasury::burn::<T>(redeem.redeemer.clone(), redeem.amount_btc)?;
-        } else {
-            ext::vault_registry::decrease_to_be_redeemed_tokens::<T>(&vault_id, redeem.amount_polka_btc)?;
-
-            // unlock user's PolkaBTC, including fee
-            let total_polka_btc = redeem
-                .amount_btc
-                .checked_add(&redeem.fee)
-                .ok_or(Error::<T>::ArithmeticOverflow)?;
-            ext::treasury::unlock::<T>(redeemer.clone(), total_polka_btc)?;
-        }
 
         // now update the collateral; the logic is different for liquidated vaults.
         let slashed_amount = if vault.is_liquidated() {
@@ -465,7 +459,8 @@ impl<T: Config> Module<T> {
                 slashed_punishment_fee
             };
             // calculate additional amount to slash, a high SLA means we slash less
-            let slashing_amount_in_dot = ext::sla::calculate_slashed_amount::<T>(&vault_id, amount_polka_btc_in_dot, reimburse)?;
+            let slashing_amount_in_dot =
+                ext::sla::calculate_slashed_amount::<T>(&vault_id, amount_polka_btc_in_dot, reimburse)?;
 
             // slash the remaining amount from the vault to the fee pool
             let remaining_dot_to_be_slashed = slashing_amount_in_dot
@@ -484,8 +479,44 @@ impl<T: Config> Module<T> {
             slashing_amount_in_dot
         };
 
+        // first update the polkabtc tokens; this logic is the same regardless of whether or not the vault is liquidated
+        if reimburse {
+            // Transfer the transaction fee to the pool. Even though the redeem was not
+            // successful, the user receives a premium in DOT, so it's to take the fee.
+            ext::treasury::unlock_and_transfer::<T>(
+                redeem.redeemer.clone(),
+                ext::fee::fee_pool_account_id::<T>(),
+                redeem.fee,
+            )?;
+            ext::fee::increase_polka_btc_rewards_for_epoch::<T>(redeem.fee);
+
+            if ext::vault_registry::is_vault_below_secure_threshold::<T>(&redeem.vault)? {
+                // vault can not afford to back the tokens that he would receive, so we burn it
+                ext::treasury::burn::<T>(redeemer.clone(), redeem.amount_btc)?;
+                ext::vault_registry::decrease_tokens::<T>(&redeem.vault, &redeem.redeemer, redeem.amount_btc)?;
+                Self::set_redeem_status(redeem_id, RedeemRequestStatus::Reimbursed(false));
+            } else {
+                // Transfer the rest of the user's PolkaBTC (i.e. excluding fee) to the vault
+                ext::treasury::unlock_and_transfer::<T>(
+                    redeem.redeemer.clone(),
+                    redeem.vault.clone(),
+                    redeem.amount_btc,
+                )?;
+                ext::vault_registry::decrease_to_be_redeemed_tokens::<T>(&vault_id, redeem.amount_btc)?;
+                Self::set_redeem_status(redeem_id, RedeemRequestStatus::Reimbursed(true));
+            }
+        } else {
+            // unlock user's PolkaBTC, including fee
+            let total_polka_btc = redeem
+                .amount_btc
+                .checked_add(&redeem.fee)
+                .ok_or(Error::<T>::ArithmeticOverflow)?;
+            ext::treasury::unlock::<T>(redeemer.clone(), total_polka_btc)?;
+            ext::vault_registry::decrease_to_be_redeemed_tokens::<T>(&vault_id, redeem.amount_btc)?;
+            Self::set_redeem_status(redeem_id, RedeemRequestStatus::Retried);
+        }
+
         ext::sla::event_update_vault_sla::<T>(&vault_id, ext::sla::VaultEvent::RedeemFailure)?;
-        Self::remove_redeem_request(redeem_id, true, reimburse);
         Self::deposit_event(<Event<T>>::CancelRedeem(
             redeem_id,
             redeemer,
@@ -493,6 +524,28 @@ impl<T: Config> Module<T> {
             slashed_amount,
             reimburse,
         ));
+
+        Ok(())
+    }
+
+    fn _mint_tokens_for_reimbursed_redeem(vault_id: T::AccountId, redeem_id: H256) -> DispatchResult {
+        ensure!(
+            <RedeemRequests<T>>::contains_key(&redeem_id),
+            Error::<T>::RedeemIdNotFound
+        );
+        let redeem = <RedeemRequests<T>>::get(&redeem_id);
+        ensure!(
+            matches!(redeem.status, RedeemRequestStatus::Reimbursed(false)),
+            Error::<T>::InvalidRedeemStatus
+        );
+
+        ensure!(redeem.vault == vault_id, Error::<T>::UnauthorizedUser);
+
+        ext::vault_registry::try_increase_to_be_issued_tokens::<T>(&vault_id, redeem.amount_btc)?;
+        ext::vault_registry::issue_tokens::<T>(&vault_id, redeem.amount_btc)?;
+        ext::treasury::mint::<T>(vault_id, redeem.amount_btc);
+
+        Self::set_redeem_status(redeem_id, RedeemRequestStatus::Completed);
 
         Ok(())
     }
@@ -507,12 +560,10 @@ impl<T: Config> Module<T> {
         <RedeemRequests<T>>::insert(key, value)
     }
 
-    fn remove_redeem_request(id: H256, cancelled: bool, reimburse: bool) {
+    fn set_redeem_status(id: H256, status: RedeemRequestStatus) {
         // TODO: delete redeem request from storage
         <RedeemRequests<T>>::mutate(id, |request| {
-            request.completed = !cancelled;
-            request.cancelled = cancelled;
-            request.reimburse = reimburse
+            request.status = status;
         });
     }
 
@@ -557,12 +608,8 @@ impl<T: Config> Module<T> {
         );
         // NOTE: temporary workaround until we delete
         ensure!(
-            !<RedeemRequests<T>>::get(*redeem_id).completed,
-            Error::<T>::RedeemCompleted
-        );
-        ensure!(
-            !<RedeemRequests<T>>::get(*redeem_id).cancelled,
-            Error::<T>::RedeemCancelled
+            <RedeemRequests<T>>::get(*redeem_id).status == RedeemRequestStatus::Pending,
+            Error::<T>::InvalidRedeemStatus
         );
         Ok(<RedeemRequests<T>>::get(*redeem_id))
     }
@@ -581,8 +628,11 @@ impl<T: Config> Module<T> {
             Error::<T>::RedeemIdNotFound
         );
         ensure!(
-            !<RedeemRequests<T>>::get(*redeem_id).cancelled,
-            Error::<T>::RedeemCancelled
+            matches!(
+                <RedeemRequests<T>>::get(*redeem_id).status,
+                RedeemRequestStatus::Pending | RedeemRequestStatus::Completed
+            ),
+            Error::<T>::InvalidRedeemStatus
         );
         Ok(<RedeemRequests<T>>::get(*redeem_id))
     }
@@ -604,8 +654,7 @@ decl_error! {
         CommitPeriodExpired,
         UnauthorizedUser,
         TimeNotExpired,
-        RedeemCompleted,
-        RedeemCancelled,
+        InvalidRedeemStatus,
         RedeemIdNotFound,
         /// Unable to convert value
         TryIntoIntError,

--- a/crates/redeem/src/lib.rs
+++ b/crates/redeem/src/lib.rs
@@ -465,7 +465,7 @@ impl<T: Config> Module<T> {
                 slashed_punishment_fee
             };
             // calculate additional amount to slash, a high SLA means we slash less
-            let slashing_amount_in_dot = ext::sla::calculate_slashed_amount::<T>(&vault_id, amount_polka_btc_in_dot)?;
+            let slashing_amount_in_dot = ext::sla::calculate_slashed_amount::<T>(&vault_id, amount_polka_btc_in_dot, reimburse)?;
 
             // slash the remaining amount from the vault to the fee pool
             let remaining_dot_to_be_slashed = slashing_amount_in_dot

--- a/crates/redeem/src/tests.rs
+++ b/crates/redeem/src/tests.rs
@@ -378,7 +378,7 @@ fn test_execute_redeem_succeeds_with_another_account() {
         assert_emitted!(Event::ExecuteRedeem(H256([0; 32]), ALICE, 100, 0, BOB));
         assert_err!(
             Redeem::get_open_redeem_request_from_id(&H256([0u8; 32])),
-            TestError::InvalidRedeemStatus,
+            TestError::RedeemCompleted,
         );
     })
 }
@@ -476,7 +476,7 @@ fn test_execute_redeem_succeeds() {
         assert_emitted!(Event::ExecuteRedeem(H256([0; 32]), ALICE, 100, 0, BOB));
         assert_err!(
             Redeem::get_open_redeem_request_from_id(&H256([0u8; 32])),
-            TestError::InvalidRedeemStatus,
+            TestError::RedeemCompleted,
         );
     })
 }
@@ -576,7 +576,7 @@ fn test_cancel_redeem_succeeds() {
         assert_ok!(Redeem::cancel_redeem(Origin::signed(ALICE), H256([0u8; 32]), false));
         assert_err!(
             Redeem::get_open_redeem_request_from_id(&H256([0u8; 32])),
-            TestError::InvalidRedeemStatus,
+            TestError::RedeemCancelled,
         );
         assert_emitted!(Event::CancelRedeem(H256([0; 32]), ALICE, BOB, 0, false));
     })

--- a/crates/redeem/src/types.rs
+++ b/crates/redeem/src/types.rs
@@ -11,6 +11,8 @@ pub enum Version {
     V0,
     /// BtcAddress type with script format.
     V1,
+    /// RedeemRequestStatus, removed amount_dot and amount_polka_btc
+    V2,
 }
 
 pub(crate) type DOT<T> = <<T as collateral::Config>::DOT as Currency<<T as frame_system::Config>::AccountId>>::Balance;
@@ -62,6 +64,48 @@ pub struct RedeemRequest<AccountId, BlockNumber, PolkaBTC, DOT> {
     pub redeemer: AccountId,
     pub btc_address: BtcAddress,
     pub status: RedeemRequestStatus,
+}
+
+#[derive(Encode, Decode, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
+pub struct RedeemRequestV1<AccountId, BlockNumber, PolkaBTC, DOT> {
+    pub vault: AccountId,
+    pub opentime: BlockNumber,
+    #[cfg_attr(feature = "std", serde(bound(deserialize = "PolkaBTC: std::str::FromStr")))]
+    #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
+    #[cfg_attr(feature = "std", serde(bound(serialize = "PolkaBTC: std::fmt::Display")))]
+    #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
+    /// Total redeem amount (`amount_btc + dotsToBtc(amount_dot)`)
+    pub amount_polka_btc: PolkaBTC,
+    #[cfg_attr(feature = "std", serde(bound(deserialize = "PolkaBTC: std::str::FromStr")))]
+    #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
+    #[cfg_attr(feature = "std", serde(bound(serialize = "PolkaBTC: std::fmt::Display")))]
+    #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
+    /// Total redeem fees in PolkaBTC - taken from request amount
+    pub fee: PolkaBTC,
+    #[cfg_attr(feature = "std", serde(bound(deserialize = "PolkaBTC: std::str::FromStr")))]
+    #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
+    #[cfg_attr(feature = "std", serde(bound(serialize = "PolkaBTC: std::fmt::Display")))]
+    #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
+    /// Total amount of BTC for the vault to send
+    pub amount_btc: PolkaBTC,
+    #[cfg_attr(feature = "std", serde(bound(deserialize = "DOT: std::str::FromStr")))]
+    #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
+    #[cfg_attr(feature = "std", serde(bound(serialize = "DOT: std::fmt::Display")))]
+    #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
+    /// Partial redeem amount in DOT, currently unused
+    pub amount_dot: DOT,
+    #[cfg_attr(feature = "std", serde(bound(deserialize = "DOT: std::str::FromStr")))]
+    #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
+    #[cfg_attr(feature = "std", serde(bound(serialize = "DOT: std::fmt::Display")))]
+    #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
+    /// Premium redeem amount in DOT
+    pub premium_dot: DOT,
+    pub redeemer: AccountId,
+    pub btc_address: BtcAddress,
+    pub completed: bool,
+    pub cancelled: bool,
+    pub reimburse: bool,
 }
 
 #[cfg(feature = "std")]

--- a/crates/sla/src/lib.rs
+++ b/crates/sla/src/lib.rs
@@ -340,7 +340,8 @@ impl<T: Config> Module<T> {
     ///
     /// * `vault_id` - account of the vault in question
     /// * `stake` - the amount of collateral placed for the redeem/replace
-    pub fn calculate_slashed_amount(vault_id: &T::AccountId, stake: DOT<T>) -> Result<DOT<T>, DispatchError> {
+    /// * `reimburse` - if true, this function returns 110-130%. If false, it returns 10-30% 
+    pub fn calculate_slashed_amount(vault_id: &T::AccountId, stake: DOT<T>, reimburse: bool) -> Result<DOT<T>, DispatchError> {
         let current_sla = <VaultSla<T>>::get(vault_id);
 
         let liquidation_threshold = ext::vault_registry::get_liquidation_collateral_threshold::<T>();
@@ -348,7 +349,14 @@ impl<T: Config> Module<T> {
         let premium_redeem_threshold = ext::vault_registry::get_premium_redeem_threshold::<T>();
         let premium_redeem_threshold = Self::fixed_point_unsigned_to_signed(premium_redeem_threshold)?;
 
-        Self::_calculate_slashed_amount(current_sla, stake, liquidation_threshold, premium_redeem_threshold)
+        let total = Self::_calculate_slashed_amount(current_sla, stake, liquidation_threshold, premium_redeem_threshold)?;
+
+        if reimburse {
+            Ok(total)
+        }         else {
+            // vault is already losing the btc, so subtract the equivalent value of the lost btc
+            Ok(total.checked_sub(&stake).ok_or(Error::<T>::ArithmeticUnderflow)?)
+        }
     }
 
     /// Explicitly set the vault's SLA score, used in tests.

--- a/crates/sla/src/lib.rs
+++ b/crates/sla/src/lib.rs
@@ -340,8 +340,12 @@ impl<T: Config> Module<T> {
     ///
     /// * `vault_id` - account of the vault in question
     /// * `stake` - the amount of collateral placed for the redeem/replace
-    /// * `reimburse` - if true, this function returns 110-130%. If false, it returns 10-30% 
-    pub fn calculate_slashed_amount(vault_id: &T::AccountId, stake: DOT<T>, reimburse: bool) -> Result<DOT<T>, DispatchError> {
+    /// * `reimburse` - if true, this function returns 110-130%. If false, it returns 10-30%
+    pub fn calculate_slashed_amount(
+        vault_id: &T::AccountId,
+        stake: DOT<T>,
+        reimburse: bool,
+    ) -> Result<DOT<T>, DispatchError> {
         let current_sla = <VaultSla<T>>::get(vault_id);
 
         let liquidation_threshold = ext::vault_registry::get_liquidation_collateral_threshold::<T>();
@@ -349,11 +353,12 @@ impl<T: Config> Module<T> {
         let premium_redeem_threshold = ext::vault_registry::get_premium_redeem_threshold::<T>();
         let premium_redeem_threshold = Self::fixed_point_unsigned_to_signed(premium_redeem_threshold)?;
 
-        let total = Self::_calculate_slashed_amount(current_sla, stake, liquidation_threshold, premium_redeem_threshold)?;
+        let total =
+            Self::_calculate_slashed_amount(current_sla, stake, liquidation_threshold, premium_redeem_threshold)?;
 
         if reimburse {
             Ok(total)
-        }         else {
+        } else {
             // vault is already losing the btc, so subtract the equivalent value of the lost btc
             Ok(total.checked_sub(&stake).ok_or(Error::<T>::ArithmeticUnderflow)?)
         }

--- a/crates/staked-relayers/src/tests.rs
+++ b/crates/staked-relayers/src/tests.rs
@@ -12,7 +12,7 @@ use bitcoin::{
 use btc_relay::{BtcAddress, BtcPublicKey, Error as BtcRelayError};
 use frame_support::{assert_err, assert_noop, assert_ok, dispatch::DispatchError};
 use mocktopus::mocking::*;
-use redeem::types::RedeemRequest;
+use redeem::types::{RedeemRequest, RedeemRequestStatus};
 use replace::types::ReplaceRequest;
 use security::types::{ErrorCode, StatusCode};
 use sp_core::{H160, H256};
@@ -1192,16 +1192,12 @@ fn test_is_transaction_invalid_fails_with_valid_request_or_redeem() {
             MockResult::Return(Ok(RedeemRequest {
                 vault: BOB,
                 opentime: 0,
-                amount_polka_btc: 0,
                 fee: 0,
                 amount_btc: 100,
-                amount_dot: 0,
                 premium_dot: 0,
                 redeemer: ALICE,
                 btc_address: recipient_address,
-                completed: false,
-                cancelled: false,
-                reimburse: false,
+                status: RedeemRequestStatus::Pending,
             }))
         });
 

--- a/parachain/runtime/tests/mock/issue_testing_utils.rs
+++ b/parachain/runtime/tests/mock/issue_testing_utils.rs
@@ -37,10 +37,6 @@ impl RequestIssueBuilder {
     }
 
     pub fn request(&self) -> (H256, IssueRequest<AccountId32, u32, u128, u128>) {
-        assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
-
-        SystemModule::set_block_number(1);
-
         try_register_vault(DEFAULT_COLLATERAL, self.vault);
 
         // alice requests polka_btc by locking btc with bob
@@ -50,13 +46,6 @@ impl RequestIssueBuilder {
             DEFAULT_GRIEFING_COLLATERAL
         ))
         .dispatch(origin_of(account_of(self.user))));
-
-        CollateralModule::transfer(
-            account_of(self.vault),
-            account_of(FAUCET),
-            CollateralModule::get_balance_from_account(&account_of(self.vault)),
-        )
-        .unwrap();
 
         let issue_id = assert_issue_request_event();
         let issue = IssueModule::get_issue_request_from_id(&issue_id).unwrap();

--- a/parachain/runtime/tests/mock/issue_testing_utils.rs
+++ b/parachain/runtime/tests/mock/issue_testing_utils.rs
@@ -7,11 +7,6 @@ pub const PROOF_SUBMITTER: [u8; 32] = CAROL;
 pub const DEFAULT_GRIEFING_COLLATERAL: u128 = 5_000;
 pub const DEFAULT_COLLATERAL: u128 = 1_000_000;
 
-pub const DEFAULT_USER_FREE_BALANCE: u128 = 1_000_000;
-pub const DEFAULT_USER_LOCKED_BALANCE: u128 = 100_000;
-pub const DEFAULT_USER_FREE_TOKENS: u128 = 1000;
-pub const DEFAULT_USER_LOCKED_TOKENS: u128 = 1000;
-
 pub fn request_issue(amount_btc: u128) -> (H256, IssueRequest<AccountId32, u32, u128, u128>) {
     RequestIssueBuilder::new(amount_btc).request()
 }
@@ -134,15 +129,6 @@ impl ExecuteIssueBuilder {
 
 pub fn execute_issue(issue_id: H256) {
     ExecuteIssueBuilder::new(issue_id).assert_execute()
-}
-
-pub fn default_user_state() -> UserData {
-    UserData {
-        free_balance: DEFAULT_USER_FREE_BALANCE,
-        locked_balance: DEFAULT_USER_LOCKED_BALANCE,
-        locked_tokens: DEFAULT_USER_LOCKED_TOKENS,
-        free_tokens: DEFAULT_USER_FREE_TOKENS,
-    }
 }
 
 pub fn assert_issue_request_event() -> H256 {

--- a/parachain/runtime/tests/mock/mod.rs
+++ b/parachain/runtime/tests/mock/mod.rs
@@ -42,6 +42,11 @@ pub const FAUCET: [u8; 32] = [128u8; 32];
 pub const INITIAL_BALANCE: u128 = 1_000_000_000_000;
 pub const INITIAL_LIQUIDATION_VAULT_BALANCE: u128 = 1_000;
 
+pub const DEFAULT_USER_FREE_BALANCE: u128 = 1_000_000;
+pub const DEFAULT_USER_LOCKED_BALANCE: u128 = 100_000;
+pub const DEFAULT_USER_FREE_TOKENS: u128 = 10_000_000;
+pub const DEFAULT_USER_LOCKED_TOKENS: u128 = 1000;
+
 pub const CONFIRMATIONS: u32 = 6;
 
 pub type BTCRelayCall = btc_relay::Call<Runtime>;
@@ -69,6 +74,15 @@ pub type ReplaceModule = replace::Module<Runtime>;
 
 pub type StakedRelayersCall = staked_relayers::Call<Runtime>;
 pub type StakedRelayersModule = staked_relayers::Module<Runtime>;
+
+pub fn default_user_state() -> UserData {
+    UserData {
+        free_balance: DEFAULT_USER_FREE_BALANCE,
+        locked_balance: DEFAULT_USER_LOCKED_BALANCE,
+        locked_tokens: DEFAULT_USER_LOCKED_TOKENS,
+        free_tokens: DEFAULT_USER_FREE_TOKENS,
+    }
+}
 
 pub fn origin_of(account_id: AccountId) -> <Runtime as frame_system::Config>::Origin {
     <Runtime as frame_system::Config>::Origin::signed(account_id)

--- a/parachain/runtime/tests/mock/redeem_testing_utils.rs
+++ b/parachain/runtime/tests/mock/redeem_testing_utils.rs
@@ -3,8 +3,6 @@ use crate::*;
 pub const USER: [u8; 32] = ALICE;
 pub const VAULT: [u8; 32] = BOB;
 pub const USER_BTC_ADDRESS: BtcAddress = BtcAddress::P2PKH(H160([2u8; 20]));
-pub const DEFAULT_USER_FREE_BALANCE: u128 = 1_000_000;
-pub const DEFAULT_USER_LOCKED_BALANCE: u128 = 100_000;
 
 pub fn setup_cancelable_redeem(user: [u8; 32], vault: [u8; 32], collateral: u128, polka_btc: u128) -> H256 {
     let redeem_id = setup_redeem(polka_btc, user, vault, collateral);

--- a/parachain/runtime/tests/mock/redeem_testing_utils.rs
+++ b/parachain/runtime/tests/mock/redeem_testing_utils.rs
@@ -25,29 +25,7 @@ pub fn setup_cancelable_redeem(user: [u8; 32], vault: [u8; 32], collateral: u128
     redeem_id
 }
 
-pub fn setup_redeem(polka_btc: u128, user: [u8; 32], vault: [u8; 32], collateral: u128) -> H256 {
-    SystemModule::set_block_number(1);
-
-    set_default_thresholds();
-
-    assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
-
-    let fee = FeeModule::get_redeem_fee(polka_btc).unwrap();
-
-    // burn surplus free balance to make checking easier
-    CollateralModule::transfer(
-        account_of(vault),
-        account_of(FAUCET),
-        CollateralModule::get_balance_from_account(&account_of(vault)) - collateral,
-    )
-    .unwrap();
-
-    // create tokens for the vault and user
-    force_issue_tokens(user, vault, collateral, polka_btc - fee);
-
-    // mint tokens to the user such that he can afford the fee
-    TreasuryModule::mint(user.into(), fee);
-
+pub fn setup_redeem(polka_btc: u128, user: [u8; 32], vault: [u8; 32], _collateral: u128) -> H256 {
     // alice requests to redeem polka_btc from Bob
     assert_ok!(Call::Redeem(RedeemCall::request_redeem(
         polka_btc,

--- a/parachain/runtime/tests/test_fee_pool.rs
+++ b/parachain/runtime/tests/test_fee_pool.rs
@@ -13,10 +13,14 @@ const RELAYER_2: [u8; 32] = GRACE;
 
 fn test_with(execute: impl Fn(Currency) -> ()) {
     ExtBuilder::build().execute_with(|| {
+        SystemModule::set_block_number(1);
+        assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
         setup_dot_reward();
         execute(Currency::DOT);
     });
     ExtBuilder::build().execute_with(|| {
+        SystemModule::set_block_number(1);
+        assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
         execute(Currency::PolkaBTC);
     });
 }
@@ -107,6 +111,8 @@ fn setup_dot_reward() {
 }
 
 fn set_issued_and_backing(vault: [u8; 32], amount_issued: u128, backing: u128) {
+    SystemModule::set_block_number(1);
+
     // we want issued to be 100 times amount_issued, _including fees_
     let amount_issued = 100 * amount_issued;
     let fee = FeeModule::get_issue_fee_from_total(amount_issued).unwrap();

--- a/parachain/runtime/tests/test_issue.rs
+++ b/parachain/runtime/tests/test_issue.rs
@@ -263,6 +263,7 @@ fn integration_test_issue_refund() {
             CoreVaultData {
                 issued: issue.amount + 4 * issue.fee,
                 backing_collateral: 2000,
+                free_tokens: issue.fee * 3,
                 ..Default::default()
             },
         );

--- a/parachain/runtime/tests/test_issue.rs
+++ b/parachain/runtime/tests/test_issue.rs
@@ -12,6 +12,12 @@ fn test_with<R>(execute: impl FnOnce() -> R) -> R {
     })
 }
 
+fn test_with_initialized_vault<R>(execute: impl FnOnce() -> R) -> R {
+    test_with(|| {
+        CoreVaultData::force_to(VAULT, default_vault_state());
+        execute()
+    })
+}
 #[test]
 fn integration_test_issue_should_fail_if_not_running() {
     test_with(|| {
@@ -36,22 +42,17 @@ fn integration_test_issue_should_fail_if_not_running() {
 }
 
 #[test]
-fn integration_test_issue_polka_btc_execute() {
+fn integration_test_issue_polka_btc_execute_succeeds() {
     test_with(|| {
-        let user = ALICE;
-        let vault = BOB;
         let vault_proof_submitter = CAROL;
 
         let amount_btc = 1000000;
         let griefing_collateral = 100;
         let collateral_vault = required_collateral_for_issue(amount_btc);
 
-        let initial_dot_balance = CollateralModule::get_balance_from_account(&account_of(user));
-        let initial_btc_balance = TreasuryModule::get_balance_from_account(account_of(user));
-
         assert_ok!(
             Call::VaultRegistry(VaultRegistryCall::register_vault(collateral_vault, dummy_public_key()))
-                .dispatch(origin_of(account_of(vault)))
+                .dispatch(origin_of(account_of(VAULT)))
         );
         assert_ok!(
             Call::VaultRegistry(VaultRegistryCall::register_vault(collateral_vault, dummy_public_key()))
@@ -61,10 +62,10 @@ fn integration_test_issue_polka_btc_execute() {
         // alice requests polka_btc by locking btc with bob
         assert_ok!(Call::Issue(IssueCall::request_issue(
             amount_btc,
-            account_of(vault),
+            account_of(VAULT),
             griefing_collateral
         ))
-        .dispatch(origin_of(account_of(ALICE))));
+        .dispatch(origin_of(account_of(USER))));
 
         let issue_id = assert_issue_request_event();
         let issue_request = IssueModule::get_issue_request_from_id(&issue_id).unwrap();
@@ -80,33 +81,24 @@ fn integration_test_issue_polka_btc_execute() {
         // alice executes the issue by confirming the btc transaction
         assert_ok!(Call::Issue(IssueCall::execute_issue(issue_id, tx_id, proof, raw_tx))
             .dispatch(origin_of(account_of(vault_proof_submitter))));
+    });
+}
 
-        // fee should be added to epoch rewards
-        assert_eq!(FeeModule::epoch_rewards_polka_btc(), fee_amount_btc);
+#[test]
+fn integration_test_issue_polka_btc_execute_bookkeeping() {
+    test_with_initialized_vault(|| {
+        let requested_btc = 1000;
+        let (issue_id, issue) = request_issue(requested_btc);
+        execute_issue(issue_id);
 
-        let final_dot_balance = CollateralModule::get_balance_from_account(&account_of(user));
-        let final_btc_balance = TreasuryModule::get_balance_from_account(account_of(user));
-
-        // griefing collateral reimbursed
-        assert_eq!(final_dot_balance, initial_dot_balance);
-
-        // polka_btc minted
-        assert_eq!(final_btc_balance, initial_btc_balance + amount_btc);
-
-        // vault should have 0 to-be-issued tokens
         assert_eq!(
-            VaultRegistryModule::get_vault_from_id(&account_of(vault))
-                .unwrap()
-                .to_be_issued_tokens,
-            0
+            ParachainState::get(),
+            ParachainState::default().with_changes(|user, vault, _, fee_pool| {
+                user.free_tokens += requested_btc;
+                fee_pool.tokens += issue.fee;
+                vault.issued += issue.fee + requested_btc;
+            })
         );
-
-        // force issue rewards and withdraw
-        assert_ok!(FeeModule::update_rewards_for_epoch());
-        assert_ok!(Call::Fee(FeeCall::withdraw_polka_btc(FeeModule::get_polka_btc_rewards(
-            &account_of(vault)
-        )))
-        .dispatch(origin_of(account_of(vault))));
     });
 }
 
@@ -155,161 +147,102 @@ fn integration_test_withdraw_after_request_issue() {
     });
 }
 
-/// Like integration_test_issue_polka_btc_execute, but here request only half of the amount - we
-/// still transfer the same amount of bitcoin though. Check that it acts as if we requested the
-/// full amount
 #[test]
 fn integration_test_issue_overpayment() {
-    test_with(|| {
-        let user = ALICE;
-        let vault = BOB;
+    test_with_initialized_vault(|| {
+        let requested_btc = 1000;
+        let (issue_id, issue) = request_issue(requested_btc);
+        let sent_btc = (issue.amount + issue.fee) * 2;
 
-        let amount_btc = 1000000;
-        let overpayment_factor = 2;
-        let requested_amount_btc = amount_btc / overpayment_factor;
-        let griefing_collateral = 100;
-        let collateral_vault = required_collateral_for_issue(amount_btc);
-
-        let initial_dot_balance = CollateralModule::get_balance_from_account(&account_of(user));
-        let initial_btc_balance = TreasuryModule::get_balance_from_account(account_of(user));
-
-        assert_ok!(
-            Call::VaultRegistry(VaultRegistryCall::register_vault(collateral_vault, dummy_public_key()))
-                .dispatch(origin_of(account_of(vault)))
-        );
-
-        // alice requests polka_btc by locking btc with bob
-        assert_ok!(Call::Issue(IssueCall::request_issue(
-            requested_amount_btc,
-            account_of(vault),
-            griefing_collateral
-        ))
-        .dispatch(origin_of(account_of(ALICE))));
-
-        let issue_id = assert_issue_request_event();
-        let issue_request = IssueModule::get_issue_request_from_id(&issue_id).unwrap();
-        let vault_btc_address = issue_request.btc_address;
-
-        let fee_amount_btc = FeeModule::get_issue_fee(amount_btc).unwrap();
-        let total_amount_btc = amount_btc + fee_amount_btc;
-
-        // send the btc from the user to the vault
-        let (tx_id, _height, proof, raw_tx) = generate_transaction_and_mine(vault_btc_address, total_amount_btc, None);
-
-        SystemModule::set_block_number(1 + CONFIRMATIONS);
-
-        // alice executes the issue by confirming the btc transaction
-        assert_ok!(
-            Call::Issue(IssueCall::execute_issue(issue_id, tx_id, proof, raw_tx)).dispatch(origin_of(account_of(user)))
-        );
-
-        // fee should be added to epoch rewards
-        assert_eq!(FeeModule::epoch_rewards_polka_btc(), fee_amount_btc);
-
-        let final_dot_balance = CollateralModule::get_balance_from_account(&account_of(user));
-        let final_btc_balance = TreasuryModule::get_balance_from_account(account_of(user));
-
-        // griefing collateral reimbursed
-        assert_eq!(final_dot_balance, initial_dot_balance);
-
-        // polka_btc minted
-        assert_eq!(final_btc_balance, initial_btc_balance + amount_btc);
+        ExecuteIssueBuilder::new(issue_id)
+            .with_amount(sent_btc)
+            .assert_execute();
 
         assert_eq!(
-            FeePool::get(),
-            FeePool {
-                balance: 0,
-                tokens: fee_amount_btc,
-            }
+            ParachainState::get(),
+            ParachainState::default().with_changes(|user, vault, _, fee_pool| {
+                user.free_tokens += 2 * requested_btc;
+                fee_pool.tokens += 2 * issue.fee;
+                vault.issued += 2 * (issue.fee + requested_btc);
+            })
         );
-
-        // force issue rewards and withdraw
-        assert_ok!(FeeModule::update_rewards_for_epoch());
-        assert_ok!(Call::Fee(FeeCall::withdraw_polka_btc(FeeModule::get_polka_btc_rewards(
-            &account_of(vault)
-        )))
-        .dispatch(origin_of(account_of(vault))));
     });
 }
 
 #[test]
+/// overpay by a factor of 4
 fn integration_test_issue_refund() {
-    test_with(|| {
-        let (issue_id, issue) = request_issue(1000);
-
-        // verify that the vault has no spendable tokens at start
-        assert_eq!(UserData::get(VAULT).free_tokens, 0);
+    test_with_initialized_vault(|| {
+        let requested_btc = 1000;
 
         // make sure we don't have enough collateral to fulfil the overpayment
+        let current_minimum_collateral =
+            VaultRegistryModule::get_required_collateral_for_vault(account_of(VAULT)).unwrap();
         CoreVaultData::force_to(
             VAULT,
             CoreVaultData {
-                backing_collateral: 2000,
+                backing_collateral: current_minimum_collateral + requested_btc * 2,
                 ..CoreVaultData::vault(VAULT)
             },
         );
+        let initial_state = ParachainState::get();
 
-        // overpay by a factor of 4
+        let (issue_id, issue) = request_issue(requested_btc);
+        let sent_btc = (issue.amount + issue.fee) * 4;
+
         ExecuteIssueBuilder::new(issue_id)
-            .with_amount(4 * (issue.amount + issue.fee))
+            .with_amount(sent_btc)
             .assert_execute();
+
+        // not enough collateral to back sent amount, so it's as if the user sent the correct amount
+        let post_redeem_state = ParachainState::get();
+        assert_eq!(
+            post_redeem_state,
+            initial_state.with_changes(|user, vault, _, fee_pool| {
+                user.free_tokens += requested_btc;
+                fee_pool.tokens += issue.fee;
+                vault.issued += issue.fee + requested_btc;
+            })
+        );
 
         // perform the refund
         execute_refund(VAULT);
 
-        // check that we the vault has issued the amount as usual, and 4 times the normal fee
         assert_eq!(
-            CoreVaultData::vault(VAULT),
-            CoreVaultData {
-                issued: issue.amount + 4 * issue.fee,
-                backing_collateral: 2000,
-                free_tokens: issue.fee * 3,
-                ..Default::default()
-            },
+            ParachainState::get(),
+            post_redeem_state.with_changes(|_user, vault, _, _fee_pool| {
+                vault.free_tokens += issue.fee * 3;
+                vault.issued += issue.fee * 3;
+            })
         );
-
-        // check that fee was minted and is spendable by the vault
-        assert_eq!(UserData::get(VAULT).free_tokens, 3 * issue.fee);
     });
 }
 
 #[test]
 fn integration_test_issue_underpayment_succeeds() {
-    test_with(|| {
-        let (issue_id, issue) = RequestIssueBuilder::new(4_000).request();
+    test_with_initialized_vault(|| {
+        let requested_btc = 4000;
+        let (issue_id, issue) = request_issue(requested_btc);
+        let sent_btc = (issue.amount + issue.fee) / 4;
 
-        // only pay 25%
         ExecuteIssueBuilder::new(issue_id)
-            .with_amount((issue.amount + issue.fee) / 4)
+            .with_amount(sent_btc)
             .with_submitter(USER, false)
             .assert_execute();
 
-        // check that we the vault has issued only 25%
         assert_eq!(
-            CoreVaultData::vault(VAULT),
-            CoreVaultData {
-                issued: (issue.amount + issue.fee) / 4,
-                backing_collateral: DEFAULT_COLLATERAL,
-                ..Default::default()
-            },
-        );
+            ParachainState::get(),
+            ParachainState::default().with_changes(|user, vault, _, fee_pool| {
+                // user loses 75% of griefing collateral for having only fulfilled 25%
+                let slashed_griefing_collateral = (issue.griefing_collateral * 3) / 4;
+                user.free_balance -= slashed_griefing_collateral;
+                fee_pool.balance += slashed_griefing_collateral;
 
-        // check that the user lost 75% of griefing collateral, and received 25% of requested polkabtc
-        assert_eq!(
-            UserData::get(USER),
-            UserData {
-                free_balance: DEFAULT_USER_FREE_BALANCE - (issue.griefing_collateral * 3) / 4,
-                free_tokens: DEFAULT_USER_FREE_TOKENS + issue.amount / 4,
-                ..default_user_state()
-            }
-        );
-
-        assert_eq!(
-            FeePool::get(),
-            FeePool {
-                balance: (issue.griefing_collateral * 3) / 4,
-                tokens: issue.fee / 4,
-            }
+                // token updating as if only 25% was requested
+                user.free_tokens += requested_btc / 4;
+                fee_pool.tokens += issue.fee / 4;
+                vault.issued += (issue.fee + requested_btc) / 4;
+            })
         );
     });
 }
@@ -332,7 +265,7 @@ fn integration_test_issue_underpayment_executed_by_third_party_fails() {
 
 #[test]
 fn integration_test_issue_polka_btc_cancel() {
-    test_with(|| {
+    test_with_initialized_vault(|| {
         // random non-zero starting state
         let (issue_id, issue) = RequestIssueBuilder::new(10_000).request();
 
@@ -354,68 +287,20 @@ fn integration_test_issue_polka_btc_cancel() {
         assert_ok!(Call::Issue(IssueCall::cancel_issue(issue_id)).dispatch(origin_of(account_of(VAULT))));
 
         assert_eq!(
-            CoreVaultData::vault(VAULT),
-            CoreVaultData {
-                backing_collateral: DEFAULT_COLLATERAL,
-                ..Default::default()
-            },
-        );
-
-        assert_eq!(
-            FeePool::get(),
-            FeePool {
-                balance: issue.griefing_collateral,
-                tokens: 0,
-            }
-        );
-
-        assert_eq!(
-            UserData::get(USER),
-            UserData {
-                free_balance: DEFAULT_USER_FREE_BALANCE - issue.griefing_collateral,
-                ..default_user_state()
-            }
+            ParachainState::get(),
+            ParachainState::default().with_changes(|user, _vault, _, fee_pool| {
+                user.free_balance -= issue.griefing_collateral;
+                fee_pool.balance += issue.griefing_collateral;
+            })
         );
     });
 }
 
 #[test]
 fn integration_test_issue_polka_btc_cancel_liquidated() {
-    test_with(|| {
-        let user = ALICE;
-        let vault = BOB;
+    test_with_initialized_vault(|| {
+        let (issue_id, issue) = RequestIssueBuilder::new(10_000).request();
 
-        let amount_btc = 100000;
-        let griefing_collateral = 100;
-        let collateral_vault = 1000000;
-
-        let initial_dot_balance = CollateralModule::get_balance_from_account(&account_of(user));
-        let initial_btc_balance = TreasuryModule::get_balance_from_account(account_of(user));
-
-        assert_ok!(
-            Call::VaultRegistry(VaultRegistryCall::register_vault(collateral_vault, dummy_public_key()))
-                .dispatch(origin_of(account_of(vault)))
-        );
-
-        // alice requests polka_btc by locking btc with bob
-        assert_ok!(Call::Issue(IssueCall::request_issue(
-            amount_btc,
-            account_of(vault),
-            griefing_collateral
-        ))
-        .dispatch(origin_of(account_of(ALICE))));
-
-        let issue_id = assert_issue_request_event();
-        let issue = IssueModule::get_issue_request_from_id(&issue_id).unwrap();
-
-        drop_exchange_rate_and_liquidate(vault);
-
-        assert_eq!(
-            VaultRegistryModule::get_liquidation_vault().to_be_issued_tokens,
-            issue.amount + issue.fee
-        );
-
-        // expire request without transferring btc
         SystemModule::set_block_number(IssueModule::issue_period() + 1 + 1);
 
         // alice cannot execute past expiry
@@ -426,131 +311,51 @@ fn integration_test_issue_polka_btc_cancel_liquidated() {
                 vec![],
                 vec![]
             ))
-            .dispatch(origin_of(account_of(vault))),
+            .dispatch(origin_of(account_of(VAULT))),
             IssueError::CommitPeriodExpired
         );
 
+        drop_exchange_rate_and_liquidate(VAULT);
+        let post_liquidation_status = ParachainState::get();
+
         // bob cancels issue request
-        assert_ok!(Call::Issue(IssueCall::cancel_issue(issue_id)).dispatch(origin_of(account_of(vault))));
+        assert_ok!(Call::Issue(IssueCall::cancel_issue(issue_id)).dispatch(origin_of(account_of(VAULT))));
 
-        assert_eq!(VaultRegistryModule::get_liquidation_vault().to_be_issued_tokens, 0);
+        assert_eq!(
+            ParachainState::get(),
+            post_liquidation_status.with_changes(|user, _vault, liquidation_vault, _fee_pool| {
+                // griefing collateral released instead of slashed
+                user.locked_balance -= issue.griefing_collateral;
+                user.free_balance += issue.griefing_collateral;
 
-        let final_dot_balance = CollateralModule::get_balance_from_account(&account_of(user));
-        let final_btc_balance = TreasuryModule::get_balance_from_account(account_of(user));
-
-        // griefing collateral is NOT slashed
-        assert_eq!(final_dot_balance, initial_dot_balance);
-
-        // no polka_btc for alice
-        assert_eq!(final_btc_balance, initial_btc_balance);
+                liquidation_vault.to_be_issued -= issue.amount + issue.fee;
+            })
+        );
     });
 }
 
 #[test]
 fn integration_test_issue_polka_btc_execute_liquidated() {
-    test_with(|| {
-        let amount_btc = 1000;
-
-        let (issue_id, issue) = request_issue(amount_btc);
-
-        let fee_amount_btc = issue.fee;
-        let total_amount_btc = amount_btc + fee_amount_btc;
-
-        assert_eq!(
-            CoreVaultData::vault(VAULT),
-            CoreVaultData {
-                to_be_issued: total_amount_btc,
-                backing_collateral: DEFAULT_COLLATERAL,
-                ..Default::default()
-            },
-        );
+    test_with_initialized_vault(|| {
+        let (issue_id, issue) = RequestIssueBuilder::new(10_000).request();
 
         drop_exchange_rate_and_liquidate(VAULT);
-        execute_issue(issue_id);
-
-        // fee should be added to epoch rewards
-        assert_eq!(FeeModule::epoch_rewards_polka_btc(), fee_amount_btc);
-
-        // vault should be empty
-        assert_eq!(CoreVaultData::vault(VAULT), CoreVaultData::default());
-        // liquidation vault took everything from vault
-        assert_eq!(
-            CoreVaultData::liquidation_vault(),
-            CoreVaultData {
-                backing_collateral: DEFAULT_COLLATERAL,
-                issued: amount_btc + fee_amount_btc,
-                free_balance: INITIAL_LIQUIDATION_VAULT_BALANCE,
-                ..Default::default()
-            }
-        );
-        // net effect is that user received free_tokens
-        assert_eq!(
-            UserData::get(USER),
-            UserData {
-                free_tokens: DEFAULT_USER_FREE_TOKENS + amount_btc,
-                ..default_user_state()
-            },
-        );
-
-        // force issue rewards and withdraw
-        assert_ok!(FeeModule::update_rewards_for_epoch());
-        assert_ok!(Call::Fee(FeeCall::withdraw_polka_btc(FeeModule::get_polka_btc_rewards(
-            &account_of(VAULT)
-        )))
-        .dispatch(origin_of(account_of(VAULT))));
-        // should not have received fee
-        assert_eq!(TreasuryModule::get_balance_from_account(account_of(VAULT)), 0);
-    });
-}
-
-#[test]
-fn integration_test_issue_polka_btc_execute_not_liquidated() {
-    test_with(|| {
-        let amount_btc = 10_000;
-
-        let (issue_id, issue) = request_issue(amount_btc);
-
-        let fee_amount_btc = issue.fee;
-        let total_amount_btc = amount_btc + fee_amount_btc;
-
-        assert_eq!(
-            CoreVaultData::vault(VAULT),
-            CoreVaultData {
-                to_be_issued: total_amount_btc,
-                backing_collateral: DEFAULT_COLLATERAL,
-                ..Default::default()
-            },
-        );
+        let post_liquidation_status = ParachainState::get();
 
         execute_issue(issue_id);
 
-        // fee should be added to epoch rewards
-        assert_eq!(FeeModule::epoch_rewards_polka_btc(), fee_amount_btc);
-
         assert_eq!(
-            CoreVaultData::vault(VAULT),
-            CoreVaultData {
-                issued: amount_btc + fee_amount_btc,
-                backing_collateral: DEFAULT_COLLATERAL,
-                ..Default::default()
-            },
-        );
-        // net effect is that user received free_tokens
-        assert_eq!(
-            UserData::get(USER),
-            UserData {
-                free_tokens: DEFAULT_USER_FREE_TOKENS + amount_btc,
-                ..default_user_state()
-            },
-        );
+            ParachainState::get(),
+            post_liquidation_status.with_changes(|user, _vault, liquidation_vault, fee_pool| {
+                user.free_tokens += issue.amount;
+                fee_pool.tokens += issue.fee;
 
-        // force issue rewards and withdraw
-        assert_ok!(FeeModule::update_rewards_for_epoch());
-        assert_ok!(Call::Fee(FeeCall::withdraw_polka_btc(FeeModule::get_polka_btc_rewards(
-            &account_of(VAULT)
-        )))
-        .dispatch(origin_of(account_of(VAULT))));
-        // check that a fee has been withdrawn
-        assert!(TreasuryModule::get_balance_from_account(account_of(VAULT)) > 0);
+                user.free_balance += issue.griefing_collateral;
+                user.locked_balance -= issue.griefing_collateral;
+
+                liquidation_vault.to_be_issued -= issue.amount + issue.fee;
+                liquidation_vault.issued += issue.amount + issue.fee;
+            })
+        );
     });
 }

--- a/parachain/runtime/tests/test_vault_sla.rs
+++ b/parachain/runtime/tests/test_vault_sla.rs
@@ -16,6 +16,10 @@ fn initial_sla() -> FixedI128 {
 
 fn test_with<R>(execute: impl FnOnce() -> R) -> R {
     ExtBuilder::build().execute_with(|| {
+        SystemModule::set_block_number(1);
+        assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
+        set_default_thresholds();
+
         SlaModule::set_vault_sla(&account_of(VAULT), initial_sla());
         SlaModule::set_vault_sla(&account_of(PROOF_SUBMITTER), initial_sla());
 
@@ -117,6 +121,9 @@ fn test_sla_increase_for_refund() {
 #[test]
 fn test_sla_decrease_for_redeem_failure() {
     test_with(|| {
+        UserData::force_to(USER, default_user_state());
+        CoreVaultData::force_to(VAULT, default_vault_state());
+
         let redeem_id = setup_cancelable_redeem(USER, VAULT, 10_000, 1_000);
 
         cancel_redeem(redeem_id, USER, true);


### PR DESCRIPTION
- (BREAKING) Changed IssueRequest struct
- (BREAKING) Changed RedeemRequest struct
- fixed cancel_redeem: 
    - if reimburse=true: slash 130%, but give the polkabtc to the vault if it has capacity. Otherwise, it can now call `mint_tokens_for_reimbursed_redeem` after it locked additional collateral
    - if reimburse = false, slash 30%
- refactored tests