### PR TITLE
chore: upgrade rococo-v1 dependencies

### DIFF
--- a/.deploy/Dockerfile
+++ b/.deploy/Dockerfile
@@ -3,7 +3,7 @@ FROM rust:latest
 RUN apt-get -y update
 RUN apt-get install -y build-essential cmake pkg-config libssl-dev clang libclang-dev llvm
 
-ARG TOOLCHAIN=nightly-2021-01-25
+ARG TOOLCHAIN=nightly-2021-02-15
 RUN rustup toolchain install ${TOOLCHAIN}
 RUN rustup default ${TOOLCHAIN}
 RUN rustup component add rustfmt

--- a/.deploy/Dockerfile
+++ b/.deploy/Dockerfile
@@ -3,7 +3,7 @@ FROM rust:latest
 RUN apt-get -y update
 RUN apt-get install -y build-essential cmake pkg-config libssl-dev clang libclang-dev llvm
 
-ARG TOOLCHAIN=nightly-2021-02-15
+ARG TOOLCHAIN=nightly-2021-03-15
 RUN rustup toolchain install ${TOOLCHAIN}
 RUN rustup default ${TOOLCHAIN}
 RUN rustup component add rustfmt

--- a/.deploy/rust-builder-pod.yaml
+++ b/.deploy/rust-builder-pod.yaml
@@ -16,7 +16,7 @@ spec:
   containers:
     - name: jnlp
     - name: rust
-      image: registry.gitlab.com/interlay/containers/rust-base:nightly-2021-02-15
+      image: registry.gitlab.com/interlay/containers/rust-base:nightly-2021-03-15
       imagePullPolicy: Always
       command:
         - cat

--- a/.deploy/rust-builder-pod.yaml
+++ b/.deploy/rust-builder-pod.yaml
@@ -16,7 +16,7 @@ spec:
   containers:
     - name: jnlp
     - name: rust
-      image: registry.gitlab.com/interlay/containers/rust-base:nightly-2021-01-25
+      image: registry.gitlab.com/interlay/containers/rust-base:nightly-2021-02-15
       imagePullPolicy: Always
       command:
         - cat

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "always-assert"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf688625d06217d5b1bb0ea9d9c44a1635fd0ee3534466388d18203174f4d11"
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
+checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
 name = "approx"
@@ -955,6 +961,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "chacha20"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1073,6 +1085,12 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
@@ -1198,7 +1216,7 @@ dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
- "itertools",
+ "itertools 0.9.0",
  "log",
  "serde",
  "smallvec 1.6.1",
@@ -1271,7 +1289,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils 0.8.3",
  "lazy_static",
- "memoffset 0.6.1",
+ "memoffset 0.6.3",
  "scopeguard",
 ]
 
