### PR TITLE
[BREAKING] fix(request_issue): make requested amount be the number of btc to be sent

### DIFF
--- a/crates/fee/src/lib.rs
+++ b/crates/fee/src/lib.rs
@@ -358,24 +358,6 @@ impl<T: Config> Module<T> {
         Self::btc_for(amount, <IssueFee<T>>::get())
     }
 
-    /// Calculate the fee portion of a total amount. For `amount = fee + issued_polkabtc`, this
-    /// function returns `fee`.
-    ///
-    /// # Arguments
-    ///
-    /// * `amount` - total amount in PolkaBTC
-    pub fn get_issue_fee_from_total(amount: PolkaBTC<T>) -> Result<PolkaBTC<T>, DispatchError> {
-        // calculate 'percentage' = x / (1+x)
-        let percentage = <IssueFee<T>>::get()
-            .checked_div(
-                &<IssueFee<T>>::get()
-                    .checked_add(&UnsignedFixedPoint::<T>::one())
-                    .ok_or(Error::<T>::ArithmeticOverflow)?,
-            )
-            .ok_or(Error::<T>::ArithmeticUnderflow)?;
-        Self::btc_for(amount, percentage)
-    }
-
     /// Calculate the required issue griefing collateral in DOT.
     ///
     /// # Arguments

--- a/crates/issue/src/ext.rs
+++ b/crates/issue/src/ext.rs
@@ -170,10 +170,6 @@ pub(crate) mod fee {
         <fee::Module<T>>::get_issue_fee(amount)
     }
 
-    pub fn get_issue_fee_from_total<T: fee::Config>(amount: PolkaBTC<T>) -> Result<PolkaBTC<T>, DispatchError> {
-        <fee::Module<T>>::get_issue_fee_from_total(amount)
-    }
-
     pub fn get_issue_griefing_collateral<T: fee::Config>(amount: DOT<T>) -> Result<DOT<T>, DispatchError> {
         <fee::Module<T>>::get_issue_griefing_collateral(amount)
     }

--- a/crates/issue/src/types.rs
+++ b/crates/issue/src/types.rs
@@ -52,11 +52,13 @@ pub struct IssueRequest<AccountId, BlockNumber, PolkaBTC, DOT> {
     #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
     #[cfg_attr(feature = "std", serde(bound(serialize = "PolkaBTC: std::fmt::Display")))]
     #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
+    /// the number of tokens that will be transfered to the user (as such, this does not include the fee)
     pub amount: PolkaBTC,
     #[cfg_attr(feature = "std", serde(bound(deserialize = "PolkaBTC: std::str::FromStr")))]
     #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
     #[cfg_attr(feature = "std", serde(bound(serialize = "PolkaBTC: std::fmt::Display")))]
     #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
+    /// the number of tokens that will be tranferred to the fee pool
     pub fee: PolkaBTC,
     pub requester: AccountId,
     pub btc_address: BtcAddress,

--- a/parachain/runtime/tests/test_fee_pool.rs
+++ b/parachain/runtime/tests/test_fee_pool.rs
@@ -114,9 +114,7 @@ fn set_issued_and_backing(vault: [u8; 32], amount_issued: u128, backing: u128) {
     SystemModule::set_block_number(1);
 
     // we want issued to be 100 times amount_issued, _including fees_
-    let amount_issued = 100 * amount_issued;
-    let fee = FeeModule::get_issue_fee_from_total(amount_issued).unwrap();
-    let request_amount = amount_issued - fee;
+    let request_amount = 100 * amount_issued;
 
     let (issue_id, _) = RequestIssueBuilder::new(request_amount).with_vault(vault).request();
     ExecuteIssueBuilder::new(issue_id)


### PR DESCRIPTION
This changes request_issue such that the requested amount is equal to the amount of btc the user has to send. Note that this does mean that they will receive fewer PolkaBTC than they requested.

Changes are required in the UI. The testdata-gen tool needs to be updated as well, although it is not urgent - as far as I can see the current version has been broken for a long time, as it does not pay the fee