### PR TITLE
[BREAKING] fix(request_issue): make requested amount be the number of btc to be sent

### DIFF
--- a/crates/fee/src/lib.rs
+++ b/crates/fee/src/lib.rs
@@ -358,24 +358,6 @@ impl<T: Config> Module<T> {
         Self::btc_for(amount, <IssueFee<T>>::get())
     }
 
-    /// Calculate the fee portion of a total amount. For `amount = fee + issued_polkabtc`, this
-    /// function returns `fee`.
-    ///
-    /// # Arguments
-    ///
-    /// * `amount` - total amount in PolkaBTC
-    pub fn get_issue_fee_from_total(amount: PolkaBTC<T>) -> Result<PolkaBTC<T>, DispatchError> {
-        // calculate 'percentage' = x / (1+x)
-        let percentage = <IssueFee<T>>::get()
-            .checked_div(
-                &<IssueFee<T>>::get()
-                    .checked_add(&UnsignedFixedPoint::<T>::one())
-                    .ok_or(Error::<T>::ArithmeticOverflow)?,
-            )
-            .ok_or(Error::<T>::ArithmeticUnderflow)?;
-        Self::btc_for(amount, percentage)
-    }
-
     /// Calculate the required issue griefing collateral in DOT.
     ///
     /// # Arguments