@@ -1345,9 +1363,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8f45d9ad417bcef4817d614a501ab55cdd96a6fdb24f49aab89a54acfd66b19"
+checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
 dependencies = [
  "quote",
  "syn",
@@ -1367,7 +1385,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=rococo-v1#24b1ee6bd1d96f255889f167e59ef9c9399a6305"
+source = "git+https://github.com/paritytech/cumulus?branch=rococo-v1#9d89ed653217203810822483ae86fd8867f59620"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1391,7 +1409,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=rococo-v1#24b1ee6bd1d96f255889f167e59ef9c9399a6305"
+source = "git+https://github.com/paritytech/cumulus?branch=rococo-v1#9d89ed653217203810822483ae86fd8867f59620"
 dependencies = [
  "async-trait",
  "dyn-clone",
@@ -1416,7 +1434,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=rococo-v1#24b1ee6bd1d96f255889f167e59ef9c9399a6305"
+source = "git+https://github.com/paritytech/cumulus?branch=rococo-v1#9d89ed653217203810822483ae86fd8867f59620"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -1441,7 +1459,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=rococo-v1#24b1ee6bd1d96f255889f167e59ef9c9399a6305"
+source = "git+https://github.com/paritytech/cumulus?branch=rococo-v1#9d89ed653217203810822483ae86fd8867f59620"
 dependencies = [
  "derive_more",
  "futures 0.3.13",
@@ -1465,7 +1483,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=rococo-v1#24b1ee6bd1d96f255889f167e59ef9c9399a6305"
+source = "git+https://github.com/paritytech/cumulus?branch=rococo-v1#9d89ed653217203810822483ae86fd8867f59620"
 dependencies = [
  "cumulus-client-collator",
  "cumulus-client-consensus-common",
@@ -1477,6 +1495,7 @@ dependencies = [
  "sc-chain-spec",
  "sc-client-api",
  "sc-service",
+ "sc-telemetry",
  "sc-tracing",
  "sp-api",
  "sp-blockchain",
@@ -1489,7 +1508,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=rococo-v1#24b1ee6bd1d96f255889f167e59ef9c9399a6305"
+source = "git+https://github.com/paritytech/cumulus?branch=rococo-v1#9d89ed653217203810822483ae86fd8867f59620"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",
@@ -1518,7 +1537,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm-handler"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=rococo-v1#24b1ee6bd1d96f255889f167e59ef9c9399a6305"
+source = "git+https://github.com/paritytech/cumulus?branch=rococo-v1#9d89ed653217203810822483ae86fd8867f59620"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1533,7 +1552,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=rococo-v1#24b1ee6bd1d96f255889f167e59ef9c9399a6305"
+source = "git+https://github.com/paritytech/cumulus?branch=rococo-v1#9d89ed653217203810822483ae86fd8867f59620"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -1548,7 +1567,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=rococo-v1#24b1ee6bd1d96f255889f167e59ef9c9399a6305"
+source = "git+https://github.com/paritytech/cumulus?branch=rococo-v1#9d89ed653217203810822483ae86fd8867f59620"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -1617,10 +1636,11 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.11"
+version = "0.99.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cb0e6161ad61ed084a36ba71fbba9e3ac5aee3606fb607fe08da6acbcf3d8c"
+checksum = "f82b1b72f1263f214c0f823371768776c4f5841b942c9883aa8e5ec584fd0ba6"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn",
@@ -2052,7 +2072,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2070,7 +2090,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "3.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2089,7 +2109,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "Inflector",
  "chrono",
@@ -2110,9 +2130,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-election-provider-support"
+version = "3.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "sp-arithmetic",
+ "sp-npos-elections",
+ "sp-std",
+]
+
+[[package]]
 name = "frame-executive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2128,7 +2161,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -2139,7 +2172,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -2165,7 +2198,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -2177,10 +2210,10 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-support-procedural-tools-derive",
- "proc-macro-crate",
+ "proc-macro-crate 1.0.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -2189,7 +2222,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2199,7 +2232,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -2216,7 +2249,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2230,7 +2263,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2239,7 +2272,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -2249,10 +2282,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs-swap"
-version = "0.2.5"
+name = "fs-err"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5839fda247e24ca4919c87c71dd5ca658f1f39e4f06829f80e3f15c3bafcfc2c"
+checksum = "bcd1163ae48bda72a20ae26d66a04d3094135cadab911cff418ae5e33f253431"
+
+[[package]]
+name = "fs-swap"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d47dad3685eceed8488986cad3d5027165ea5edb164331770e2059555f10a5"
 dependencies = [
  "lazy_static",
  "libc",
@@ -2356,7 +2395,7 @@ dependencies = [
  "lazy_static",
  "log",
  "parking_lot 0.9.0",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "serde",
  "serde_json",
 ]
@@ -2611,9 +2650,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "3.5.3"
+version = "3.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb0867bbc5a3da37a753e78021d5fcf8a4db00e18dd2dd90fd36e24190e162d"
+checksum = "580b6f551b29a3a02436318aed09ba1c58eea177dc49e39beac627ad356730a5"
 dependencies = [
  "log",
  "pest",
@@ -2850,8 +2889,8 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.5",
- "socket2",
+ "pin-project 1.0.6",
+ "socket2 0.3.19",
  "tokio 0.2.25",
  "tower-service",
  "tracing",
@@ -3081,6 +3120,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3097,9 +3145,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.48"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9f84f9b115ce7843d60706df1422a916680bfdfcbdb0447c5614ff9d7e4d78"
+checksum = "dc15e39392125075f60c95ba416f5381ff6c3a948ff02ab12464715adf56c821"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3148,7 +3196,7 @@ version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99a847f9ec7bb52149b2786a17c9cb260d6effc6b8eeb8c16b343a487a7563a3"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 0.1.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -3307,13 +3355,14 @@ dependencies = [
 [[package]]
 name = "kusama-runtime"
 version = "0.8.29"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "bitvec",
  "frame-executive",
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
  "log",
  "pallet-authority-discovery",
  "pallet-authorship",
@@ -3440,9 +3489,9 @@ checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
 name = "libc"
-version = "0.2.89"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "538c092e5586f4cdd7dd8078c4a79220e3e168880218124dcbce860f0ea938c6"
+checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
 
 [[package]]
 name = "libloading"
@@ -3493,7 +3542,7 @@ dependencies = [
  "libp2p-yamux",
  "parity-multiaddr",
  "parking_lot 0.11.1",
- "pin-project 1.0.5",
+ "pin-project 1.0.6",
  "smallvec 1.6.1",
  "wasm-timer",
 ]
@@ -3518,7 +3567,7 @@ dependencies = [
  "multistream-select",
  "parity-multiaddr",
  "parking_lot 0.11.1",
- "pin-project 1.0.5",
+ "pin-project 1.0.6",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -3657,7 +3706,7 @@ dependencies = [
  "log",
  "rand 0.7.3",
  "smallvec 1.6.1",
- "socket2",
+ "socket2 0.3.19",
  "void",
 ]
 
@@ -3741,7 +3790,7 @@ checksum = "6ce3374f3b28162db9d3442c9347c4f14cb01e8290052615c7d341d40eae0599"
 dependencies = [
  "futures 0.3.13",
  "log",
- "pin-project 1.0.5",
+ "pin-project 1.0.6",
  "rand 0.7.3",
  "salsa20",
  "sha3",
@@ -3807,7 +3856,7 @@ dependencies = [
  "libc",
  "libp2p-core",
  "log",
- "socket2",
+ "socket2 0.3.19",
 ]
 
 [[package]]
@@ -4039,9 +4088,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
+checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
 dependencies = [
  "autocfg 1.0.1",
 ]
@@ -4087,8 +4136,9 @@ dependencies = [
 [[package]]
 name = "metered-channel"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
+ "derive_more",
  "futures 0.3.13",
  "futures-timer 3.0.2",
 ]
@@ -4173,7 +4223,7 @@ checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
  "log",
  "mio",
- "miow 0.3.6",
+ "miow 0.3.7",
  "winapi 0.3.9",
 ]
 
@@ -4202,11 +4252,10 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "socket2",
  "winapi 0.3.9",
 ]
 
@@ -4475,7 +4524,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85ee3c48cb9d9b275ad967a0e96715badc13c6029adb92f34fa17b9ff28fd81f"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 0.1.5",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -4498,7 +4547,7 @@ dependencies = [
  "bytes 1.0.1",
  "futures 0.3.13",
  "log",
- "pin-project 1.0.5",
+ "pin-project 1.0.6",
  "smallvec 1.6.1",
  "unsigned-varint 0.7.0",
 ]
@@ -4532,12 +4581,12 @@ dependencies = [
 
 [[package]]
 name = "nb-connect"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670361df1bc2399ee1ff50406a0d422587dd3bb0da596e1978fe8e05dabddf4f"
+checksum = "a19900e7eee95eb2b3c2e26d12a874cc80aaf750e31be6fcbe743ead369fa45d"
 dependencies = [
  "libc",
- "socket2",
+ "socket2 0.4.0",
 ]
 
 [[package]]
@@ -4674,12 +4723,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "oorandom"
-version = "11.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4718,7 +4761,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4730,13 +4773,12 @@ dependencies = [
  "sp-consensus-aura",
  "sp-runtime",
  "sp-std",
- "sp-timestamp",
 ]
 
 [[package]]
 name = "pallet-authority-discovery"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4752,7 +4794,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4767,7 +4809,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4786,13 +4828,12 @@ dependencies = [
  "sp-session",
  "sp-staking",
  "sp-std",
- "sp-timestamp",
 ]
 
 [[package]]
 name = "pallet-balances"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4807,7 +4848,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4821,7 +4862,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4838,7 +4879,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4853,15 +4894,15 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
+ "frame-election-provider-support",
  "frame-support",
  "frame-system",
  "log",
  "parity-scale-codec",
  "serde",
  "sp-arithmetic",
- "sp-election-providers",
  "sp-io",
  "sp-npos-elections",
  "sp-runtime",
@@ -4872,7 +4913,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4887,7 +4928,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4909,7 +4950,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -4925,7 +4966,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4945,7 +4986,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4962,7 +5003,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4976,7 +5017,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4991,7 +5032,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5005,7 +5046,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5021,7 +5062,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5036,7 +5077,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5049,7 +5090,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -5064,7 +5105,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5080,7 +5121,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5100,7 +5141,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5114,19 +5155,20 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-benchmarking",
+ "frame-election-provider-support",
  "frame-support",
  "frame-system",
  "log",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
+ "paste 1.0.5",
  "rand_chacha 0.2.2",
  "serde",
  "sp-application-crypto",
- "sp-election-providers",
  "sp-io",
  "sp-npos-elections",
  "sp-runtime",
@@ -5138,9 +5180,9 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.0.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -5149,7 +5191,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5163,7 +5205,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5182,7 +5224,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5196,7 +5238,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5212,7 +5254,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -5229,7 +5271,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -5240,7 +5282,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5255,7 +5297,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5270,7 +5312,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -5329,9 +5371,9 @@ dependencies = [
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c6805f98667a3828afb2ec2c396a8d610497e8d546f5447188aae47c5a79ec"
+checksum = "58341485071825827b7f03cf7efd1cb21e6a709bea778fb50227fd45d2f361b4"
 dependencies = [
  "arrayref",
  "bs58",
@@ -5364,7 +5406,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa04976a81fde04924b40cc4036c4d12841e8bb04325a5cf2ada75731a150a7d"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 0.1.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -5387,7 +5429,7 @@ dependencies = [
  "libc",
  "log",
  "mio-named-pipes",
- "miow 0.3.6",
+ "miow 0.3.7",
  "rand 0.7.3",
  "tokio 0.1.22",
  "tokio-named-pipes",
@@ -5661,27 +5703,27 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
+checksum = "918192b5c59119d51e0cd221f4d49dde9112824ba717369e903c97d076083d0f"
 dependencies = [
- "pin-project-internal 0.4.27",
+ "pin-project-internal 0.4.28",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
+checksum = "bc174859768806e91ae575187ada95c91a29e96a98dc5d2cd9a1fed039501ba6"
 dependencies = [
- "pin-project-internal 1.0.5",
+ "pin-project-internal 1.0.6",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
+checksum = "3be26700300be6d9d23264c73211d8190e755b6b5ca7a1b28230025511b52a5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5690,9 +5732,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
+checksum = "a490329918e856ed1b083f244e3bfe2d8c4f336407e4ea9e1a9f479ff09049e5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5738,7 +5780,7 @@ checksum = "989d43012e2ca1c4a02507c67282691a0a3207f9dc67cec596b43fe925b3d325"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "futures 0.3.13",
  "polkadot-node-network-protocol",
@@ -5752,7 +5794,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "futures 0.3.13",
  "parity-scale-codec",
@@ -5766,7 +5808,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "futures 0.3.13",
  "lru",
@@ -5788,18 +5830,17 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "futures 0.3.13",
- "futures-timer 3.0.2",
  "lru",
+ "parity-scale-codec",
  "polkadot-erasure-coding",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "rand 0.8.3",
- "streamunordered",
  "thiserror",
  "tracing",
 ]
@@ -5807,7 +5848,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "0.8.29"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "frame-benchmarking-cli",
  "futures 0.3.13",
@@ -5827,14 +5868,18 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
+ "always-assert",
  "futures 0.3.13",
+ "futures-timer 3.0.2",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
+ "sp-core",
+ "sp-runtime",
  "thiserror",
  "tracing",
 ]
@@ -5842,7 +5887,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "0.7.30"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
@@ -5854,11 +5899,11 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "0.8.29"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
- "reed-solomon-erasure",
+ "reed-solomon-novelpoly",
  "sp-core",
  "sp-trie",
  "thiserror",
@@ -5867,7 +5912,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "futures 0.3.13",
  "polkadot-node-network-protocol",
@@ -5881,11 +5926,12 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "async-trait",
  "futures 0.3.13",
  "parity-scale-codec",
+ "parking_lot 0.11.1",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
  "polkadot-primitives",
@@ -5898,7 +5944,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "futures 0.3.13",
  "polkadot-erasure-coding",
@@ -5914,7 +5960,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -5943,7 +5989,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "bitvec",
  "futures 0.3.13",
@@ -5964,7 +6010,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "bitvec",
  "futures 0.3.13",
@@ -5982,7 +6028,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "futures 0.3.13",
  "polkadot-node-subsystem",
@@ -5997,7 +6043,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-selection"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "futures 0.3.13",
  "polkadot-node-primitives",
@@ -6012,7 +6058,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "futures 0.3.13",
  "parity-scale-codec",
@@ -6028,7 +6074,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "futures 0.3.13",
  "polkadot-node-subsystem",
@@ -6041,7 +6087,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-proposer"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "futures 0.3.13",
  "futures-timer 3.0.2",
@@ -6051,6 +6097,7 @@ dependencies = [
  "sc-basic-authorship",
  "sc-block-builder",
  "sc-client-api",
+ "sc-telemetry",
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
@@ -6065,7 +6112,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "bitvec",
  "futures 0.3.13",
@@ -6080,7 +6127,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "futures 0.3.13",
  "memory-lru",
@@ -6097,7 +6144,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "async-std",
  "lazy_static",
@@ -6114,7 +6161,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "futures 0.3.13",
  "parity-scale-codec",
@@ -6124,13 +6171,12 @@ dependencies = [
  "sc-network",
  "strum",
  "thiserror",
- "zstd",
 ]
 
 [[package]]
 name = "polkadot-node-primitives"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "futures 0.3.13",
  "parity-scale-codec",
@@ -6148,7 +6194,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "async-std",
  "async-trait",
@@ -6160,7 +6206,7 @@ dependencies = [
  "mick-jaeger",
  "parity-scale-codec",
  "parking_lot 0.11.1",
- "pin-project 1.0.5",
+ "pin-project 1.0.6",
  "polkadot-node-jaeger",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
@@ -6178,14 +6224,14 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "async-trait",
  "futures 0.3.13",
  "futures-timer 3.0.2",
  "metered-channel",
  "parity-scale-codec",
- "pin-project 1.0.5",
+ "pin-project 1.0.6",
  "polkadot-node-jaeger",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
@@ -6204,12 +6250,11 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "async-trait",
  "futures 0.3.13",
  "futures-timer 3.0.2",
- "oorandom",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
@@ -6221,7 +6266,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain"
 version = "0.8.29"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "derive_more",
  "futures 0.3.13",
@@ -6246,23 +6291,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "polkadot-pov-distribution"
-version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
-dependencies = [
- "futures 0.3.13",
- "polkadot-node-network-protocol",
- "polkadot-node-subsystem",
- "polkadot-node-subsystem-util",
- "polkadot-primitives",
- "thiserror",
- "tracing",
-]
-
-[[package]]
 name = "polkadot-primitives"
 version = "0.8.29"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "bitvec",
  "frame-system",
@@ -6285,12 +6316,14 @@ dependencies = [
  "sp-std",
  "sp-trie",
  "sp-version",
+ "thiserror",
+ "zstd",
 ]
 
 [[package]]
 name = "polkadot-procmacro-subsystem-dispatch-gen"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "assert_matches",
  "proc-macro2",
@@ -6301,7 +6334,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "0.8.29"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "jsonrpc-core",
  "pallet-transaction-payment-rpc",
@@ -6331,13 +6364,14 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime"
 version = "0.8.29"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "bitvec",
  "frame-executive",
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
  "log",
  "pallet-authority-discovery",
  "pallet-authorship",
@@ -6397,15 +6431,17 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "0.8.29"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "impl-trait-for-tuples",
  "libsecp256k1",
  "log",
  "pallet-authorship",
+ "pallet-babe",
  "pallet-balances",
  "pallet-offences",
  "pallet-session",
@@ -6435,12 +6471,14 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "bitvec",
  "derive_more",
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "libsecp256k1",
  "log",
  "pallet-authority-discovery",
  "pallet-authorship",
@@ -6472,7 +6510,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "0.8.3"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "frame-benchmarking",
  "frame-system-rpc-runtime-api",
@@ -6505,7 +6543,6 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
  "polkadot-parachain",
- "polkadot-pov-distribution",
  "polkadot-primitives",
  "polkadot-rpc",
  "polkadot-runtime",
@@ -6556,7 +6593,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "arrayvec 0.5.2",
  "futures 0.3.13",
@@ -6573,7 +6610,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "0.8.29"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -6582,11 +6619,11 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a7bc6b2a29e632e45451c941832803a18cce6781db04de8a04696cdca8bde4"
+checksum = "4fc12d774e799ee9ebae13f4076ca003b40d18a11ac0f3641e6f899618580b7b"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "log",
  "wepoll-sys",
@@ -6639,6 +6676,16 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
+ "toml",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+dependencies = [
+ "thiserror",
  "toml",
 ]
 
@@ -6719,14 +6766,14 @@ checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
 dependencies = [
  "bytes 1.0.1",
  "heck",
- "itertools",
+ "itertools 0.9.0",
  "log",
  "multimap",
  "petgraph",
  "prost",
  "prost-types",
  "tempfile",
- "which 4.0.2",
+ "which 4.1.0",
 ]
 
 [[package]]
@@ -6736,7 +6783,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.9.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -7171,12 +7218,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "reed-solomon-erasure"
-version = "4.0.2"
+name = "reed-solomon-novelpoly"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a415a013dd7c5d4221382329a5a3482566da675737494935cbbbcdec04662f9d"
+checksum = "f11e01a8ef53ec033daf53a9385a1d0bb266155797919096e4134118f45efe82"
 dependencies = [
- "smallvec 1.6.1",
+ "derive_more",
+ "fs-err",
+ "itertools 0.10.0",
+ "static_init",
+ "thiserror",
 ]
 
 [[package]]
@@ -7283,7 +7334,7 @@ dependencies = [
 [[package]]
 name = "remote-externalities"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "env_logger 0.8.3",
  "hex-literal 0.3.1",
@@ -7294,6 +7345,7 @@ dependencies = [
  "parity-scale-codec",
  "sp-core",
  "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7380,7 +7432,7 @@ dependencies = [
 [[package]]
 name = "rococo-parachain-primitives"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=rococo-v1#24b1ee6bd1d96f255889f167e59ef9c9399a6305"
+source = "git+https://github.com/paritytech/cumulus?branch=rococo-v1#9d89ed653217203810822483ae86fd8867f59620"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -7389,7 +7441,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "0.8.29"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -7534,7 +7586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
 dependencies = [
  "futures 0.3.13",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "static_assertions",
 ]
 
@@ -7574,7 +7626,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7602,7 +7654,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "futures 0.3.13",
  "futures-timer 3.0.2",
@@ -7625,7 +7677,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -7641,7 +7693,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7662,9 +7714,9 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.0.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -7673,7 +7725,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "chrono",
  "fdlimit",
@@ -7711,7 +7763,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "derive_more",
  "fnv",
@@ -7745,7 +7797,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -7775,7 +7827,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -7786,7 +7838,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "derive_more",
  "futures 0.3.13",
@@ -7818,7 +7870,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "derive_more",
  "fork-tree",
@@ -7864,7 +7916,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "derive_more",
  "futures 0.3.13",
@@ -7888,7 +7940,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -7901,7 +7953,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "futures 0.3.13",
  "futures-timer 3.0.2",
@@ -7920,6 +7972,7 @@ dependencies = [
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
+ "sp-timestamp",
  "sp-trie",
  "thiserror",
 ]
@@ -7927,7 +7980,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "log",
  "sc-client-api",
@@ -7941,7 +7994,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -7970,7 +8023,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -7986,7 +8039,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8001,7 +8054,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8019,7 +8072,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "derive_more",
  "dyn-clone",
@@ -8031,7 +8084,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.11.1",
- "pin-project 1.0.5",
+ "pin-project 1.0.6",
  "rand 0.7.3",
  "sc-block-builder",
  "sc-client-api",
@@ -8058,7 +8111,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "derive_more",
  "finality-grandpa",
@@ -8082,7 +8135,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-warp-sync"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "derive_more",
  "futures 0.3.13",
@@ -8103,7 +8156,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.13",
@@ -8121,7 +8174,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8141,7 +8194,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -8160,7 +8213,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "async-std",
  "async-trait",
@@ -8186,7 +8239,7 @@ dependencies = [
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.11.1",
- "pin-project 1.0.5",
+ "pin-project 1.0.6",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -8213,7 +8266,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "futures 0.3.13",
  "futures-timer 3.0.2",
@@ -8223,18 +8276,20 @@ dependencies = [
  "sc-network",
  "sp-runtime",
  "substrate-prometheus-endpoint",
+ "tracing",
  "wasm-timer",
 ]
 
 [[package]]
 name = "sc-offchain"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
  "futures 0.3.13",
  "futures-timer 3.0.2",
+ "hex",
  "hyper 0.13.10",
  "hyper-rustls",
  "log",
@@ -8256,7 +8311,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "futures 0.3.13",
  "libp2p",
@@ -8269,7 +8324,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -8278,7 +8333,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "futures 0.3.13",
  "hash-db",
@@ -8312,7 +8367,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "derive_more",
  "futures 0.3.13",
@@ -8336,7 +8391,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "futures 0.1.31",
  "jsonrpc-core",
@@ -8354,7 +8409,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "directories",
  "exit-future",
@@ -8369,7 +8424,7 @@ dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot 0.11.1",
- "pin-project 1.0.5",
+ "pin-project 1.0.6",
  "rand 0.7.3",
  "sc-block-builder",
  "sc-chain-spec",
@@ -8417,7 +8472,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8432,7 +8487,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -8452,21 +8507,19 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "chrono",
  "futures 0.3.13",
  "libp2p",
  "log",
  "parking_lot 0.11.1",
- "pin-project 1.0.5",
+ "pin-project 1.0.6",
  "rand 0.7.3",
  "serde",
  "serde_json",
- "sp-utils",
  "take_mut",
- "tracing",
- "tracing-subscriber",
+ "thiserror",
  "void",
  "wasm-timer",
 ]
@@ -8474,7 +8527,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -8485,7 +8538,6 @@ dependencies = [
  "parking_lot 0.11.1",
  "regex",
  "rustc-hash",
- "sc-telemetry",
  "sc-tracing-proc-macro",
  "serde",
  "serde_json",
@@ -8502,9 +8554,9 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.0.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -8513,7 +8565,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "derive_more",
  "futures 0.3.13",
@@ -8535,7 +8587,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "futures 0.3.13",
  "futures-diagnose",
@@ -8740,18 +8792,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
+checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
+checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8972,6 +9024,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "soketto"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8990,7 +9052,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "log",
  "sp-core",
@@ -9002,7 +9064,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "hash-db",
  "log",
@@ -9019,10 +9081,10 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "blake2-rfc",
- "proc-macro-crate",
+ "proc-macro-crate 1.0.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -9031,7 +9093,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -9043,7 +9105,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -9056,7 +9118,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9068,7 +9130,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -9079,7 +9141,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9091,7 +9153,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "futures 0.3.13",
  "log",
@@ -9109,7 +9171,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "serde",
  "serde_json",
@@ -9118,7 +9180,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "futures 0.3.13",
  "futures-timer 3.0.2",
@@ -9144,11 +9206,12 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
  "sp-application-crypto",
+ "sp-consensus",
  "sp-consensus-slots",
  "sp-inherents",
  "sp-runtime",
@@ -9159,10 +9222,11 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "merlin",
  "parity-scale-codec",
+ "serde",
  "sp-api",
  "sp-application-crypto",
  "sp-consensus",
@@ -9179,7 +9243,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "parity-scale-codec",
  "sp-arithmetic",
@@ -9189,7 +9253,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -9201,7 +9265,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -9245,7 +9309,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "kvdb",
  "parking_lot 0.11.1",
@@ -9254,7 +9318,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9262,20 +9326,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-election-providers"
-version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
-dependencies = [
- "parity-scale-codec",
- "sp-arithmetic",
- "sp-npos-elections",
- "sp-std",
-]
-
-[[package]]
 name = "sp-externalities"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -9286,7 +9339,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -9303,7 +9356,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.11.1",
@@ -9315,7 +9368,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "futures 0.3.13",
  "hash-db",
@@ -9339,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -9350,7 +9403,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -9367,7 +9420,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -9380,9 +9433,9 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.0.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -9391,7 +9444,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -9401,7 +9454,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "backtrace",
 ]
@@ -9409,7 +9462,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "serde",
  "sp-core",
@@ -9418,7 +9471,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -9439,7 +9492,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -9456,10 +9509,10 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "Inflector",
- "proc-macro-crate",
+ "proc-macro-crate 1.0.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -9468,7 +9521,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "serde",
  "serde_json",
@@ -9477,7 +9530,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9490,7 +9543,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -9500,7 +9553,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "hash-db",
  "log",
@@ -9522,12 +9575,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 
 [[package]]
 name = "sp-storage"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9540,7 +9593,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "log",
  "sp-core",
@@ -9553,9 +9606,8 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
- "impl-trait-for-tuples",
  "parity-scale-codec",
  "sp-api",
  "sp-inherents",
@@ -9567,7 +9619,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9580,7 +9632,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "derive_more",
  "futures 0.3.13",
@@ -9596,7 +9648,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -9610,7 +9662,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "futures 0.3.13",
  "futures-core",
@@ -9622,7 +9674,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9634,7 +9686,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -9700,6 +9752,31 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "static_init"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11b73400442027c4adedda20a9f9b7945234a5bd8d5f7e86da22bd5d0622369c"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "parking_lot 0.11.1",
+ "static_init_macro",
+]
+
+[[package]]
+name = "static_init_macro"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2261c91034a1edc3fc4d1b80e89d82714faede0515c14a75da10cb941546bbf"
+dependencies = [
+ "cfg_aliases",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "statrs"
@@ -9817,7 +9894,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "platforms 1.1.0",
 ]
@@ -9825,7 +9902,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.13",
@@ -9848,7 +9925,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "async-std",
  "derive_more",
@@ -10381,7 +10458,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project 1.0.5",
+ "pin-project 1.0.6",
  "tracing",
 ]
 
@@ -10476,7 +10553,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#645299e8b23ec5fa52935b1a6edbf36886e80141"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#401c24e8a62cdf058882b0e92815faef966d9fa1"
 dependencies = [
  "frame-try-runtime",
  "log",
@@ -10688,9 +10765,9 @@ checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
 name = "vec-arena"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
+checksum = "34b2f665b594b07095e3ac3f718e13c2197143416fae4c5706cffb7b1af8d7f1"
 
 [[package]]
 name = "vec_map"
@@ -10718,9 +10795,9 @@ checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
  "winapi 0.3.9",
@@ -10762,9 +10839,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
+checksum = "8fe8f61dba8e5d645a4d8132dc7a0a66861ed5e1045d2c0ed940fab33bac0fbe"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -10772,9 +10849,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7d8b6942b8bb3a9b0e73fc79b98095a27de6fa247615e59d096754a3bc2aa8"
+checksum = "046ceba58ff062da072c7cb4ba5b22a37f00a302483f7e2a6cdc18fedbdc1fd3"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -10787,9 +10864,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e67a5806118af01f0d9045915676b22aaebecf4178ae7021bc171dab0b897ab"
+checksum = "73157efb9af26fb564bb59a009afd1c7c334a44db171d280690d0c3faaec3468"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -10799,9 +10876,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ac38da8ef716661f0f36c0d8320b89028efe10c7c0afde65baffb496ce0d3b"
+checksum = "0ef9aa01d36cda046f797c57959ff5f3c615c9cc63997a8d545831ec7976819b"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -10809,9 +10886,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
+checksum = "96eb45c1b2ee33545a813a92dbb53856418bf7eb54ab34f7f7ff1448a5b3735d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10822,9 +10899,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
+checksum = "b7148f4696fb4960a346eaa60bbfb42a1ac4ebba21f750f75fc1375b098d5ffa"
 
 [[package]]
 name = "wasm-gc-api"
@@ -11059,7 +11136,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "memoffset 0.6.1",
+ "memoffset 0.6.3",
  "more-asserts",
  "psm",
  "region",
@@ -11070,9 +11147,9 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "35.0.0"
+version = "35.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db5ae96da18bb5926341516fd409b5a8ce4e4714da7f0a1063d3b20ac9f9a1e1"
+checksum = "1a5800e9f86a1eae935e38bea11e60fd253f6d514d153fb39b3e5535a7b37b56"
 dependencies = [
  "leb128",
 ]
@@ -11088,9 +11165,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.48"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec600b26223b2948cedfde2a0aa6756dcf1fef616f43d7b3097aaf53a6c4d92b"
+checksum = "59fe19d70f5dacc03f6e46777213facae5ac3801575d56ca6cbd4c93dcd12310"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -11127,13 +11204,14 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "0.8.29"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "bitvec",
  "frame-executive",
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
  "log",
  "pallet-authority-discovery",
  "pallet-authorship",
@@ -11170,6 +11248,7 @@ dependencies = [
  "polkadot-parachain",
  "polkadot-primitives",
  "polkadot-runtime-common",
+ "polkadot-runtime-parachains",
  "rustc-hex",
  "serde",
  "serde_derive",
@@ -11203,12 +11282,12 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.0.2"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
+checksum = "b55551e42cbdf2ce2bedd2203d0cc08dba002c27510f86dab6d0ce304cba3dfe"
 dependencies = [
+ "either",
  "libc",
- "thiserror",
 ]
 
 [[package]]
@@ -11284,7 +11363,7 @@ dependencies = [
 [[package]]
 name = "xcm"
 version = "0.8.22"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -11292,7 +11371,7 @@ dependencies = [
 [[package]]
 name = "xcm-builder"
 version = "0.8.22"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -11308,7 +11387,7 @@ dependencies = [
 [[package]]
 name = "xcm-executor"
 version = "0.8.22"
-source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2f7b975015d5c3f50199cda82b9b84e38726d001"
+source = "git+https://github.com/paritytech/polkadot?branch=rococo-v1#2e07b871f138c7e3d6e11188b5ee6725b4aa0b53"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -11384,6 +11463,6 @@ checksum = "a1e6e8778706838f43f771d80d37787cb2fe06dafe89dd3aebaf6721b9eaec81"
 dependencies = [
  "cc",
  "glob",
- "itertools",
+ "itertools 0.9.0",
  "libc",
 ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
     apt-get dist-upgrade -y -o Dpkg::Options::="--force-confold" && \
     apt-get install -y cmake pkg-config libssl-dev git clang
 
-ARG TOOLCHAIN=nightly-2021-02-15
+ARG TOOLCHAIN=nightly-2021-03-15
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     export PATH="$PATH:$HOME/.cargo/bin" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
     apt-get dist-upgrade -y -o Dpkg::Options::="--force-confold" && \
     apt-get install -y cmake pkg-config libssl-dev git clang
 
-ARG TOOLCHAIN=nightly-2021-01-25
+ARG TOOLCHAIN=nightly-2021-02-15
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     export PATH="$PATH:$HOME/.cargo/bin" && \

--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ curl https://sh.rustup.rs -sSf | sh
 Building requires `nightly`. Run the following commands to set it up:
 
 ```
-rustup toolchain install nightly-2021-01-25
-rustup default nightly-2021-01-25
+rustup toolchain install nightly-2021-02-15
+rustup default nightly-2021-02-15
 rustup component add rustfmt
 rustup component add rls
 rustup toolchain install nightly
-rustup target add wasm32-unknown-unknown --toolchain nightly-2021-01-25
+rustup target add wasm32-unknown-unknown --toolchain nightly-2021-02-15
 ```
 
 To build, run:

--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ curl https://sh.rustup.rs -sSf | sh
 Building requires `nightly`. Run the following commands to set it up:
 
 ```
-rustup toolchain install nightly-2021-02-15
-rustup default nightly-2021-02-15
+rustup toolchain install nightly-2021-03-15
+rustup default nightly-2021-03-15
 rustup component add rustfmt
 rustup component add rls
 rustup toolchain install nightly
-rustup target add wasm32-unknown-unknown --toolchain nightly-2021-02-15
+rustup target add wasm32-unknown-unknown --toolchain nightly-2021-03-15
 ```
 
 To build, run:

--- a/crates/btc-relay/src/benchmarking.rs
+++ b/crates/btc-relay/src/benchmarking.rs
@@ -8,7 +8,7 @@ use bitcoin::{
     },
 };
 use frame_benchmarking::{account, benchmarks};
-use frame_system::{Module as System, RawOrigin};
+use frame_system::{Pallet as System, RawOrigin};
 use sp_core::{H256, U256};
 use sp_std::prelude::*;
 

--- a/crates/btc-relay/src/lib.rs
+++ b/crates/btc-relay/src/lib.rs
@@ -309,7 +309,7 @@ impl<T: Config> Module<T> {
         let block_header_hash = raw_block_header.hash();
 
         // register the current height to track stable parachain confirmations
-        let para_height = <frame_system::Module<T>>::block_number();
+        let para_height = <frame_system::Pallet<T>>::block_number();
 
         // construct the BlockChain struct
         let blockchain = Self::initialize_blockchain(block_height, block_header_hash);
@@ -394,7 +394,7 @@ impl<T: Config> Module<T> {
         };
 
         // register the current height to track stable parachain confirmations
-        let para_height = <frame_system::Module<T>>::block_number();
+        let para_height = <frame_system::Pallet<T>>::block_number();
 
         // Create rich block header
         let block_header = RichBlockHeader::<T::AccountId, T::BlockNumber> {
@@ -1370,7 +1370,7 @@ impl<T: Config> Module<T> {
     /// # Arguments
     /// * `para_height` - height of the parachain when the block was stored
     pub fn check_parachain_confirmations(para_height: T::BlockNumber) -> Result<(), DispatchError> {
-        let current_height = <frame_system::Module<T>>::block_number();
+        let current_height = <frame_system::Pallet<T>>::block_number();
 
         ensure!(
             para_height + Self::parachain_confirmations() <= current_height,

--- a/crates/btc-relay/src/mock.rs
+++ b/crates/btc-relay/src/mock.rs
@@ -22,22 +22,22 @@ frame_support::construct_runtime!(
         NodeBlock = Block,
         UncheckedExtrinsic = UncheckedExtrinsic,
     {
-        System: frame_system::{Module, Call, Storage, Config, Event<T>},
-        Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
+        System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
+        Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
 
         // Tokens & Balances
-        DOT: pallet_balances::<Instance1>::{Module, Call, Storage, Config<T>, Event<T>},
-        PolkaBTC: pallet_balances::<Instance2>::{Module, Call, Storage, Config<T>, Event<T>},
+        DOT: pallet_balances::<Instance1>::{Pallet, Call, Storage, Config<T>, Event<T>},
+        PolkaBTC: pallet_balances::<Instance2>::{Pallet, Call, Storage, Config<T>, Event<T>},
 
-        Collateral: collateral::{Module, Call, Storage, Event<T>},
-        Treasury: treasury::{Module, Call, Storage, Event<T>},
+        Collateral: collateral::{Pallet, Call, Storage, Event<T>},
+        Treasury: treasury::{Pallet, Call, Storage, Event<T>},
 
         // Operational
-        BTCRelay: btc_relay::{Module, Call, Config<T>, Storage, Event<T>},
-        Security: security::{Module, Call, Storage, Event},
-        VaultRegistry: vault_registry::{Module, Call, Config<T>, Storage, Event<T>},
-        ExchangeRateOracle: exchange_rate_oracle::{Module, Call, Config<T>, Storage, Event<T>},
-        Sla: sla::{Module, Call, Config<T>, Storage, Event<T>},
+        BTCRelay: btc_relay::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Security: security::{Pallet, Call, Storage, Event},
+        VaultRegistry: vault_registry::{Pallet, Call, Config<T>, Storage, Event<T>},
+        ExchangeRateOracle: exchange_rate_oracle::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Sla: sla::{Pallet, Call, Config<T>, Storage, Event<T>},
     }
 );
 
@@ -124,12 +124,12 @@ impl sla::Config for Test {
 
 impl treasury::Config for Test {
     type Event = TestEvent;
-    type PolkaBTC = pallet_balances::Module<Test, pallet_balances::Instance2>;
+    type PolkaBTC = pallet_balances::Pallet<Test, pallet_balances::Instance2>;
 }
 
 impl collateral::Config for Test {
     type Event = TestEvent;
-    type DOT = pallet_balances::Module<Test, pallet_balances::Instance1>;
+    type DOT = pallet_balances::Pallet<Test, pallet_balances::Instance1>;
 }
 
 impl vault_registry::Config for Test {

--- a/crates/collateral/src/mock.rs
+++ b/crates/collateral/src/mock.rs
@@ -17,9 +17,9 @@ frame_support::construct_runtime!(
         NodeBlock = Block,
         UncheckedExtrinsic = UncheckedExtrinsic,
     {
-        System: frame_system::{Module, Call, Storage, Config, Event<T>},
-        Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
-        Collateral: collateral::{Module, Call, Storage, Event<T>},
+        System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
+        Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+        Collateral: collateral::{Pallet, Call, Storage, Event<T>},
     }
 );
 

--- a/crates/exchange-rate-oracle/src/lib.rs
+++ b/crates/exchange-rate-oracle/src/lib.rs
@@ -346,7 +346,7 @@ impl<T: Config> Module<T> {
 
     /// Returns the current timestamp
     fn get_current_time() -> T::Moment {
-        <pallet_timestamp::Module<T>>::get()
+        <pallet_timestamp::Pallet<T>>::get()
     }
 
     /// Add a new authorized oracle

--- a/crates/exchange-rate-oracle/src/mock.rs
+++ b/crates/exchange-rate-oracle/src/mock.rs
@@ -19,15 +19,15 @@ frame_support::construct_runtime!(
         NodeBlock = Block,
         UncheckedExtrinsic = UncheckedExtrinsic,
     {
-        System: frame_system::{Module, Call, Storage, Config, Event<T>},
-        Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
-        Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
+        System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
+        Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
+        Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
 
         // Operational
-        Collateral: collateral::{Module, Call, Storage, Event<T>},
-        Treasury: treasury::{Module, Call, Storage, Event<T>},
-        Security: security::{Module, Call, Storage, Event},
-        ExchangeRateOracle: exchange_rate_oracle::{Module, Call, Config<T>, Storage, Event<T>},
+        Collateral: collateral::{Pallet, Call, Storage, Event<T>},
+        Treasury: treasury::{Pallet, Call, Storage, Event<T>},
+        Security: security::{Pallet, Call, Storage, Event},
+        ExchangeRateOracle: exchange_rate_oracle::{Pallet, Call, Config<T>, Storage, Event<T>},
     }
 );
 

--- a/crates/fee/src/mock.rs
+++ b/crates/fee/src/mock.rs
@@ -19,22 +19,22 @@ frame_support::construct_runtime!(
         NodeBlock = Block,
         UncheckedExtrinsic = UncheckedExtrinsic,
     {
-        System: frame_system::{Module, Call, Storage, Config, Event<T>},
-        Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
+        System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
+        Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
 
         // Tokens & Balances
-        DOT: pallet_balances::<Instance1>::{Module, Call, Storage, Config<T>, Event<T>},
-        PolkaBTC: pallet_balances::<Instance2>::{Module, Call, Storage, Config<T>, Event<T>},
+        DOT: pallet_balances::<Instance1>::{Pallet, Call, Storage, Config<T>, Event<T>},
+        PolkaBTC: pallet_balances::<Instance2>::{Pallet, Call, Storage, Config<T>, Event<T>},
 
-        Collateral: collateral::{Module, Call, Storage, Event<T>},
-        Treasury: treasury::{Module, Call, Storage, Event<T>},
+        Collateral: collateral::{Pallet, Call, Storage, Event<T>},
+        Treasury: treasury::{Pallet, Call, Storage, Event<T>},
 
         // Operational
-        Security: security::{Module, Call, Storage, Event},
-        VaultRegistry: vault_registry::{Module, Call, Config<T>, Storage, Event<T>},
-        ExchangeRateOracle: exchange_rate_oracle::{Module, Call, Config<T>, Storage, Event<T>},
-        Fee: fee::{Module, Call, Config<T>, Storage, Event<T>},
-        Sla: sla::{Module, Call, Config<T>, Storage, Event<T>},
+        Security: security::{Pallet, Call, Storage, Event},
+        VaultRegistry: vault_registry::{Pallet, Call, Config<T>, Storage, Event<T>},
+        ExchangeRateOracle: exchange_rate_oracle::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Fee: fee::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Sla: sla::{Pallet, Call, Config<T>, Storage, Event<T>},
     }
 );
 
@@ -111,12 +111,12 @@ impl pallet_balances::Config<pallet_balances::Instance2> for Test {
 
 impl collateral::Config for Test {
     type Event = TestEvent;
-    type DOT = pallet_balances::Module<Test, pallet_balances::Instance1>;
+    type DOT = pallet_balances::Pallet<Test, pallet_balances::Instance1>;
 }
 
 impl treasury::Config for Test {
     type Event = TestEvent;
-    type PolkaBTC = pallet_balances::Module<Test, pallet_balances::Instance2>;
+    type PolkaBTC = pallet_balances::Pallet<Test, pallet_balances::Instance2>;
 }
 
 impl exchange_rate_oracle::Config for Test {

--- a/crates/issue/src/benchmarking.rs
+++ b/crates/issue/src/benchmarking.rs
@@ -7,7 +7,7 @@ use bitcoin::{
 use btc_relay::{BtcAddress, BtcPublicKey, Module as BtcRelay};
 use exchange_rate_oracle::Module as ExchangeRateOracle;
 use frame_benchmarking::{account, benchmarks};
-use frame_system::{Module as System, RawOrigin};
+use frame_system::{Pallet as System, RawOrigin};
 use security::Module as Security;
 use sp_core::{H160, H256, U256};
 use sp_runtime::FixedPointNumber;

--- a/crates/issue/src/lib.rs
+++ b/crates/issue/src/lib.rs
@@ -253,7 +253,7 @@ impl<T: Config> Module<T> {
         // Check that Parachain is RUNNING
         ext::security::ensure_parachain_status_running::<T>()?;
 
-        let height = <frame_system::Module<T>>::block_number();
+        let height = <frame_system::Pallet<T>>::block_number();
         let vault = ext::vault_registry::get_active_vault_from_id::<T>(&vault_id)?;
         // Check that the vault is currently not banned
         ext::vault_registry::ensure_not_banned::<T>(&vault_id, height)?;
@@ -546,7 +546,7 @@ impl<T: Config> Module<T> {
 }
 
 fn has_request_expired<T: Config>(opentime: T::BlockNumber, period: T::BlockNumber) -> bool {
-    let height = <frame_system::Module<T>>::block_number();
+    let height = <frame_system::Pallet<T>>::block_number();
     height > opentime + period
 }
 

--- a/crates/issue/src/mock.rs
+++ b/crates/issue/src/mock.rs
@@ -19,25 +19,25 @@ frame_support::construct_runtime!(
         NodeBlock = Block,
         UncheckedExtrinsic = UncheckedExtrinsic,
     {
-        System: frame_system::{Module, Call, Storage, Config, Event<T>},
-        Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
+        System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
+        Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
 
         // Tokens & Balances
-        DOT: pallet_balances::<Instance1>::{Module, Call, Storage, Config<T>, Event<T>},
-        PolkaBTC: pallet_balances::<Instance2>::{Module, Call, Storage, Config<T>, Event<T>},
+        DOT: pallet_balances::<Instance1>::{Pallet, Call, Storage, Config<T>, Event<T>},
+        PolkaBTC: pallet_balances::<Instance2>::{Pallet, Call, Storage, Config<T>, Event<T>},
 
-        Collateral: collateral::{Module, Call, Storage, Event<T>},
-        Treasury: treasury::{Module, Call, Storage, Event<T>},
+        Collateral: collateral::{Pallet, Call, Storage, Event<T>},
+        Treasury: treasury::{Pallet, Call, Storage, Event<T>},
 
         // Operational
-        BTCRelay: btc_relay::{Module, Call, Config<T>, Storage, Event<T>},
-        Security: security::{Module, Call, Storage, Event},
-        VaultRegistry: vault_registry::{Module, Call, Config<T>, Storage, Event<T>},
-        ExchangeRateOracle: exchange_rate_oracle::{Module, Call, Config<T>, Storage, Event<T>},
-        Issue: issue::{Module, Call, Config<T>, Storage, Event<T>},
-        Fee: fee::{Module, Call, Config<T>, Storage, Event<T>},
-        Sla: sla::{Module, Call, Config<T>, Storage, Event<T>},
-        Refund: refund::{Module, Call, Config<T>, Storage, Event<T>},
+        BTCRelay: btc_relay::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Security: security::{Pallet, Call, Storage, Event},
+        VaultRegistry: vault_registry::{Pallet, Call, Config<T>, Storage, Event<T>},
+        ExchangeRateOracle: exchange_rate_oracle::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Issue: issue::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Fee: fee::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Sla: sla::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Refund: refund::{Pallet, Call, Config<T>, Storage, Event<T>},
     }
 );
 
@@ -121,7 +121,7 @@ impl vault_registry::Config for Test {
 
 impl collateral::Config for Test {
     type Event = TestEvent;
-    type DOT = pallet_balances::Module<Test, pallet_balances::Instance1>;
+    type DOT = pallet_balances::Pallet<Test, pallet_balances::Instance1>;
 }
 
 impl btc_relay::Config for Test {
@@ -135,7 +135,7 @@ impl security::Config for Test {
 
 impl treasury::Config for Test {
     type Event = TestEvent;
-    type PolkaBTC = pallet_balances::Module<Test, pallet_balances::Instance2>;
+    type PolkaBTC = pallet_balances::Pallet<Test, pallet_balances::Instance2>;
 }
 
 impl refund::Config for Test {

--- a/crates/issue/src/tests.rs
+++ b/crates/issue/src/tests.rs
@@ -68,7 +68,7 @@ fn test_request_issue_banned_fails() {
         assert_ok!(<exchange_rate_oracle::Module<Test>>::_set_exchange_rate(
             FixedU128::one()
         ));
-        <frame_system::Module<Test>>::set_block_number(0);
+        <frame_system::Pallet<Test>>::set_block_number(0);
         <vault_registry::Module<Test>>::insert_vault(
             &BOB,
             vault_registry::Vault {
@@ -149,7 +149,7 @@ fn test_execute_issue_commit_period_expired_fails() {
             .mock_safe(|_| MockResult::Return(Ok(init_zero_vault::<Test>(BOB))));
 
         let issue_id = request_issue_ok(ALICE, 3, BOB, 20);
-        <frame_system::Module<Test>>::set_block_number(20);
+        <frame_system::Pallet<Test>>::set_block_number(20);
         assert_noop!(execute_issue(ALICE, &issue_id), TestError::CommitPeriodExpired);
     })
 }
@@ -164,7 +164,7 @@ fn test_execute_issue_succeeds() {
         ext::vault_registry::is_vault_liquidated::<Test>.mock_safe(|_| MockResult::Return(Ok(false)));
 
         let issue_id = request_issue_ok(ALICE, 3, BOB, 20);
-        <frame_system::Module<Test>>::set_block_number(5);
+        <frame_system::Pallet<Test>>::set_block_number(5);
 
         ext::security::ensure_parachain_status_running::<Test>.mock_safe(|| MockResult::Return(Ok(())));
         ext::btc_relay::verify_transaction_inclusion::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
@@ -188,7 +188,7 @@ fn test_execute_issue_overpayment_succeeds() {
         ext::vault_registry::issue_tokens::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
 
         let issue_id = request_issue_ok(ALICE, 3, BOB, 20);
-        <frame_system::Module<Test>>::set_block_number(5);
+        <frame_system::Pallet<Test>>::set_block_number(5);
         ext::security::ensure_parachain_status_running::<Test>.mock_safe(|| MockResult::Return(Ok(())));
 
         ext::btc_relay::verify_transaction_inclusion::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
@@ -230,7 +230,7 @@ fn test_execute_issue_refund_succeeds() {
         ext::vault_registry::issue_tokens::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
 
         let issue_id = request_issue_ok(ALICE, 3, BOB, 20);
-        <frame_system::Module<Test>>::set_block_number(5);
+        <frame_system::Pallet<Test>>::set_block_number(5);
         ext::security::ensure_parachain_status_running::<Test>.mock_safe(|| MockResult::Return(Ok(())));
 
         ext::btc_relay::verify_transaction_inclusion::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
@@ -273,14 +273,14 @@ fn test_cancel_issue_not_found_fails() {
 #[test]
 fn test_cancel_issue_not_expired_fails() {
     run_test(|| {
-        <frame_system::Module<Test>>::set_block_number(1);
+        <frame_system::Pallet<Test>>::set_block_number(1);
 
         ext::vault_registry::get_active_vault_from_id::<Test>
             .mock_safe(|_| MockResult::Return(Ok(init_zero_vault::<Test>(BOB))));
 
         let issue_id = request_issue_ok(ALICE, 3, BOB, 20);
         // issue period is 10, we issued at block 1, so at block 5 the cancel should fail
-        <frame_system::Module<Test>>::set_block_number(5);
+        <frame_system::Pallet<Test>>::set_block_number(5);
         assert_noop!(cancel_issue(ALICE, &issue_id), TestError::TimeNotExpired,);
     })
 }
@@ -288,7 +288,7 @@ fn test_cancel_issue_not_expired_fails() {
 #[test]
 fn test_cancel_issue_succeeds() {
     run_test(|| {
-        <frame_system::Module<Test>>::set_block_number(1);
+        <frame_system::Pallet<Test>>::set_block_number(1);
 
         ext::vault_registry::get_active_vault_from_id::<Test>
             .mock_safe(|_| MockResult::Return(Ok(init_zero_vault::<Test>(BOB))));
@@ -301,7 +301,7 @@ fn test_cancel_issue_succeeds() {
 
         let issue_id = request_issue_ok(ALICE, 3, BOB, 20);
         // issue period is 10, we issued at block 1, so at block 15 the cancel should succeed
-        <frame_system::Module<Test>>::set_block_number(15);
+        <frame_system::Pallet<Test>>::set_block_number(15);
         assert_ok!(cancel_issue(ALICE, &issue_id));
     })
 }

--- a/crates/redeem/src/benchmarking.rs
+++ b/crates/redeem/src/benchmarking.rs
@@ -6,7 +6,7 @@ use bitcoin::{
 };
 use btc_relay::{BtcAddress, BtcPublicKey, Module as BtcRelay};
 use frame_benchmarking::{account, benchmarks};
-use frame_system::{Module as System, RawOrigin};
+use frame_system::{Pallet as System, RawOrigin};
 use sp_core::{H160, H256, U256};
 use sp_std::prelude::*;
 use vault_registry::{

--- a/crates/redeem/src/lib.rs
+++ b/crates/redeem/src/lib.rs
@@ -297,7 +297,7 @@ impl<T: Config> Module<T> {
             .ok_or(Error::<T>::ArithmeticUnderflow)?;
 
         let vault = ext::vault_registry::get_active_vault_from_id::<T>(&vault_id)?;
-        let height = <frame_system::Module<T>>::block_number();
+        let height = <frame_system::Pallet<T>>::block_number();
         ext::vault_registry::ensure_not_banned::<T>(&vault_id, height)?;
         ensure!(
             redeem_amount_polka_btc <= vault.issued_tokens,
@@ -680,7 +680,7 @@ impl<T: Config> Module<T> {
 }
 
 fn has_request_expired<T: Config>(opentime: T::BlockNumber, period: T::BlockNumber) -> bool {
-    let height = <frame_system::Module<T>>::block_number();
+    let height = <frame_system::Pallet<T>>::block_number();
     height > opentime + period
 }
 

--- a/crates/redeem/src/mock.rs
+++ b/crates/redeem/src/mock.rs
@@ -19,24 +19,24 @@ frame_support::construct_runtime!(
         NodeBlock = Block,
         UncheckedExtrinsic = UncheckedExtrinsic,
     {
-        System: frame_system::{Module, Call, Storage, Config, Event<T>},
-        Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
+        System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
+        Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
 
         // Tokens & Balances
-        DOT: pallet_balances::<Instance1>::{Module, Call, Storage, Config<T>, Event<T>},
-        PolkaBTC: pallet_balances::<Instance2>::{Module, Call, Storage, Config<T>, Event<T>},
+        DOT: pallet_balances::<Instance1>::{Pallet, Call, Storage, Config<T>, Event<T>},
+        PolkaBTC: pallet_balances::<Instance2>::{Pallet, Call, Storage, Config<T>, Event<T>},
 
-        Collateral: collateral::{Module, Call, Storage, Event<T>},
-        Treasury: treasury::{Module, Call, Storage, Event<T>},
+        Collateral: collateral::{Pallet, Call, Storage, Event<T>},
+        Treasury: treasury::{Pallet, Call, Storage, Event<T>},
 
         // Operational
-        BTCRelay: btc_relay::{Module, Call, Config<T>, Storage, Event<T>},
-        Security: security::{Module, Call, Storage, Event},
-        VaultRegistry: vault_registry::{Module, Call, Config<T>, Storage, Event<T>},
-        ExchangeRateOracle: exchange_rate_oracle::{Module, Call, Config<T>, Storage, Event<T>},
-        Redeem: redeem::{Module, Call, Config<T>, Storage, Event<T>},
-        Fee: fee::{Module, Call, Config<T>, Storage, Event<T>},
-        Sla: sla::{Module, Call, Config<T>, Storage, Event<T>},
+        BTCRelay: btc_relay::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Security: security::{Pallet, Call, Storage, Event},
+        VaultRegistry: vault_registry::{Pallet, Call, Config<T>, Storage, Event<T>},
+        ExchangeRateOracle: exchange_rate_oracle::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Redeem: redeem::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Fee: fee::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Sla: sla::{Pallet, Call, Config<T>, Storage, Event<T>},
     }
 );
 
@@ -120,7 +120,7 @@ impl vault_registry::Config for Test {
 
 impl collateral::Config for Test {
     type Event = TestEvent;
-    type DOT = pallet_balances::Module<Test, pallet_balances::Instance1>;
+    type DOT = pallet_balances::Pallet<Test, pallet_balances::Instance1>;
 }
 
 impl btc_relay::Config for Test {
@@ -134,7 +134,7 @@ impl security::Config for Test {
 
 impl treasury::Config for Test {
     type Event = TestEvent;
-    type PolkaBTC = pallet_balances::Module<Test, pallet_balances::Instance2>;
+    type PolkaBTC = pallet_balances::Pallet<Test, pallet_balances::Instance2>;
 }
 
 parameter_types! {

--- a/crates/redeem/src/tests.rs
+++ b/crates/redeem/src/tests.rs
@@ -519,7 +519,7 @@ fn test_cancel_redeem_fails_with_time_not_expired() {
 #[test]
 fn test_cancel_redeem_fails_with_unauthorized_caller() {
     run_test(|| {
-        <frame_system::Module<Test>>::set_block_number(20);
+        <frame_system::Pallet<Test>>::set_block_number(20);
 
         Redeem::get_open_redeem_request_from_id.mock_safe(|_| {
             MockResult::Return(Ok(RedeemRequest {

--- a/crates/refund/src/mock.rs
+++ b/crates/refund/src/mock.rs
@@ -22,24 +22,24 @@ frame_support::construct_runtime!(
         NodeBlock = Block,
         UncheckedExtrinsic = UncheckedExtrinsic,
     {
-        System: frame_system::{Module, Call, Storage, Config, Event<T>},
-        Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
+        System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
+        Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
 
         // Tokens & Balances
-        DOT: pallet_balances::<Instance1>::{Module, Call, Storage, Config<T>, Event<T>},
-        PolkaBTC: pallet_balances::<Instance2>::{Module, Call, Storage, Config<T>, Event<T>},
+        DOT: pallet_balances::<Instance1>::{Pallet, Call, Storage, Config<T>, Event<T>},
+        PolkaBTC: pallet_balances::<Instance2>::{Pallet, Call, Storage, Config<T>, Event<T>},
 
-        Collateral: collateral::{Module, Call, Storage, Event<T>},
-        Treasury: treasury::{Module, Call, Storage, Event<T>},
+        Collateral: collateral::{Pallet, Call, Storage, Event<T>},
+        Treasury: treasury::{Pallet, Call, Storage, Event<T>},
 
         // Operational
-        BTCRelay: btc_relay::{Module, Call, Config<T>, Storage, Event<T>},
-        Security: security::{Module, Call, Storage, Event},
-        VaultRegistry: vault_registry::{Module, Call, Config<T>, Storage, Event<T>},
-        ExchangeRateOracle: exchange_rate_oracle::{Module, Call, Config<T>, Storage, Event<T>},
-        Fee: fee::{Module, Call, Config<T>, Storage, Event<T>},
-        Sla: sla::{Module, Call, Config<T>, Storage, Event<T>},
-        Refund: refund::{Module, Call, Config<T>, Storage, Event<T>},
+        BTCRelay: btc_relay::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Security: security::{Pallet, Call, Storage, Event},
+        VaultRegistry: vault_registry::{Pallet, Call, Config<T>, Storage, Event<T>},
+        ExchangeRateOracle: exchange_rate_oracle::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Fee: fee::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Sla: sla::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Refund: refund::{Pallet, Call, Config<T>, Storage, Event<T>},
     }
 );
 
@@ -121,7 +121,7 @@ impl Config for Test {
 
 impl treasury::Config for Test {
     type Event = TestEvent;
-    type PolkaBTC = pallet_balances::Module<Test, pallet_balances::Instance2>;
+    type PolkaBTC = pallet_balances::Pallet<Test, pallet_balances::Instance2>;
 }
 
 impl fee::Config for Test {
@@ -137,7 +137,7 @@ impl sla::Config for Test {
 
 impl collateral::Config for Test {
     type Event = TestEvent;
-    type DOT = pallet_balances::Module<Test, pallet_balances::Instance1>;
+    type DOT = pallet_balances::Pallet<Test, pallet_balances::Instance1>;
 }
 
 impl btc_relay::Config for Test {

--- a/crates/replace/src/benchmarking.rs
+++ b/crates/replace/src/benchmarking.rs
@@ -7,7 +7,7 @@ use bitcoin::{
 use btc_relay::{BtcAddress, BtcPublicKey, Module as BtcRelay};
 use exchange_rate_oracle::Module as ExchangeRateOracle;
 use frame_benchmarking::{account, benchmarks};
-use frame_system::{Module as System, RawOrigin};
+use frame_system::{Pallet as System, RawOrigin};
 use sp_core::{H160, H256, U256};
 use sp_runtime::FixedPointNumber;
 use sp_std::prelude::*;

--- a/crates/replace/src/lib.rs
+++ b/crates/replace/src/lib.rs
@@ -703,12 +703,12 @@ impl<T: Config> Module<T> {
     }
 
     fn current_height() -> T::BlockNumber {
-        <frame_system::Module<T>>::block_number()
+        <frame_system::Pallet<T>>::block_number()
     }
 }
 
 fn has_request_expired<T: Config>(opentime: T::BlockNumber, period: T::BlockNumber) -> bool {
-    let height = <frame_system::Module<T>>::block_number();
+    let height = <frame_system::Pallet<T>>::block_number();
     height > opentime + period
 }
 

--- a/crates/replace/src/mock.rs
+++ b/crates/replace/src/mock.rs
@@ -19,24 +19,24 @@ frame_support::construct_runtime!(
         NodeBlock = Block,
         UncheckedExtrinsic = UncheckedExtrinsic,
     {
-        System: frame_system::{Module, Call, Storage, Config, Event<T>},
-        Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
+        System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
+        Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
 
         // Tokens & Balances
-        DOT: pallet_balances::<Instance1>::{Module, Call, Storage, Config<T>, Event<T>},
-        PolkaBTC: pallet_balances::<Instance2>::{Module, Call, Storage, Config<T>, Event<T>},
+        DOT: pallet_balances::<Instance1>::{Pallet, Call, Storage, Config<T>, Event<T>},
+        PolkaBTC: pallet_balances::<Instance2>::{Pallet, Call, Storage, Config<T>, Event<T>},
 
-        Collateral: collateral::{Module, Call, Storage, Event<T>},
-        Treasury: treasury::{Module, Call, Storage, Event<T>},
+        Collateral: collateral::{Pallet, Call, Storage, Event<T>},
+        Treasury: treasury::{Pallet, Call, Storage, Event<T>},
 
         // Operational
-        BTCRelay: btc_relay::{Module, Call, Config<T>, Storage, Event<T>},
-        Security: security::{Module, Call, Storage, Event},
-        VaultRegistry: vault_registry::{Module, Call, Config<T>, Storage, Event<T>},
-        ExchangeRateOracle: exchange_rate_oracle::{Module, Call, Config<T>, Storage, Event<T>},
-        Replace: replace::{Module, Call, Config<T>, Storage, Event<T>},
-        Fee: fee::{Module, Call, Config<T>, Storage, Event<T>},
-        Sla: sla::{Module, Call, Config<T>, Storage, Event<T>},
+        BTCRelay: btc_relay::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Security: security::{Pallet, Call, Storage, Event},
+        VaultRegistry: vault_registry::{Pallet, Call, Config<T>, Storage, Event<T>},
+        ExchangeRateOracle: exchange_rate_oracle::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Replace: replace::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Fee: fee::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Sla: sla::{Pallet, Call, Config<T>, Storage, Event<T>},
     }
 );
 
@@ -120,7 +120,7 @@ impl vault_registry::Config for Test {
 
 impl collateral::Config for Test {
     type Event = TestEvent;
-    type DOT = pallet_balances::Module<Test, pallet_balances::Instance1>;
+    type DOT = pallet_balances::Pallet<Test, pallet_balances::Instance1>;
 }
 
 impl btc_relay::Config for Test {
@@ -134,7 +134,7 @@ impl security::Config for Test {
 
 impl treasury::Config for Test {
     type Event = TestEvent;
-    type PolkaBTC = pallet_balances::Module<Test, pallet_balances::Instance2>;
+    type PolkaBTC = pallet_balances::Pallet<Test, pallet_balances::Instance2>;
 }
 
 impl sla::Config for Test {

--- a/crates/security/src/lib.rs
+++ b/crates/security/src/lib.rs
@@ -272,7 +272,7 @@ impl<T: Config> Module<T> {
         hasher.input(Self::get_nonce().encode());
         // supplement with prev block hash to prevent replays
         // even if the `Nonce` is reset (i.e. purge-chain)
-        hasher.input(frame_system::Module::<T>::parent_hash());
+        hasher.input(frame_system::Pallet::<T>::parent_hash());
         let mut result = [0; 32];
         result.copy_from_slice(&hasher.result()[..]);
         H256(result)

--- a/crates/security/src/mock.rs
+++ b/crates/security/src/mock.rs
@@ -19,8 +19,8 @@ frame_support::construct_runtime!(
         NodeBlock = Block,
         UncheckedExtrinsic = UncheckedExtrinsic,
     {
-        System: frame_system::{Module, Call, Storage, Config, Event<T>},
-        Security: security::{Module, Call, Storage, Event},
+        System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
+        Security: security::{Pallet, Call, Storage, Event},
     }
 );
 

--- a/crates/security/src/tests.rs
+++ b/crates/security/src/tests.rs
@@ -199,7 +199,7 @@ fn test_get_nonce() {
 #[test]
 fn testget_secure_id() {
     run_test(|| {
-        frame_system::Module::<Test>::set_parent_hash(H256::zero());
+        frame_system::Pallet::<Test>::set_parent_hash(H256::zero());
         assert_eq!(
             Security::get_secure_id(&1),
             H256::from_slice(&[

--- a/crates/sla/src/mock.rs
+++ b/crates/sla/src/mock.rs
@@ -19,21 +19,21 @@ frame_support::construct_runtime!(
         NodeBlock = Block,
         UncheckedExtrinsic = UncheckedExtrinsic,
     {
-        System: frame_system::{Module, Call, Storage, Config, Event<T>},
-        Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
+        System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
+        Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
 
         // Tokens & Balances
-        DOT: pallet_balances::<Instance1>::{Module, Call, Storage, Config<T>, Event<T>},
-        PolkaBTC: pallet_balances::<Instance2>::{Module, Call, Storage, Config<T>, Event<T>},
+        DOT: pallet_balances::<Instance1>::{Pallet, Call, Storage, Config<T>, Event<T>},
+        PolkaBTC: pallet_balances::<Instance2>::{Pallet, Call, Storage, Config<T>, Event<T>},
 
-        Collateral: collateral::{Module, Call, Storage, Event<T>},
-        Treasury: treasury::{Module, Call, Storage, Event<T>},
+        Collateral: collateral::{Pallet, Call, Storage, Event<T>},
+        Treasury: treasury::{Pallet, Call, Storage, Event<T>},
 
         // Operational
-        Security: security::{Module, Call, Storage, Event},
-        VaultRegistry: vault_registry::{Module, Call, Config<T>, Storage, Event<T>},
-        ExchangeRateOracle: exchange_rate_oracle::{Module, Call, Config<T>, Storage, Event<T>},
-        Sla: sla::{Module, Call, Config<T>, Storage, Event<T>},
+        Security: security::{Pallet, Call, Storage, Event},
+        VaultRegistry: vault_registry::{Pallet, Call, Config<T>, Storage, Event<T>},
+        ExchangeRateOracle: exchange_rate_oracle::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Sla: sla::{Pallet, Call, Config<T>, Storage, Event<T>},
     }
 );
 
@@ -110,17 +110,17 @@ impl pallet_balances::Config<pallet_balances::Instance2> for Test {
 
 impl collateral::Config for Test {
     type Event = TestEvent;
-    type DOT = pallet_balances::Module<Test, pallet_balances::Instance1>;
+    type DOT = pallet_balances::Pallet<Test, pallet_balances::Instance1>;
 }
 
 impl treasury::Config for Test {
     type Event = TestEvent;
-    type PolkaBTC = pallet_balances::Module<Test, pallet_balances::Instance2>;
+    type PolkaBTC = pallet_balances::Pallet<Test, pallet_balances::Instance2>;
 }
 
 impl vault_registry::Config for Test {
     type Event = TestEvent;
-    type RandomnessSource = pallet_randomness_collective_flip::Module<Test>;
+    type RandomnessSource = pallet_randomness_collective_flip::Pallet<Test>;
     type UnsignedFixedPoint = FixedU128;
     type WeightInfo = ();
 }

--- a/crates/staked-relayers/src/benchmarking.rs
+++ b/crates/staked-relayers/src/benchmarking.rs
@@ -7,7 +7,7 @@ use bitcoin::{
 use btc_relay::{BtcAddress, BtcPublicKey, Module as BtcRelay};
 use collateral::Module as Collateral;
 use frame_benchmarking::{account, benchmarks};
-use frame_system::{Module as System, RawOrigin};
+use frame_system::{Pallet as System, RawOrigin};
 use sp_core::{H160, U256};
 use sp_std::prelude::*;
 use vault_registry::{

--- a/crates/staked-relayers/src/lib.rs
+++ b/crates/staked-relayers/src/lib.rs
@@ -211,7 +211,7 @@ decl_module! {
             ext::collateral::lock_collateral::<T>(&signer, stake)?;
             ext::sla::initialize_relayer_stake::<T>(&signer, stake)?;
 
-            let height = <frame_system::Module<T>>::block_number();
+            let height = <frame_system::Pallet<T>>::block_number();
             let maturity = height + Self::get_maturity_period();
             Self::insert_inactive_staked_relayer(&signer, stake, maturity);
             Self::deposit_event(<Event<T>>::RegisterStakedRelayer(signer, maturity, stake));
@@ -364,7 +364,7 @@ decl_module! {
             let mut tally = Tally::default();
             tally.aye.insert(signer.clone(), staked_relayer.stake);
 
-            let height = <frame_system::Module<T>>::block_number();
+            let height = <frame_system::Pallet<T>>::block_number();
             let status_update_id = Self::insert_active_status_update(StatusUpdate{
                 new_status_code: status_code.clone(),
                 old_status_code: ext::security::get_parachain_status::<T>(),
@@ -678,7 +678,7 @@ impl<T: Config> Module<T> {
     /// * `id` - AccountId of the caller.
     pub fn activate_staked_relayer(id: &T::AccountId) -> DispatchResult {
         let staked_relayer = Self::get_inactive_staked_relayer(id)?;
-        let height = <frame_system::Module<T>>::block_number();
+        let height = <frame_system::Pallet<T>>::block_number();
         Self::try_bond_staked_relayer(id, staked_relayer.stake, height, staked_relayer.height)?;
         Ok(())
     }

--- a/crates/staked-relayers/src/mock.rs
+++ b/crates/staked-relayers/src/mock.rs
@@ -19,27 +19,27 @@ frame_support::construct_runtime!(
         NodeBlock = Block,
         UncheckedExtrinsic = UncheckedExtrinsic,
     {
-        System: frame_system::{Module, Call, Storage, Config, Event<T>},
-        Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
+        System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
+        Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
 
         // Tokens & Balances
-        DOT: pallet_balances::<Instance1>::{Module, Call, Storage, Config<T>, Event<T>},
-        PolkaBTC: pallet_balances::<Instance2>::{Module, Call, Storage, Config<T>, Event<T>},
+        DOT: pallet_balances::<Instance1>::{Pallet, Call, Storage, Config<T>, Event<T>},
+        PolkaBTC: pallet_balances::<Instance2>::{Pallet, Call, Storage, Config<T>, Event<T>},
 
-        Collateral: collateral::{Module, Call, Storage, Event<T>},
-        Treasury: treasury::{Module, Call, Storage, Event<T>},
+        Collateral: collateral::{Pallet, Call, Storage, Event<T>},
+        Treasury: treasury::{Pallet, Call, Storage, Event<T>},
 
         // Operational
-        BTCRelay: btc_relay::{Module, Call, Config<T>, Storage, Event<T>},
-        Security: security::{Module, Call, Storage, Event},
-        StakedRelayers: staked_relayers::{Module, Call, Config<T>, Storage, Event<T>},
-        VaultRegistry: vault_registry::{Module, Call, Config<T>, Storage, Event<T>},
-        ExchangeRateOracle: exchange_rate_oracle::{Module, Call, Config<T>, Storage, Event<T>},
-        Redeem: redeem::{Module, Call, Config<T>, Storage, Event<T>},
-        Replace: replace::{Module, Call, Config<T>, Storage, Event<T>},
-        Fee: fee::{Module, Call, Config<T>, Storage, Event<T>},
-        Sla: sla::{Module, Call, Config<T>, Storage, Event<T>},
-        Refund: refund::{Module, Call, Config<T>, Storage, Event<T>},
+        BTCRelay: btc_relay::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Security: security::{Pallet, Call, Storage, Event},
+        StakedRelayers: staked_relayers::{Pallet, Call, Config<T>, Storage, Event<T>},
+        VaultRegistry: vault_registry::{Pallet, Call, Config<T>, Storage, Event<T>},
+        ExchangeRateOracle: exchange_rate_oracle::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Redeem: redeem::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Replace: replace::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Fee: fee::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Sla: sla::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Refund: refund::{Pallet, Call, Config<T>, Storage, Event<T>},
     }
 );
 
@@ -131,14 +131,14 @@ impl security::Config for Test {
 
 impl vault_registry::Config for Test {
     type Event = TestEvent;
-    type RandomnessSource = pallet_randomness_collective_flip::Module<Test>;
+    type RandomnessSource = pallet_randomness_collective_flip::Pallet<Test>;
     type UnsignedFixedPoint = FixedU128;
     type WeightInfo = ();
 }
 
 impl treasury::Config for Test {
     type Event = TestEvent;
-    type PolkaBTC = pallet_balances::Module<Test, pallet_balances::Instance2>;
+    type PolkaBTC = pallet_balances::Pallet<Test, pallet_balances::Instance2>;
 }
 
 impl exchange_rate_oracle::Config for Test {
@@ -165,7 +165,7 @@ impl refund::Config for Test {
 
 impl collateral::Config for Test {
     type Event = TestEvent;
-    type DOT = pallet_balances::Module<Test, pallet_balances::Instance1>;
+    type DOT = pallet_balances::Pallet<Test, pallet_balances::Instance1>;
 }
 
 impl btc_relay::Config for Test {

--- a/crates/treasury/src/mock.rs
+++ b/crates/treasury/src/mock.rs
@@ -18,9 +18,9 @@ frame_support::construct_runtime!(
         NodeBlock = Block,
         UncheckedExtrinsic = UncheckedExtrinsic,
     {
-        System: frame_system::{Module, Call, Storage, Config, Event<T>},
-        Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
-        Treasury: treasury::{Module, Call, Storage, Event<T>},
+        System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
+        Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+        Treasury: treasury::{Pallet, Call, Storage, Event<T>},
     }
 );
 

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -73,7 +73,7 @@ pub trait Config:
     /// The overarching event type.
     type Event: From<Event<Self>> + Into<<Self as frame_system::Config>::Event>;
 
-    type RandomnessSource: Randomness<H256>;
+    type RandomnessSource: Randomness<H256, Self::BlockNumber>;
 
     type UnsignedFixedPoint: FixedPointNumber + Encode + EncodeLike + Decode;
 
@@ -918,7 +918,7 @@ impl<T: Config> Module<T> {
     }
 
     pub fn ban_vault(vault_id: T::AccountId) -> DispatchResult {
-        let height = <frame_system::Module<T>>::block_number();
+        let height = <frame_system::Pallet<T>>::block_number();
         let mut vault = Self::get_active_rich_vault_from_id(&vault_id)?;
         vault.ban_until(height + Self::punishment_delay());
         Ok(())
@@ -1255,7 +1255,7 @@ impl<T: Config> Module<T> {
         // convert into a slice. Endianness of the conversion function is arbitrary chosen
         let bytes = &raw_subject.to_be_bytes();
 
-        let rand_hash = T::RandomnessSource::random(bytes);
+        let (rand_hash, _) = T::RandomnessSource::random(bytes);
 
         let ret = rand_hash.to_low_u64_le() % (limit as u64);
         ret as usize

--- a/crates/vault-registry/src/mock.rs
+++ b/crates/vault-registry/src/mock.rs
@@ -19,20 +19,20 @@ frame_support::construct_runtime!(
         NodeBlock = Block,
         UncheckedExtrinsic = UncheckedExtrinsic,
     {
-        System: frame_system::{Module, Call, Storage, Config, Event<T>},
-        Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
+        System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
+        Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
 
         // Tokens & Balances
-        DOT: pallet_balances::<Instance1>::{Module, Call, Storage, Config<T>, Event<T>},
-        PolkaBTC: pallet_balances::<Instance2>::{Module, Call, Storage, Config<T>, Event<T>},
+        DOT: pallet_balances::<Instance1>::{Pallet, Call, Storage, Config<T>, Event<T>},
+        PolkaBTC: pallet_balances::<Instance2>::{Pallet, Call, Storage, Config<T>, Event<T>},
 
-        Collateral: collateral::{Module, Call, Storage, Event<T>},
-        Treasury: treasury::{Module, Call, Storage, Event<T>},
+        Collateral: collateral::{Pallet, Call, Storage, Event<T>},
+        Treasury: treasury::{Pallet, Call, Storage, Event<T>},
 
         // Operational
-        Security: security::{Module, Call, Storage, Event},
-        VaultRegistry: vault_registry::{Module, Call, Config<T>, Storage, Event<T>},
-        ExchangeRateOracle: exchange_rate_oracle::{Module, Call, Config<T>, Storage, Event<T>},
+        Security: security::{Pallet, Call, Storage, Event},
+        VaultRegistry: vault_registry::{Pallet, Call, Config<T>, Storage, Event<T>},
+        ExchangeRateOracle: exchange_rate_oracle::{Pallet, Call, Config<T>, Storage, Event<T>},
     }
 );
 
@@ -109,12 +109,12 @@ impl pallet_balances::Config<pallet_balances::Instance2> for Test {
 
 impl collateral::Config for Test {
     type Event = TestEvent;
-    type DOT = pallet_balances::Module<Test, pallet_balances::Instance1>;
+    type DOT = pallet_balances::Pallet<Test, pallet_balances::Instance1>;
 }
 
 impl treasury::Config for Test {
     type Event = TestEvent;
-    type PolkaBTC = pallet_balances::Module<Test, pallet_balances::Instance2>;
+    type PolkaBTC = pallet_balances::Pallet<Test, pallet_balances::Instance2>;
 }
 
 parameter_types! {

--- a/crates/vault-registry/src/types.rs
+++ b/crates/vault-registry/src/types.rs
@@ -359,7 +359,7 @@ impl<T: Config> RichVault<T> {
 
     pub fn issuable_tokens(&self) -> Result<PolkaBTC<T>, DispatchError> {
         // unable to issue additional tokens when banned
-        if self.is_banned(<frame_system::Module<T>>::block_number()) {
+        if self.is_banned(<frame_system::Pallet<T>>::block_number()) {
             return Ok(0u32.into());
         }
 
@@ -375,7 +375,7 @@ impl<T: Config> RichVault<T> {
 
     pub fn redeemable_tokens(&self) -> Result<PolkaBTC<T>, DispatchError> {
         // unable to redeem additional tokens when banned
-        if self.is_banned(<frame_system::Module<T>>::block_number()) {
+        if self.is_banned(<frame_system::Pallet<T>>::block_number()) {
             return Ok(0u32.into());
         }
 

--- a/parachain/runtime/src/lib.rs
+++ b/parachain/runtime/src/lib.rs
@@ -435,14 +435,14 @@ pub use collateral::RawEvent as CollateralEvent;
 
 impl collateral::Config for Runtime {
     type Event = Event;
-    type DOT = pallet_balances::Module<Runtime, pallet_balances::Instance1>;
+    type DOT = pallet_balances::Pallet<Runtime, pallet_balances::Instance1>;
 }
 
 pub use treasury::RawEvent as TreasuryEvent;
 
 impl treasury::Config for Runtime {
     type Event = Event;
-    type PolkaBTC = pallet_balances::Module<Runtime, pallet_balances::Instance2>;
+    type PolkaBTC = pallet_balances::Pallet<Runtime, pallet_balances::Instance2>;
 }
 
 impl security::Config for Runtime {
@@ -532,34 +532,34 @@ macro_rules! construct_polkabtc_runtime {
                 NodeBlock = opaque::Block,
                 UncheckedExtrinsic = UncheckedExtrinsic
             {
-                System: frame_system::{Module, Call, Storage, Config, Event<T>},
-                Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
-                Sudo: pallet_sudo::{Module, Call, Storage, Config<T>, Event<T>},
-                Utility: pallet_utility::{Module, Call, Event},
-                RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Module, Call, Storage},
-                TransactionPayment: pallet_transaction_payment::{Module, Storage},
+                System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
+                Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
+                Sudo: pallet_sudo::{Pallet, Call, Storage, Config<T>, Event<T>},
+                Utility: pallet_utility::{Pallet, Call, Event},
+                RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Pallet, Call, Storage},
+                TransactionPayment: pallet_transaction_payment::{Pallet, Storage},
 
                 // Tokens & Balances
-                DOT: pallet_balances::<Instance1>::{Module, Call, Storage, Config<T>, Event<T>},
-                PolkaBTC: pallet_balances::<Instance2>::{Module, Call, Storage, Config<T>, Event<T>},
+                DOT: pallet_balances::<Instance1>::{Pallet, Call, Storage, Config<T>, Event<T>},
+                PolkaBTC: pallet_balances::<Instance2>::{Pallet, Call, Storage, Config<T>, Event<T>},
 
-                Collateral: collateral::{Module, Call, Storage, Event<T>},
-                Treasury: treasury::{Module, Call, Storage, Event<T>},
+                Collateral: collateral::{Pallet, Call, Storage, Event<T>},
+                Treasury: treasury::{Pallet, Call, Storage, Event<T>},
 
                 // Bitcoin SPV
-                BTCRelay: btc_relay::{Module, Call, Config<T>, Storage, Event<T>},
+                BTCRelay: btc_relay::{Pallet, Call, Config<T>, Storage, Event<T>},
 
                 // Operational
-                Security: security::{Module, Call, Storage, Event},
-                StakedRelayers: staked_relayers::{Module, Call, Config<T>, Storage, Event<T>},
-                VaultRegistry: vault_registry::{Module, Call, Config<T>, Storage, Event<T>},
-                ExchangeRateOracle: exchange_rate_oracle::{Module, Call, Config<T>, Storage, Event<T>},
-                Issue: issue::{Module, Call, Config<T>, Storage, Event<T>},
-                Redeem: redeem::{Module, Call, Config<T>, Storage, Event<T>},
-                Replace: replace::{Module, Call, Config<T>, Storage, Event<T>},
-                Fee: fee::{Module, Call, Config<T>, Storage, Event<T>},
-                Sla: sla::{Module, Call, Config<T>, Storage, Event<T>},
-                Refund: refund::{Module, Call, Config<T>, Storage, Event<T>},
+                Security: security::{Pallet, Call, Storage, Event},
+                StakedRelayers: staked_relayers::{Pallet, Call, Config<T>, Storage, Event<T>},
+                VaultRegistry: vault_registry::{Pallet, Call, Config<T>, Storage, Event<T>},
+                ExchangeRateOracle: exchange_rate_oracle::{Pallet, Call, Config<T>, Storage, Event<T>},
+                Issue: issue::{Pallet, Call, Config<T>, Storage, Event<T>},
+                Redeem: redeem::{Pallet, Call, Config<T>, Storage, Event<T>},
+                Replace: replace::{Pallet, Call, Config<T>, Storage, Event<T>},
+                Fee: fee::{Pallet, Call, Config<T>, Storage, Event<T>},
+                Sla: sla::{Pallet, Call, Config<T>, Storage, Event<T>},
+                Refund: refund::{Pallet, Call, Config<T>, Storage, Event<T>},
 
 				$($modules)*
 			}
@@ -569,16 +569,16 @@ macro_rules! construct_polkabtc_runtime {
 
 #[cfg(feature = "cumulus-polkadot")]
 construct_polkabtc_runtime! {
-    ParachainSystem: cumulus_parachain_system::{Module, Call, Storage, Inherent, Event},
-    ParachainInfo: parachain_info::{Module, Storage, Config},
-    ParachainTokens: parachain_tokens::{Module, Storage, Call, Event<T>},
-    XcmHandler: xcm_handler::{Module, Event<T>, Origin, Call},
+    ParachainSystem: cumulus_parachain_system::{Pallet, Call, Storage, Inherent, Event},
+    ParachainInfo: parachain_info::{Pallet, Storage, Config},
+    ParachainTokens: parachain_tokens::{Pallet, Storage, Call, Event<T>},
+    XcmHandler: xcm_handler::{Pallet, Event<T>, Origin, Call},
 }
 
 #[cfg(feature = "aura-grandpa")]
 construct_polkabtc_runtime! {
-    Aura: pallet_aura::{Module, Config<T>},
-    Grandpa: pallet_grandpa::{Module, Call, Storage, Config, Event},
+    Aura: pallet_aura::{Pallet, Config<T>},
+    Grandpa: pallet_grandpa::{Pallet, Call, Storage, Config, Event},
 }
 
 /// The address format for describing accounts.
@@ -607,7 +607,7 @@ pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, Call, Signatu
 pub type CheckedExtrinsic = generic::CheckedExtrinsic<AccountId, Call, SignedExtra>;
 /// Executive: handles dispatch to the various modules.
 pub type Executive =
-    frame_executive::Executive<Runtime, Block, frame_system::ChainContext<Runtime>, Runtime, AllModules>;
+    frame_executive::Executive<Runtime, Block, frame_system::ChainContext<Runtime>, Runtime, AllPallets>;
 
 #[cfg(not(feature = "disable-runtime-api"))]
 impl_runtime_apis! {
@@ -652,7 +652,7 @@ impl_runtime_apis! {
         }
 
         fn random_seed() -> <Block as BlockT>::Hash {
-            RandomnessCollectiveFlip::random_seed()
+            RandomnessCollectiveFlip::random_seed().0
         }
     }
 
@@ -673,8 +673,8 @@ impl_runtime_apis! {
 
     #[cfg(feature = "aura-grandpa")]
     impl sp_consensus_aura::AuraApi<Block, AuraId> for Runtime {
-        fn slot_duration() -> u64 {
-            Aura::slot_duration()
+        fn slot_duration() -> sp_consensus_aura::SlotDuration {
+            sp_consensus_aura::SlotDuration::from_millis(Aura::slot_duration())
         }
 
         fn authorities() -> Vec<AuraId> {

--- a/parachain/runtime/tests/mock/mod.rs
+++ b/parachain/runtime/tests/mock/mod.rs
@@ -635,7 +635,7 @@ pub fn generate_transaction_and_mine(
 }
 
 #[allow(dead_code)]
-pub type SystemModule = frame_system::Module<Runtime>;
+pub type SystemModule = frame_system::Pallet<Runtime>;
 
 #[allow(dead_code)]
 pub type SecurityModule = security::Module<Runtime>;

--- a/parachain/service/src/cumulus.rs
+++ b/parachain/service/src/cumulus.rs
@@ -7,8 +7,7 @@ use polkadot_primitives::v0::CollatorPair;
 // use rococo_primitives::Block;
 pub use sc_executor::NativeExecutor;
 use sc_service::{Configuration, PartialComponents, Role, TaskManager};
-use sc_telemetry::TelemetrySpan;
-use sp_core::Pair;
+use sc_telemetry::{Telemetry, TelemetryWorker, TelemetryWorkerHandle};
 use sp_runtime::traits::BlakeTwo256;
 use sp_trie::PrefixedMemoryDB;
 use std::sync::Arc;
@@ -28,15 +27,35 @@ pub fn new_partial(
         (),
         sp_consensus::import_queue::BasicQueue<Block, PrefixedMemoryDB<BlakeTwo256>>,
         sc_transaction_pool::FullPool<Block, FullClient>,
-        (),
+        (Option<Telemetry>, Option<TelemetryWorkerHandle>),
     >,
     sc_service::Error,
 > {
     let inherent_data_providers = sp_inherents::InherentDataProviders::new();
 
-    let (client, backend, keystore_container, task_manager) =
-        sc_service::new_full_parts::<Block, RuntimeApi, Executor>(&config)?;
+    let telemetry = config
+        .telemetry_endpoints
+        .clone()
+        .filter(|x| !x.is_empty())
+        .map(|endpoints| -> Result<_, sc_telemetry::Error> {
+            let worker = TelemetryWorker::new(16)?;
+            let telemetry = worker.handle().new_telemetry(endpoints);
+            Ok((worker, telemetry))
+        })
+        .transpose()?;
+
+    let (client, backend, keystore_container, task_manager) = sc_service::new_full_parts::<Block, RuntimeApi, Executor>(
+        &config,
+        telemetry.as_ref().map(|(_, telemetry)| telemetry.handle()),
+    )?;
     let client = Arc::new(client);
+
+    let telemetry_worker_handle = telemetry.as_ref().map(|(worker, _)| worker.handle());
+
+    let telemetry = telemetry.map(|(worker, telemetry)| {
+        task_manager.spawn_handle().spawn("telemetry", worker.run());
+        telemetry
+    });
 
     let registry = config.prometheus_registry();
 
@@ -65,7 +84,7 @@ pub fn new_partial(
         transaction_pool,
         inherent_data_providers,
         select_chain: (),
-        other: (),
+        other: (telemetry, telemetry_worker_handle),
     };
 
     Ok(params)
@@ -88,17 +107,19 @@ async fn start_node_impl(
 
     let parachain_config = prepare_node_config(parachain_config);
 
-    let polkadot_full_node = cumulus_service::build_polkadot_full_node(polkadot_config, collator_key.public())
-        .map_err(|e| match e {
-            polkadot_service::Error::Sub(x) => x,
-            s => format!("{}", s).into(),
-        })?;
-
     let params = new_partial(&parachain_config)?;
     params
         .inherent_data_providers
         .register_provider(sp_timestamp::InherentDataProvider)
         .unwrap();
+    let (mut telemetry, telemetry_worker_handle) = params.other;
+
+    let polkadot_full_node =
+        cumulus_service::build_polkadot_full_node(polkadot_config, collator_key.clone(), telemetry_worker_handle)
+            .map_err(|e| match e {
+                polkadot_service::Error::Sub(x) => x,
+                s => format!("{}", s).into(),
+            })?;
 
     let client = params.client.clone();
     let backend = params.backend.clone();
@@ -139,9 +160,6 @@ async fn start_node_impl(
         })
     };
 
-    let telemetry_span = TelemetrySpan::new();
-    let _telemetry_span_entered = telemetry_span.enter();
-
     sc_service::spawn_tasks(sc_service::SpawnTasksParams {
         on_demand: None,
         remote_blockchain: None,
@@ -155,12 +173,12 @@ async fn start_node_impl(
         network: network.clone(),
         network_status_sinks,
         system_rpc_tx,
-        telemetry_span: Some(telemetry_span.clone()),
+        telemetry: telemetry.as_mut(),
     })?;
 
     let announce_block = {
         let network = network.clone();
-        Arc::new(move |hash, data| network.announce_block(hash, Some(data)))
+        Arc::new(move |hash, data| network.announce_block(hash, data))
     };
 
     if validator {
@@ -169,6 +187,7 @@ async fn start_node_impl(
             client.clone(),
             transaction_pool,
             prometheus_registry.as_ref(),
+            telemetry.as_ref().map(|x| x.handle()),
         );
         let spawner = task_manager.spawn_handle();
 

--- a/parachain/src/command.rs
+++ b/parachain/src/command.rs
@@ -315,7 +315,7 @@ async fn start_node(cli: Cli, config: Configuration) -> sc_service::error::Resul
     let genesis_state = format!("0x{:?}", HexDisplay::from(&block.header().encode()));
 
     let task_executor = config.task_executor.clone();
-    let polkadot_config = SubstrateCli::create_configuration(&polkadot_cli, &polkadot_cli, task_executor, None)
+    let polkadot_config = SubstrateCli::create_configuration(&polkadot_cli, &polkadot_cli, task_executor)
         .map_err(|err| format!("Relay chain argument error: {}", err))?;
     let collator = cli.run.base.validator || cli.collator;
 
@@ -389,7 +389,7 @@ impl CliConfiguration<Self> for RelayChainCli {
         self.base.base.prometheus_config(default_listen_port)
     }
 
-    fn init<C: SubstrateCli>(&self) -> Result<sc_telemetry::TelemetryWorker> {
+    fn init<C: SubstrateCli>(&self) -> Result<()> {
         unreachable!("PolkadotCli is never initialized; qed");
     }
 


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Most of the code shift is because Substrate has renamed `Module` to `Pallet`. I purposefully haven't changed our internal representations yet to reduce the overhead.