### PR TITLE
[BREAKING] feat!: allow vaults to opt-out of new issues

### DIFF
--- a/crates/issue/src/lib.rs
+++ b/crates/issue/src/lib.rs
@@ -41,7 +41,7 @@ use frame_system::{ensure_root, ensure_signed};
 use primitive_types::H256;
 use sp_runtime::{traits::*, ModuleId};
 use sp_std::{convert::TryInto, vec::Vec};
-use vault_registry::CurrencySource;
+use vault_registry::{CurrencySource, VaultStatus};
 
 /// The issue module id, used for deriving its sovereign account ID.
 const _MODULE_ID: ModuleId = ModuleId(*b"issuemod");
@@ -256,6 +256,13 @@ impl<T: Config> Module<T> {
 
         let height = <frame_system::Pallet<T>>::block_number();
         let vault = ext::vault_registry::get_active_vault_from_id::<T>(&vault_id)?;
+
+        // ensure that the vault is accepting new issues
+        ensure!(
+            vault.status == VaultStatus::Active(true),
+            Error::<T>::VaultNotAcceptingNewIssues
+        );
+
         // Check that the vault is currently not banned
         ext::vault_registry::ensure_not_banned::<T>(&vault_id, height)?;
 
@@ -560,6 +567,7 @@ decl_error! {
         TimeNotExpired,
         IssueCompleted,
         IssueCancelled,
+        VaultNotAcceptingNewIssues,
         /// Unable to convert value
         TryIntoIntError,
         ArithmeticUnderflow,

--- a/crates/issue/src/tests.rs
+++ b/crates/issue/src/tests.rs
@@ -81,7 +81,7 @@ fn test_request_issue_banned_fails() {
                 backing_collateral: 0,
                 wallet: Wallet::new(BtcPublicKey::default()),
                 banned_until: Some(1),
-                status: VaultStatus::Active,
+                status: VaultStatus::Active(true),
             },
         );
         assert_noop!(request_issue(ALICE, 3, BOB, 0), VaultRegistryError::VaultBanned);

--- a/crates/redeem/src/tests.rs
+++ b/crates/redeem/src/tests.rs
@@ -78,7 +78,7 @@ fn test_request_redeem_fails_with_amount_below_minimum() {
                 backing_collateral: 0,
                 wallet: Wallet::new(dummy_public_key()),
                 banned_until: None,
-                status: VaultStatus::Active,
+                status: VaultStatus::Active(true),
             },
         );
 
@@ -149,7 +149,7 @@ fn test_request_redeem_succeeds_with_normal_redeem() {
                 backing_collateral: 0,
                 wallet: Wallet::new(dummy_public_key()),
                 banned_until: None,
-                status: VaultStatus::Active,
+                status: VaultStatus::Active(true),
             },
         );
 
@@ -267,7 +267,7 @@ fn test_execute_redeem_succeeds_with_another_account() {
                 replace_collateral: 0,
                 wallet: Wallet::new(dummy_public_key()),
                 banned_until: None,
-                status: VaultStatus::Active,
+                status: VaultStatus::Active(true),
             },
         );
         ext::btc_relay::verify_transaction_inclusion::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
@@ -366,7 +366,7 @@ fn test_execute_redeem_succeeds() {
                 replace_collateral: 0,
                 wallet: Wallet::new(dummy_public_key()),
                 banned_until: None,
-                status: VaultStatus::Active,
+                status: VaultStatus::Active(true),
             },
         );
         ext::btc_relay::verify_transaction_inclusion::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
@@ -504,7 +504,7 @@ fn test_cancel_redeem_succeeds() {
         ext::vault_registry::slash_collateral_saturated::<Test>.mock_safe(move |_, _, _| MockResult::Return(Ok(0)));
         ext::vault_registry::get_vault_from_id::<Test>.mock_safe(|_| {
             MockResult::Return(Ok(vault_registry::types::Vault {
-                status: VaultStatus::Active,
+                status: VaultStatus::Active(true),
                 ..Default::default()
             }))
         });

--- a/crates/staked-relayers/src/tests.rs
+++ b/crates/staked-relayers/src/tests.rs
@@ -1008,7 +1008,7 @@ fn test_is_transaction_invalid_fails_with_valid_merge_transaction() {
                 backing_collateral: 0,
                 wallet: wallet.clone(),
                 banned_until: None,
-                status: VaultStatus::Active,
+                status: VaultStatus::Active(true),
             }))
         });
 
@@ -1066,7 +1066,7 @@ fn test_is_transaction_invalid_fails_with_valid_request_or_redeem() {
                 backing_collateral: 0,
                 wallet: wallet.clone(),
                 banned_until: None,
-                status: VaultStatus::Active,
+                status: VaultStatus::Active(true),
             }))
         });
 
@@ -1220,7 +1220,7 @@ fn test_is_transaction_invalid_fails_with_valid_merge_testnet_transaction() {
                 backing_collateral: 0,
                 wallet: wallet.clone(),
                 banned_until: None,
-                status: VaultStatus::Active,
+                status: VaultStatus::Active(true),
             }))
         });
 