--- a/crates/issue/src/benchmarking.rs
+++ b/crates/issue/src/benchmarking.rs
@@ -51,7 +51,7 @@ benchmarks! {
         issue_request.vault = vault_id.clone();
         issue_request.btc_address = vault_btc_address;
         issue_request.amount = value.into();
-        Issue::<T>::insert_issue_request(issue_id, issue_request);
+        Issue::<T>::insert_issue_request(&issue_id, &issue_request);
 
         let height = 0;
         let block = BlockBuilder::new()
@@ -119,7 +119,7 @@ benchmarks! {
         let mut issue_request = IssueRequest::default();
         issue_request.requester = origin.clone();
         issue_request.vault = vault_id.clone();
-        Issue::<T>::insert_issue_request(issue_id, issue_request);
+        Issue::<T>::insert_issue_request(&issue_id, &issue_request);
         System::<T>::set_block_number(System::<T>::block_number() + Issue::<T>::issue_period() + 10u32.into());
 
         let mut vault = Vault::default();

--- a/crates/issue/src/ext.rs
+++ b/crates/issue/src/ext.rs
@@ -170,10 +170,6 @@ pub(crate) mod fee {
         <fee::Module<T>>::get_issue_fee(amount)
     }
 
-    pub fn get_issue_fee_from_total<T: fee::Config>(amount: PolkaBTC<T>) -> Result<PolkaBTC<T>, DispatchError> {
-        <fee::Module<T>>::get_issue_fee_from_total(amount)
-    }
-
     pub fn get_issue_griefing_collateral<T: fee::Config>(amount: DOT<T>) -> Result<DOT<T>, DispatchError> {
         <fee::Module<T>>::get_issue_griefing_collateral(amount)
     }

--- a/crates/issue/src/lib.rs
+++ b/crates/issue/src/lib.rs
@@ -271,10 +271,10 @@ impl<T: Config> Module<T> {
 
         ext::vault_registry::try_increase_to_be_issued_tokens::<T>(&vault_id, amount_requested)?;
 
-        let fee_polkabtc = ext::fee::get_issue_fee::<T>(amount_requested)?;
+        let fee = ext::fee::get_issue_fee::<T>(amount_requested)?;
         // calculate the amount of polkabtc that will be transferred to the user upon execution
-        let user_polkabtc = amount_requested
-            .checked_sub(&fee_polkabtc)
+        let amount_user = amount_requested
+            .checked_sub(&fee)
             .ok_or(Error::<T>::ArithmeticUnderflow)?;
 
         let issue_id = ext::security::get_secure_id::<T>(&requester);
@@ -286,8 +286,8 @@ impl<T: Config> Module<T> {
             requester: requester,
             btc_address: btc_address,
             btc_public_key: vault.wallet.public_key,
-            amount: user_polkabtc,
-            fee: fee_polkabtc,
+            amount: amount_user,
+            fee: fee,
             griefing_collateral,
             status: IssueRequestStatus::Pending,
         };

--- a/crates/issue/src/tests.rs
+++ b/crates/issue/src/tests.rs
@@ -105,9 +105,8 @@ fn test_request_issue_succeeds() {
         let origin = ALICE;
         let vault = BOB;
         let amount: Balance = 3;
-        let issue_fee = 5;
+        let issue_fee = 1;
         let issue_griefing_collateral = 20;
-        let total_amount = amount + issue_fee;
 
         ext::vault_registry::get_active_vault_from_id::<Test>
             .mock_safe(|_| MockResult::Return(Ok(init_zero_vault::<Test>(BOB))));
@@ -122,7 +121,7 @@ fn test_request_issue_succeeds() {
         let request_issue_event = TestEvent::issue(RawEvent::RequestIssue(
             issue_id,
             origin,
-            total_amount,
+            amount - issue_fee,
             issue_fee,
             issue_griefing_collateral,
             vault,

--- a/crates/issue/src/types.rs
+++ b/crates/issue/src/types.rs
@@ -52,11 +52,13 @@ pub struct IssueRequest<AccountId, BlockNumber, PolkaBTC, DOT> {
     #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
     #[cfg_attr(feature = "std", serde(bound(serialize = "PolkaBTC: std::fmt::Display")))]
     #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
+    /// the number of tokens that will be transfered to the user (as such, this does not include the fee)
     pub amount: PolkaBTC,
     #[cfg_attr(feature = "std", serde(bound(deserialize = "PolkaBTC: std::str::FromStr")))]
     #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
     #[cfg_attr(feature = "std", serde(bound(serialize = "PolkaBTC: std::fmt::Display")))]
     #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
+    /// the number of tokens that will be tranferred to the fee pool
     pub fee: PolkaBTC,
     pub requester: AccountId,
     pub btc_address: BtcAddress,

--- a/parachain/runtime/tests/test_fee_pool.rs
+++ b/parachain/runtime/tests/test_fee_pool.rs
@@ -114,9 +114,7 @@ fn set_issued_and_backing(vault: [u8; 32], amount_issued: u128, backing: u128) {
     SystemModule::set_block_number(1);
 
     // we want issued to be 100 times amount_issued, _including fees_
-    let amount_issued = 100 * amount_issued;
-    let fee = FeeModule::get_issue_fee_from_total(amount_issued).unwrap();
-    let request_amount = amount_issued - fee;
+    let request_amount = 100 * amount_issued;
 
     let (issue_id, _) = RequestIssueBuilder::new(request_amount).with_vault(vault).request();
     ExecuteIssueBuilder::new(issue_id)

--- a/parachain/runtime/tests/test_vault_sla.rs
+++ b/parachain/runtime/tests/test_vault_sla.rs
@@ -35,7 +35,7 @@ fn test_sla_increase_for_issue() {
 
         // check the sla increase for processing the issue
         let expected_sla_increase = SlaModule::vault_executed_issue_max_sla_change()
-            * FixedI128::checked_from_rational(1000, issue.amount + issue.fee).unwrap();
+            * FixedI128::checked_from_rational(issue.amount, issue.amount + issue.fee).unwrap();
         assert_eq!(
             SlaModule::vault_sla(account_of(VAULT)),
             initial_sla() + expected_sla_increase
@@ -68,7 +68,7 @@ fn test_sla_increase_for_submitting_proof_for_issue_against_self() {
             .assert_execute();
 
         let expected_sla_increase_for_issue = SlaModule::vault_executed_issue_max_sla_change()
-            * FixedI128::checked_from_rational(1000, issue.amount + issue.fee).unwrap();
+            * FixedI128::checked_from_rational(issue.amount, issue.amount + issue.fee).unwrap();
         let expected_sla_increase_for_proof_submission = SlaModule::vault_submitted_issue_proof();
 
         // check that the vault who submitted the proof is rewarded with both SLA rewards
@@ -99,7 +99,7 @@ fn test_sla_increase_for_refund() {
             .assert_execute();
 
         let expected_sla_increase_for_issue = SlaModule::vault_executed_issue_max_sla_change()
-            * FixedI128::checked_from_rational(1000, issue.amount + issue.fee).unwrap();
+            * FixedI128::checked_from_rational(issue.amount, issue.amount + issue.fee).unwrap();
 
         // check that the vault who submitted the proof is rewarded for issue
         assert_eq!(
@@ -164,7 +164,7 @@ fn test_sla_increase_for_underpayed_issue() {
 
         // check the sla increase
         let expected_sla_increase = SlaModule::vault_executed_issue_max_sla_change()
-            * FixedI128::checked_from_rational(4000, issue.amount + issue.fee).unwrap();
+            * FixedI128::checked_from_rational(issue.amount, issue.amount + issue.fee).unwrap();
         assert_eq!(
             SlaModule::vault_sla(account_of(VAULT)),
             initial_sla() + expected_sla_increase


### PR DESCRIPTION
This changes request_issue such that the requested amount is equal to the amount of btc the user has to send. Note that this does mean that they will receive fewer PolkaBTC than they requested.

Changes are required in the UI. The testdata-gen tool needs to be updated as well, although it is not urgent - as far as I can see the current version has been broken for a long time, as it does not pay the fee