### PR TITLE
refactor: remove relayer auth storage variables in btc-relay

### DIFF
--- a/crates/btc-relay/src/lib.rs
+++ b/crates/btc-relay/src/lib.rs
@@ -140,12 +140,6 @@ decl_storage! {
 
         /// Whether the module should perform OP_RETURN checks.
         DisableOpReturnCheck get(fn disable_op_return_check) config(): bool;
-
-        /// Whether to disable relayer authorization.
-        DisableRelayerAuth get(fn disable_relayer_auth) config(): bool;
-
-        /// Accounts that are able to submit block headers.
-        AuthorizedRelayers: map hasher(blake2_128_concat) T::AccountId => bool;
     }
 }
 

--- a/crates/btc-relay/src/mock.rs
+++ b/crates/btc-relay/src/mock.rs
@@ -176,7 +176,6 @@ impl ExtBuilder {
             disable_difficulty_check: false,
             disable_inclusion_check: false,
             disable_op_return_check: false,
-            disable_relayer_auth: true,
         }
         .assimilate_storage(&mut storage)
         .unwrap();

--- a/parachain/runtime/tests/mock/mod.rs
+++ b/parachain/runtime/tests/mock/mod.rs
@@ -630,7 +630,6 @@ impl ExtBuilder {
             disable_difficulty_check: false,
             disable_inclusion_check: false,
             disable_op_return_check: false,
-            disable_relayer_auth: true,
         }
         .assimilate_storage(&mut storage)
         .unwrap();

--- a/parachain/src/chain_spec.rs
+++ b/parachain/src/chain_spec.rs
@@ -384,7 +384,6 @@ fn testnet_genesis(
             disable_difficulty_check: true,
             disable_inclusion_check: false,
             disable_op_return_check: false,
-            disable_relayer_auth: false,
         },
         issue: IssueConfig { issue_period: DAYS },
         redeem: RedeemConfig {


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>