--- a/crates/vault-registry/src/default_weights.rs
+++ b/crates/vault-registry/src/default_weights.rs
@@ -31,4 +31,9 @@ impl crate::WeightInfo for () {
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
+    fn accept_new_issues() -> Weight {
+        (48_000_000 as Weight)
+            .saturating_add(DbWeight::get().reads(1 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
+    }
 }

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -295,7 +295,7 @@ decl_module! {
             Ok(())
         }
 
-        /// Configures whether or not the vaul accepts new issues.
+        /// Configures whether or not the vault accepts new issues.
         ///
         /// # Arguments
         ///
@@ -308,8 +308,7 @@ decl_module! {
         fn accept_new_issues(origin, accept_new_issues: bool) -> DispatchResult  {
             let vault_id = ensure_signed(origin)?;
             let mut vault = Self::get_active_rich_vault_from_id(&vault_id)?;
-            vault.set_accept_new_issues(accept_new_issues)?;
-            Ok(())
+            vault.set_accept_new_issues(accept_new_issues)
         }
 
         fn on_initialize(n: T::BlockNumber) -> Weight {

--- a/crates/vault-registry/src/types.rs
+++ b/crates/vault-registry/src/types.rs
@@ -23,10 +23,8 @@ pub enum Version {
     V0,
     /// BtcAddress type with script format.
     V1,
-    /// added replace_collateral to vault
+    /// added replace_collateral to vault, changed vaultStatus enum
     V2,
-    /// changed vaultStatus enum
-    V3,
 }
 
 #[derive(Debug, PartialEq)]
@@ -150,7 +148,7 @@ pub struct Vault<AccountId, BlockNumber, PolkaBTC, DOT> {
 }
 
 #[derive(Encode, Decode, Clone, Copy, PartialEq, Eq, Debug)]
-pub enum VaultStatusV2 {
+pub enum VaultStatusV1 {
     /// Vault is active
     Active = 0,
 
@@ -161,17 +159,20 @@ pub enum VaultStatusV2 {
     CommittedTheft = 2,
 }
 
-impl Default for VaultStatusV2 {
+impl Default for VaultStatusV1 {
     fn default() -> Self {
-        VaultStatusV2::Active
+        VaultStatusV1::Active
     }
 }
 
 #[derive(Encode, Decode, Default, Clone, PartialEq)]
 #[cfg_attr(feature = "std", derive(Debug))]
-pub struct VaultV2<AccountId, BlockNumber, PolkaBTC, DOT> {
+pub struct VaultV1<AccountId, BlockNumber, PolkaBTC, DOT> {
     // Account identifier of the Vault
     pub id: AccountId,
+    // number of PolkaBTC tokens that have been requested for a replace through
+    // `request_replace`, but that have not been accepted yet by a new_vault.
+    pub to_be_replaced_tokens: PolkaBTC,
     // Number of PolkaBTC tokens pending issue
     pub to_be_issued_tokens: PolkaBTC,
     // Number of issued PolkaBTC tokens
@@ -183,17 +184,11 @@ pub struct VaultV2<AccountId, BlockNumber, PolkaBTC, DOT> {
     // amount of DOT collateral that is locked to back PolkaBTC tokens. Note that
     // this excludes griefing collateral.
     pub backing_collateral: DOT,
-    // number of PolkaBTC tokens that have been requested for a replace through
-    // `request_replace`, but that have not been accepted yet by a new_vault.
-    pub to_be_replaced_tokens: PolkaBTC,
-    /// Amount of DOT that is locked as griefing collateral to be payed out if
-    /// the old_vault fails to call execute_replace
-    pub replace_collateral: DOT,
     // Block height until which this Vault is banned from being
     // used for Issue, Redeem (except during automatic liquidation) and Replace .
     pub banned_until: Option<BlockNumber>,
     /// Current status of the vault
-    pub status: VaultStatusV2,
+    pub status: VaultStatusV1,
 }
 
 #[derive(Encode, Decode, Default, Clone, PartialEq)]

--- a/parachain/runtime/tests/test_replace.rs
+++ b/parachain/runtime/tests/test_replace.rs
@@ -166,6 +166,18 @@ mod accept_replace_tests {
     }
 
     #[test]
+    fn integration_test_replace_accept_replace_by_vault_that_does_not_accept_issues_succeeds() {
+        test_with(|| {
+            assert_ok!(Call::VaultRegistry(VaultRegistryCall::accept_new_issues(false))
+                .dispatch(origin_of(account_of(NEW_VAULT))));
+
+            let (_, replace) = accept_replace(1000, 1000);
+
+            assert_state_after_accept_replace_correct(&replace);
+        });
+    }
+
+    #[test]
     fn integration_test_replace_accept_replace_below_dust_fails() {
         test_with(|| {
             // if the new_vault _asks_ for an amount below below DUST, it gets rejected


### PR DESCRIPTION
The breaking change here is the VaultStatus enum inside vault structs. The `Active` status is now `Active(bool)`, where `bool=true` indicates that the vault accepts new issues. This approach was taken of splitting it into two separate variants (e.g. `Active` and `Exiting`), because usually when we read the `status`, we don't need to differentiate between the two. The `get_active_vault` function that we use extensively would have to be turned into `get_active_or_exiting_vault` otherwise, which is just.. ugly. Not to mention that `exiting` is not 100% accurate.

Also note that unlike what Dom asked for, I did not include `BannedUntil` in the status enum. This is because of two reasons: first, after a temporary ban, you would be unable to return to the previous state, since we wouldn't remember whether or not we accepted new issues right before the ban. The second reason is that we would have no easy way to change the status after the ban is over. We could perhaps do it within the `get_active_vault` function, but then it'd only be updated after a dispatchable function is called on that vault. If the clients or UI read the struct directly, they would get a wrong status.

Finally, note (and please check) that I added checks to filter out vaults that do not accept new issues in the relevant rpc functions. I chose to do it here, rather than inside a deeper function like `get_issuable_tokens`, since otherwise also `accept_replace` and `auction_replace` wouldn't work, and I saw no reason to prevent the vaults from doing that.