### PR TITLE
[BREAKING] Fix: request expiry

### DIFF
--- a/crates/btc-relay/src/benchmarking.rs
+++ b/crates/btc-relay/src/benchmarking.rs
@@ -8,7 +8,8 @@ use bitcoin::{
     },
 };
 use frame_benchmarking::{account, benchmarks};
-use frame_system::{Pallet as System, RawOrigin};
+use frame_system::RawOrigin;
+use security::Module as Security;
 use sp_core::{H256, U256};
 use sp_std::prelude::*;
 
@@ -88,7 +89,7 @@ benchmarks! {
         let proof = block.merkle_proof(&vec![tx_id]).unwrap().try_format().unwrap();
         let raw_tx = transaction.format_with(true);
 
-        System::<T>::set_block_number(100u32.into());
+        Security::<T>::set_active_block_number(100u32.into());
 
     }: _(RawOrigin::Signed(origin), tx_id, proof, Some(0), raw_tx, value.into(), address, Some(op_return))
 
@@ -108,7 +109,7 @@ benchmarks! {
         let tx_block_height = height;
         let proof = block.merkle_proof(&vec![tx_id]).unwrap().try_format().unwrap();
 
-        System::<T>::set_block_number(100u32.into());
+        Security::<T>::set_active_block_number(100u32.into());
 
     }: _(RawOrigin::Signed(origin), tx_id, proof, Some(0))
 

--- a/crates/btc-relay/src/ext.rs
+++ b/crates/btc-relay/src/ext.rs
@@ -41,4 +41,8 @@ pub(crate) mod security {
     pub fn insert_error<T: security::Config>(error: ErrorCode) -> () {
         <security::Module<T>>::insert_error(error)
     }
+
+    pub fn active_block_number<T: security::Config>() -> T::BlockNumber {
+        <security::Module<T>>::active_block_number()
+    }
 }

--- a/crates/btc-relay/src/lib.rs
+++ b/crates/btc-relay/src/lib.rs
@@ -309,7 +309,7 @@ impl<T: Config> Module<T> {
         let block_header_hash = raw_block_header.hash();
 
         // register the current height to track stable parachain confirmations
-        let para_height = <frame_system::Pallet<T>>::block_number();
+        let para_height = ext::security::active_block_number::<T>();
 
         // construct the BlockChain struct
         let blockchain = Self::initialize_blockchain(block_height, block_header_hash);
@@ -394,7 +394,7 @@ impl<T: Config> Module<T> {
         };
 
         // register the current height to track stable parachain confirmations
-        let para_height = <frame_system::Pallet<T>>::block_number();
+        let para_height = ext::security::active_block_number::<T>();
 
         // Create rich block header
         let block_header = RichBlockHeader::<T::AccountId, T::BlockNumber> {
@@ -1370,7 +1370,7 @@ impl<T: Config> Module<T> {
     /// # Arguments
     /// * `para_height` - height of the parachain when the block was stored
     pub fn check_parachain_confirmations(para_height: T::BlockNumber) -> Result<(), DispatchError> {
-        let current_height = <frame_system::Pallet<T>>::block_number();
+        let current_height = ext::security::active_block_number::<T>();
 
         ensure!(
             para_height + Self::parachain_confirmations() <= current_height,

--- a/crates/btc-relay/src/mock.rs
+++ b/crates/btc-relay/src/mock.rs
@@ -191,6 +191,7 @@ where
     clear_mocks();
     ExtBuilder::build().execute_with(|| {
         System::set_block_number(1);
+        Security::set_active_block_number(1);
         test();
     });
 }

--- a/crates/btc-relay/src/tests.rs
+++ b/crates/btc-relay/src/tests.rs
@@ -1512,7 +1512,7 @@ fn test_check_bitcoin_confirmations_secure_insufficient_stable_confs_succeeds() 
 #[test]
 fn test_check_parachain_confirmations_succeeds() {
     run_test(|| {
-        System::set_block_number(5 + PARACHAIN_CONFIRMATIONS);
+        Security::set_active_block_number(5 + PARACHAIN_CONFIRMATIONS);
         assert_ok!(BTCRelay::check_parachain_confirmations(0));
     });
 }
@@ -1520,7 +1520,7 @@ fn test_check_parachain_confirmations_succeeds() {
 #[test]
 fn test_check_parachain_confirmations_insufficient_confs_fails() {
     run_test(|| {
-        System::set_block_number(0);
+        Security::set_active_block_number(0);
         assert_err!(
             BTCRelay::check_parachain_confirmations(0),
             TestError::ParachainConfirmations

--- a/crates/exchange-rate-oracle/src/mock.rs
+++ b/crates/exchange-rate-oracle/src/mock.rs
@@ -137,6 +137,7 @@ where
 {
     clear_mocks();
     ExtBuilder::build().execute_with(|| {
+        Security::set_active_block_number(1);
         System::set_block_number(1);
         test();
     });

--- a/crates/fee/src/mock.rs
+++ b/crates/fee/src/mock.rs
@@ -180,6 +180,7 @@ where
     clear_mocks();
     ExtBuilder::build().execute_with(|| {
         System::set_block_number(1);
+        Security::set_active_block_number(1);
         test();
     });
 }

--- a/crates/issue/src/benchmarking.rs
+++ b/crates/issue/src/benchmarking.rs
@@ -7,7 +7,7 @@ use bitcoin::{
 use btc_relay::{BtcAddress, BtcPublicKey, Module as BtcRelay};
 use exchange_rate_oracle::Module as ExchangeRateOracle;
 use frame_benchmarking::{account, benchmarks};
-use frame_system::{Pallet as System, RawOrigin};
+use frame_system::RawOrigin;
 use security::Module as Security;
 use sp_core::{H160, H256, U256};
 use sp_runtime::FixedPointNumber;
@@ -120,7 +120,7 @@ benchmarks! {
         issue_request.requester = origin.clone();
         issue_request.vault = vault_id.clone();
         Issue::<T>::insert_issue_request(&issue_id, &issue_request);
-        System::<T>::set_block_number(Security::active_block_number() + Issue::<T>::issue_period() + 10u32.into());
+        Security::<T>::set_active_block_number(Security::<T>::active_block_number() + Issue::<T>::issue_period() + 10u32.into());
 
         let mut vault = Vault::default();
         vault.id = vault_id.clone();

--- a/crates/issue/src/benchmarking.rs
+++ b/crates/issue/src/benchmarking.rs
@@ -120,7 +120,7 @@ benchmarks! {
         issue_request.requester = origin.clone();
         issue_request.vault = vault_id.clone();
         Issue::<T>::insert_issue_request(&issue_id, &issue_request);
-        System::<T>::set_block_number(System::<T>::block_number() + Issue::<T>::issue_period() + 10u32.into());
+        System::<T>::set_block_number(Security::active_block_number() + Issue::<T>::issue_period() + 10u32.into());
 
         let mut vault = Vault::default();
         vault.id = vault_id.clone();

--- a/crates/issue/src/ext.rs
+++ b/crates/issue/src/ext.rs
@@ -69,11 +69,8 @@ pub(crate) mod vault_registry {
         <vault_registry::Module<T>>::issue_tokens(vault_id, amount)
     }
 
-    pub fn ensure_not_banned<T: vault_registry::Config>(
-        vault: &T::AccountId,
-        height: T::BlockNumber,
-    ) -> DispatchResult {
-        <vault_registry::Module<T>>::_ensure_not_banned(vault, height)
+    pub fn ensure_not_banned<T: vault_registry::Config>(vault: &T::AccountId) -> DispatchResult {
+        <vault_registry::Module<T>>::_ensure_not_banned(vault)
     }
 
     pub fn decrease_to_be_issued_tokens<T: vault_registry::Config>(

--- a/crates/issue/src/ext.rs
+++ b/crates/issue/src/ext.rs
@@ -117,9 +117,8 @@ pub(crate) mod treasury {
 
 #[cfg_attr(test, mockable)]
 pub(crate) mod security {
-    use frame_support::dispatch::DispatchResult;
+    use frame_support::dispatch::{DispatchError, DispatchResult};
     use primitive_types::H256;
-    use security::ActiveBlockNumber;
 
     pub fn get_secure_id<T: security::Config>(id: &T::AccountId) -> H256 {
         <security::Module<T>>::get_secure_id(id)
@@ -129,15 +128,15 @@ pub(crate) mod security {
         <security::Module<T>>::ensure_parachain_status_running()
     }
 
-    pub fn active_block_number<T: security::Config>() -> ActiveBlockNumber<T::BlockNumber> {
+    pub fn active_block_number<T: security::Config>() -> T::BlockNumber {
         <security::Module<T>>::active_block_number()
     }
 
     pub fn has_expired<T: security::Config>(
-        open_time: &ActiveBlockNumber<T::BlockNumber>,
+        opentime: T::BlockNumber,
         period: T::BlockNumber,
-    ) -> bool {
-        <security::Module<T>>::has_expired(open_time, period)
+    ) -> Result<bool, DispatchError> {
+        <security::Module<T>>::has_expired(opentime, period)
     }
 }
 

--- a/crates/issue/src/ext.rs
+++ b/crates/issue/src/ext.rs
@@ -119,6 +119,7 @@ pub(crate) mod treasury {
 pub(crate) mod security {
     use frame_support::dispatch::DispatchResult;
     use primitive_types::H256;
+    use security::ActiveBlockNumber;
 
     pub fn get_secure_id<T: security::Config>(id: &T::AccountId) -> H256 {
         <security::Module<T>>::get_secure_id(id)
@@ -126,6 +127,17 @@ pub(crate) mod security {
 
     pub fn ensure_parachain_status_running<T: security::Config>() -> DispatchResult {
         <security::Module<T>>::ensure_parachain_status_running()
+    }
+
+    pub fn active_block_number<T: security::Config>() -> ActiveBlockNumber<T::BlockNumber> {
+        <security::Module<T>>::active_block_number()
+    }
+
+    pub fn has_expired<T: security::Config>(
+        open_time: &ActiveBlockNumber<T::BlockNumber>,
+        period: T::BlockNumber,
+    ) -> bool {
+        <security::Module<T>>::has_expired(open_time, period)
     }
 }
 
@@ -181,11 +193,10 @@ pub(crate) mod fee {
 
 #[cfg_attr(test, mockable)]
 pub(crate) mod refund {
-    use crate::{types::PolkaBTC, Vec};
+    use crate::types::PolkaBTC;
     use btc_relay::BtcAddress;
     use frame_support::dispatch::DispatchError;
     use primitive_types::H256;
-    use refund::types::RefundRequest;
 
     pub fn request_refund<T: refund::Config>(
         total_amount_btc: PolkaBTC<T>,
@@ -195,11 +206,5 @@ pub(crate) mod refund {
         issue_id: H256,
     ) -> Result<Option<H256>, DispatchError> {
         <refund::Module<T>>::request_refund(total_amount_btc, vault_id, issuer, btc_address, issue_id)
-    }
-
-    pub fn get_refund_requests_for_account<T: refund::Config>(
-        account_id: T::AccountId,
-    ) -> Vec<(H256, RefundRequest<T::AccountId, PolkaBTC<T>>)> {
-        <refund::Module<T>>::get_refund_requests_for_account(account_id)
     }
 }

--- a/crates/issue/src/ext.rs
+++ b/crates/issue/src/ext.rs
@@ -23,6 +23,10 @@ pub(crate) mod btc_relay {
     ) -> Result<(BtcAddress, i64), DispatchError> {
         <btc_relay::Module<T>>::_validate_transaction(raw_tx, minimum_btc, btc_address, issue_id)
     }
+
+    pub fn get_best_block_height<T: btc_relay::Config>() -> u32 {
+        <btc_relay::Module<T>>::get_best_block_height()
+    }
 }
 
 #[cfg_attr(test, mockable)]

--- a/crates/issue/src/lib.rs
+++ b/crates/issue/src/lib.rs
@@ -136,6 +136,7 @@ decl_module! {
                         let new_request = IssueRequest {
                             vault: old_request.vault,
                             opentime: ActiveBlockNumber(old_request.opentime),
+                            period: Self::issue_period(),
                             griefing_collateral: old_request.griefing_collateral,
                             amount: old_request.amount,
                             fee: old_request.fee,
@@ -274,6 +275,7 @@ impl<T: Config> Module<T> {
             amount: amount_user,
             fee,
             griefing_collateral,
+            period: Self::issue_period(),
             status: IssueRequestStatus::Pending,
         };
         Self::insert_issue_request(&issue_id, &request);
@@ -309,7 +311,7 @@ impl<T: Config> Module<T> {
 
         // only executable before the request has expired
         ensure!(
-            !ext::security::has_expired::<T>(&issue.opentime, Self::issue_period()),
+            !ext::security::has_expired::<T>(&issue.opentime, Self::issue_period().max(issue.period)),
             Error::<T>::CommitPeriodExpired
         );
 
@@ -427,7 +429,7 @@ impl<T: Config> Module<T> {
 
         // only cancellable after the request has expired
         ensure!(
-            ext::security::has_expired::<T>(&issue.opentime, Self::issue_period()),
+            ext::security::has_expired::<T>(&issue.opentime, Self::issue_period().max(issue.period)),
             Error::<T>::TimeNotExpired
         );
 

--- a/crates/issue/src/lib.rs
+++ b/crates/issue/src/lib.rs
@@ -239,7 +239,6 @@ impl<T: Config> Module<T> {
         // Check that Parachain is RUNNING
         ext::security::ensure_parachain_status_running::<T>()?;
 
-        let height = ext::security::active_block_number::<T>();
         let vault = ext::vault_registry::get_active_vault_from_id::<T>(&vault_id)?;
         // Check that the vault is currently not banned
         ext::vault_registry::ensure_not_banned::<T>(&vault_id)?;

--- a/crates/issue/src/lib.rs
+++ b/crates/issue/src/lib.rs
@@ -142,6 +142,7 @@ decl_module! {
                             requester: old_request.requester,
                             btc_address: old_request.btc_address,
                             btc_public_key: old_request.btc_public_key,
+                            open_bitcoin_height: 1969929, // extra conservative, testnet height at april 4th
                             status: old_request.status,
                         };
                         <IssueRequests<T>>::insert(id, new_request);
@@ -274,6 +275,7 @@ impl<T: Config> Module<T> {
             fee,
             griefing_collateral,
             period: Self::issue_period(),
+            open_bitcoin_height: ext::btc_relay::get_best_block_height::<T>(),
             status: IssueRequestStatus::Pending,
         };
         Self::insert_issue_request(&issue_id, &request);

--- a/crates/issue/src/lib.rs
+++ b/crates/issue/src/lib.rs
@@ -39,7 +39,6 @@ use frame_support::{
 };
 use frame_system::{ensure_root, ensure_signed};
 use primitive_types::H256;
-use security::ActiveBlockNumber;
 use sp_runtime::{traits::*, ModuleId};
 use sp_std::{convert::TryInto, vec::Vec};
 use vault_registry::CurrencySource;
@@ -135,7 +134,7 @@ decl_module! {
                     .for_each(|(id, old_request)| {
                         let new_request = IssueRequest {
                             vault: old_request.vault,
-                            opentime: ActiveBlockNumber(old_request.opentime),
+                            opentime: old_request.opentime,
                             period: Self::issue_period(),
                             griefing_collateral: old_request.griefing_collateral,
                             amount: old_request.amount,
@@ -311,7 +310,7 @@ impl<T: Config> Module<T> {
 
         // only executable before the request has expired
         ensure!(
-            !ext::security::has_expired::<T>(&issue.opentime, Self::issue_period().max(issue.period)),
+            !ext::security::has_expired::<T>(issue.opentime, Self::issue_period().max(issue.period))?,
             Error::<T>::CommitPeriodExpired
         );
 
@@ -429,7 +428,7 @@ impl<T: Config> Module<T> {
 
         // only cancellable after the request has expired
         ensure!(
-            ext::security::has_expired::<T>(&issue.opentime, Self::issue_period().max(issue.period)),
+            ext::security::has_expired::<T>(issue.opentime, Self::issue_period().max(issue.period))?,
             Error::<T>::TimeNotExpired
         );
 

--- a/crates/issue/src/lib.rs
+++ b/crates/issue/src/lib.rs
@@ -239,10 +239,10 @@ impl<T: Config> Module<T> {
         // Check that Parachain is RUNNING
         ext::security::ensure_parachain_status_running::<T>()?;
 
-        let height = <frame_system::Pallet<T>>::block_number();
+        let height = ext::security::active_block_number::<T>();
         let vault = ext::vault_registry::get_active_vault_from_id::<T>(&vault_id)?;
         // Check that the vault is currently not banned
-        ext::vault_registry::ensure_not_banned::<T>(&vault_id, height)?;
+        ext::vault_registry::ensure_not_banned::<T>(&vault_id)?;
 
         // calculate griefing collateral based on the total amount of tokens to be issued
         let amount_dot = ext::oracle::btc_to_dots::<T>(amount_requested)?;

--- a/crates/issue/src/lib.rs
+++ b/crates/issue/src/lib.rs
@@ -142,7 +142,7 @@ decl_module! {
                             requester: old_request.requester,
                             btc_address: old_request.btc_address,
                             btc_public_key: old_request.btc_public_key,
-                            open_bitcoin_height: 1969929, // extra conservative, testnet height at april 4th
+                            btc_height: 1969929, // extra conservative, testnet height at april 4th
                             status: old_request.status,
                         };
                         <IssueRequests<T>>::insert(id, new_request);
@@ -275,7 +275,7 @@ impl<T: Config> Module<T> {
             fee,
             griefing_collateral,
             period: Self::issue_period(),
-            open_bitcoin_height: ext::btc_relay::get_best_block_height::<T>(),
+            btc_height: ext::btc_relay::get_best_block_height::<T>(),
             status: IssueRequestStatus::Pending,
         };
         Self::insert_issue_request(&issue_id, &request);

--- a/crates/issue/src/mock.rs
+++ b/crates/issue/src/mock.rs
@@ -244,6 +244,7 @@ where
         assert_ok!(<exchange_rate_oracle::Module<Test>>::_set_exchange_rate(
             FixedU128::one()
         ));
+        Security::set_active_block_number(1);
         System::set_block_number(1);
         test();
     });

--- a/crates/issue/src/types.rs
+++ b/crates/issue/src/types.rs
@@ -2,7 +2,6 @@ use btc_relay::{BtcAddress, BtcPublicKey};
 use codec::{Decode, Encode};
 use frame_support::traits::Currency;
 use primitive_types::H256;
-use security::ActiveBlockNumber;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -45,7 +44,7 @@ impl Default for IssueRequestStatus {
 #[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
 pub struct IssueRequest<AccountId, BlockNumber, PolkaBTC, DOT> {
     pub vault: AccountId,
-    pub opentime: ActiveBlockNumber<BlockNumber>,
+    pub opentime: BlockNumber,
     pub period: BlockNumber,
     #[cfg_attr(feature = "std", serde(bound(deserialize = "DOT: std::str::FromStr")))]
     #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]

--- a/crates/issue/src/types.rs
+++ b/crates/issue/src/types.rs
@@ -14,7 +14,7 @@ pub enum Version {
     V1,
     /// IssueRequestStatus
     V2,
-    /// ActiveBlockNumber, open_bitcoin_height
+    /// ActiveBlockNumber, btc_height
     V3,
 }
 
@@ -66,7 +66,7 @@ pub struct IssueRequest<AccountId, BlockNumber, PolkaBTC, DOT> {
     pub requester: AccountId,
     pub btc_address: BtcAddress,
     pub btc_public_key: BtcPublicKey,
-    pub open_bitcoin_height: u32,
+    pub btc_height: u32,
     pub status: IssueRequestStatus,
 }
 

--- a/crates/issue/src/types.rs
+++ b/crates/issue/src/types.rs
@@ -46,6 +46,7 @@ impl Default for IssueRequestStatus {
 pub struct IssueRequest<AccountId, BlockNumber, PolkaBTC, DOT> {
     pub vault: AccountId,
     pub opentime: ActiveBlockNumber<BlockNumber>,
+    pub period: BlockNumber,
     #[cfg_attr(feature = "std", serde(bound(deserialize = "DOT: std::str::FromStr")))]
     #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
     #[cfg_attr(feature = "std", serde(bound(serialize = "DOT: std::fmt::Display")))]

--- a/crates/issue/src/types.rs
+++ b/crates/issue/src/types.rs
@@ -2,6 +2,7 @@ use btc_relay::{BtcAddress, BtcPublicKey};
 use codec::{Decode, Encode};
 use frame_support::traits::Currency;
 use primitive_types::H256;
+use security::ActiveBlockNumber;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -14,6 +15,8 @@ pub enum Version {
     V1,
     /// IssueRequestStatus
     V2,
+    /// ActiveBlockNumber
+    V3,
 }
 
 pub(crate) type DOT<T> = <<T as collateral::Config>::DOT as Currency<<T as frame_system::Config>::AccountId>>::Balance;
@@ -42,7 +45,7 @@ impl Default for IssueRequestStatus {
 #[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
 pub struct IssueRequest<AccountId, BlockNumber, PolkaBTC, DOT> {
     pub vault: AccountId,
-    pub opentime: BlockNumber,
+    pub opentime: ActiveBlockNumber<BlockNumber>,
     #[cfg_attr(feature = "std", serde(bound(deserialize = "DOT: std::str::FromStr")))]
     #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
     #[cfg_attr(feature = "std", serde(bound(serialize = "DOT: std::fmt::Display")))]
@@ -70,7 +73,7 @@ pub struct IssueRequest<AccountId, BlockNumber, PolkaBTC, DOT> {
 // See https://github.com/paritytech/substrate/issues/4641
 #[derive(Encode, Decode, Default, Clone, PartialEq)]
 #[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
-pub struct IssueRequestV1<AccountId, BlockNumber, PolkaBTC, DOT> {
+pub struct IssueRequestV2<AccountId, BlockNumber, PolkaBTC, DOT> {
     pub vault: AccountId,
     pub opentime: BlockNumber,
     #[cfg_attr(feature = "std", serde(bound(deserialize = "DOT: std::str::FromStr")))]
@@ -82,17 +85,18 @@ pub struct IssueRequestV1<AccountId, BlockNumber, PolkaBTC, DOT> {
     #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
     #[cfg_attr(feature = "std", serde(bound(serialize = "PolkaBTC: std::fmt::Display")))]
     #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
+    /// the number of tokens that will be transfered to the user (as such, this does not include the fee)
     pub amount: PolkaBTC,
     #[cfg_attr(feature = "std", serde(bound(deserialize = "PolkaBTC: std::str::FromStr")))]
     #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
     #[cfg_attr(feature = "std", serde(bound(serialize = "PolkaBTC: std::fmt::Display")))]
     #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
+    /// the number of tokens that will be tranferred to the fee pool
     pub fee: PolkaBTC,
     pub requester: AccountId,
     pub btc_address: BtcAddress,
     pub btc_public_key: BtcPublicKey,
-    pub completed: bool,
-    pub cancelled: bool,
+    pub status: IssueRequestStatus,
 }
 
 #[cfg(feature = "std")]

--- a/crates/issue/src/types.rs
+++ b/crates/issue/src/types.rs
@@ -14,7 +14,7 @@ pub enum Version {
     V1,
     /// IssueRequestStatus
     V2,
-    /// ActiveBlockNumber
+    /// ActiveBlockNumber, open_bitcoin_height
     V3,
 }
 
@@ -66,6 +66,7 @@ pub struct IssueRequest<AccountId, BlockNumber, PolkaBTC, DOT> {
     pub requester: AccountId,
     pub btc_address: BtcAddress,
     pub btc_public_key: BtcPublicKey,
+    pub open_bitcoin_height: u32,
     pub status: IssueRequestStatus,
 }
 

--- a/crates/redeem/src/benchmarking.rs
+++ b/crates/redeem/src/benchmarking.rs
@@ -6,7 +6,8 @@ use bitcoin::{
 };
 use btc_relay::{BtcAddress, BtcPublicKey, Module as BtcRelay};
 use frame_benchmarking::{account, benchmarks};
-use frame_system::{Pallet as System, RawOrigin};
+use frame_system::RawOrigin;
+use security::Module as Security;
 use sp_core::{H160, H256, U256};
 use sp_std::prelude::*;
 use vault_registry::{
@@ -121,9 +122,10 @@ benchmarks! {
         let mut redeem_request = RedeemRequest::default();
         redeem_request.vault = vault_id.clone();
         redeem_request.redeemer = origin.clone();
-        redeem_request.opentime = Security::active_block_number();
+        redeem_request.opentime = Security::<T>::active_block_number();
         Redeem::<T>::insert_redeem_request(redeem_id, redeem_request);
-        System::<T>::set_block_number(Security::active_block_number() + Redeem::<T>::redeem_period() + 10u32.into());
+        Security::<T>::set_active_block_number(Security::<T>::active_block_number() + Redeem::<T>::redeem_period() + 10u32.into());
+
 
         let mut vault = Vault::default();
         vault.id = vault_id.clone();

--- a/crates/redeem/src/benchmarking.rs
+++ b/crates/redeem/src/benchmarking.rs
@@ -121,9 +121,9 @@ benchmarks! {
         let mut redeem_request = RedeemRequest::default();
         redeem_request.vault = vault_id.clone();
         redeem_request.redeemer = origin.clone();
-        redeem_request.opentime = System::<T>::block_number();
+        redeem_request.opentime = Security::active_block_number();
         Redeem::<T>::insert_redeem_request(redeem_id, redeem_request);
-        System::<T>::set_block_number(System::<T>::block_number() + Redeem::<T>::redeem_period() + 10u32.into());
+        System::<T>::set_block_number(Security::active_block_number() + Redeem::<T>::redeem_period() + 10u32.into());
 
         let mut vault = Vault::default();
         vault.id = vault_id.clone();

--- a/crates/redeem/src/ext.rs
+++ b/crates/redeem/src/ext.rs
@@ -202,6 +202,7 @@ pub(crate) mod treasury {
 pub(crate) mod security {
     use frame_support::dispatch::DispatchError;
     use primitive_types::H256;
+    use security::ActiveBlockNumber;
 
     pub fn get_secure_id<T: security::Config>(id: &T::AccountId) -> H256 {
         <security::Module<T>>::get_secure_id(id)
@@ -209,6 +210,17 @@ pub(crate) mod security {
 
     pub fn ensure_parachain_status_running<T: security::Config>() -> Result<(), DispatchError> {
         <security::Module<T>>::ensure_parachain_status_running()
+    }
+
+    pub fn active_block_number<T: security::Config>() -> ActiveBlockNumber<T::BlockNumber> {
+        <security::Module<T>>::active_block_number()
+    }
+
+    pub fn has_expired<T: security::Config>(
+        open_time: &ActiveBlockNumber<T::BlockNumber>,
+        period: T::BlockNumber,
+    ) -> bool {
+        <security::Module<T>>::has_expired(open_time, period)
     }
 }
 

--- a/crates/redeem/src/ext.rs
+++ b/crates/redeem/src/ext.rs
@@ -20,6 +20,10 @@ pub(crate) mod btc_relay {
     ) -> Result<(BtcAddress, i64), DispatchError> {
         <btc_relay::Module<T>>::_validate_transaction(raw_tx, minimum_btc, btc_address, redeem_id)
     }
+
+    pub fn get_best_block_height<T: btc_relay::Config>() -> u32 {
+        <btc_relay::Module<T>>::get_best_block_height()
+    }
 }
 
 #[cfg_attr(test, mockable)]

--- a/crates/redeem/src/ext.rs
+++ b/crates/redeem/src/ext.rs
@@ -89,11 +89,8 @@ pub(crate) mod vault_registry {
         <vault_registry::Module<T>>::ban_vault(vault_id)
     }
 
-    pub fn ensure_not_banned<T: vault_registry::Config>(
-        vault: &T::AccountId,
-        height: T::BlockNumber,
-    ) -> DispatchResult {
-        <vault_registry::Module<T>>::_ensure_not_banned(vault, height)
+    pub fn ensure_not_banned<T: vault_registry::Config>(vault: &T::AccountId) -> DispatchResult {
+        <vault_registry::Module<T>>::_ensure_not_banned(vault)
     }
 
     pub fn is_vault_below_premium_threshold<T: vault_registry::Config>(

--- a/crates/redeem/src/ext.rs
+++ b/crates/redeem/src/ext.rs
@@ -202,7 +202,6 @@ pub(crate) mod treasury {
 pub(crate) mod security {
     use frame_support::dispatch::DispatchError;
     use primitive_types::H256;
-    use security::ActiveBlockNumber;
 
     pub fn get_secure_id<T: security::Config>(id: &T::AccountId) -> H256 {
         <security::Module<T>>::get_secure_id(id)
@@ -212,15 +211,15 @@ pub(crate) mod security {
         <security::Module<T>>::ensure_parachain_status_running()
     }
 
-    pub fn active_block_number<T: security::Config>() -> ActiveBlockNumber<T::BlockNumber> {
+    pub fn active_block_number<T: security::Config>() -> T::BlockNumber {
         <security::Module<T>>::active_block_number()
     }
 
     pub fn has_expired<T: security::Config>(
-        open_time: &ActiveBlockNumber<T::BlockNumber>,
+        opentime: T::BlockNumber,
         period: T::BlockNumber,
-    ) -> bool {
-        <security::Module<T>>::has_expired(open_time, period)
+    ) -> Result<bool, DispatchError> {
+        <security::Module<T>>::has_expired(opentime, period)
     }
 }
 

--- a/crates/redeem/src/lib.rs
+++ b/crates/redeem/src/lib.rs
@@ -39,7 +39,6 @@ use frame_support::{
 };
 use frame_system::{ensure_root, ensure_signed};
 use primitive_types::H256;
-use security::ActiveBlockNumber;
 use sp_runtime::{traits::*, ModuleId};
 use sp_std::{convert::TryInto, vec::Vec};
 use vault_registry::CurrencySource;
@@ -139,7 +138,7 @@ decl_module! {
                     .for_each(|(id, old_request)| {
                         let new_request = RedeemRequest {
                             vault: old_request.vault,
-                            opentime: ActiveBlockNumber(old_request.opentime),
+                            opentime: old_request.opentime,
                             period: Self::redeem_period(),
                             fee: old_request.fee,
                             amount_btc: old_request.amount_btc,
@@ -393,7 +392,7 @@ impl<T: Config> Module<T> {
 
         // only executable before the request has expired
         ensure!(
-            !ext::security::has_expired::<T>(&redeem.opentime, Self::redeem_period().max(redeem.period)),
+            !ext::security::has_expired::<T>(redeem.opentime, Self::redeem_period().max(redeem.period))?,
             Error::<T>::CommitPeriodExpired
         );
 
@@ -443,7 +442,7 @@ impl<T: Config> Module<T> {
 
         // only cancellable after the request has expired
         ensure!(
-            ext::security::has_expired::<T>(&redeem.opentime, Self::redeem_period().max(redeem.period)),
+            ext::security::has_expired::<T>(redeem.opentime, Self::redeem_period().max(redeem.period))?,
             Error::<T>::TimeNotExpired
         );
 

--- a/crates/redeem/src/lib.rs
+++ b/crates/redeem/src/lib.rs
@@ -295,7 +295,6 @@ impl<T: Config> Module<T> {
             .checked_sub(&fee_polka_btc)
             .ok_or(Error::<T>::ArithmeticUnderflow)?;
 
-        let height = ext::security::active_block_number::<T>();
         ext::vault_registry::ensure_not_banned::<T>(&vault_id)?;
 
         // only allow requests of amount above above the minimum

--- a/crates/redeem/src/lib.rs
+++ b/crates/redeem/src/lib.rs
@@ -140,6 +140,7 @@ decl_module! {
                         let new_request = RedeemRequest {
                             vault: old_request.vault,
                             opentime: ActiveBlockNumber(old_request.opentime),
+                            period: Self::redeem_period(),
                             fee: old_request.fee,
                             amount_btc: old_request.amount_btc,
                             premium_dot: old_request.premium_dot,
@@ -340,6 +341,7 @@ impl<T: Config> Module<T> {
                 amount_btc: redeem_amount_polka_btc,
                 // TODO: reimplement partial redeem for system liquidation
                 premium_dot,
+                period: Self::redeem_period(),
                 redeemer: redeemer.clone(),
                 btc_address: btc_address.clone(),
                 status: RedeemRequestStatus::Pending,
@@ -391,7 +393,7 @@ impl<T: Config> Module<T> {
 
         // only executable before the request has expired
         ensure!(
-            !ext::security::has_expired::<T>(&redeem.opentime, Self::redeem_period()),
+            !ext::security::has_expired::<T>(&redeem.opentime, Self::redeem_period().max(redeem.period)),
             Error::<T>::CommitPeriodExpired
         );
 
@@ -441,7 +443,7 @@ impl<T: Config> Module<T> {
 
         // only cancellable after the request has expired
         ensure!(
-            ext::security::has_expired::<T>(&redeem.opentime, Self::redeem_period()),
+            ext::security::has_expired::<T>(&redeem.opentime, Self::redeem_period().max(redeem.period)),
             Error::<T>::TimeNotExpired
         );
 

--- a/crates/redeem/src/lib.rs
+++ b/crates/redeem/src/lib.rs
@@ -295,8 +295,8 @@ impl<T: Config> Module<T> {
             .checked_sub(&fee_polka_btc)
             .ok_or(Error::<T>::ArithmeticUnderflow)?;
 
-        let height = <frame_system::Pallet<T>>::block_number();
-        ext::vault_registry::ensure_not_banned::<T>(&vault_id, height)?;
+        let height = ext::security::active_block_number::<T>();
+        ext::vault_registry::ensure_not_banned::<T>(&vault_id)?;
 
         // only allow requests of amount above above the minimum
         let dust_value = <RedeemBtcDustValue<T>>::get();

--- a/crates/redeem/src/lib.rs
+++ b/crates/redeem/src/lib.rs
@@ -145,6 +145,7 @@ decl_module! {
                             premium_dot: old_request.premium_dot,
                             redeemer: old_request.redeemer,
                             btc_address: old_request.btc_address,
+                            open_bitcoin_height: 1969929, // extra conservative, testnet height at april 4th
                             status: old_request.status,
                         };
                         <RedeemRequests<T>>::insert(id, new_request);
@@ -342,6 +343,7 @@ impl<T: Config> Module<T> {
                 period: Self::redeem_period(),
                 redeemer: redeemer.clone(),
                 btc_address: btc_address.clone(),
+                open_bitcoin_height: ext::btc_relay::get_best_block_height::<T>(),
                 status: RedeemRequestStatus::Pending,
             },
         );

--- a/crates/redeem/src/lib.rs
+++ b/crates/redeem/src/lib.rs
@@ -28,7 +28,7 @@ pub mod types;
 #[doc(inline)]
 pub use crate::types::{RedeemRequest, RedeemRequestStatus};
 
-use crate::types::{PolkaBTC, RedeemRequestV1, Version, DOT};
+use crate::types::{PolkaBTC, RedeemRequestV2, Version, DOT};
 use bitcoin::types::H256Le;
 use btc_relay::BtcAddress;
 use frame_support::{
@@ -39,6 +39,7 @@ use frame_support::{
 };
 use frame_system::{ensure_root, ensure_signed};
 use primitive_types::H256;
+use security::ActiveBlockNumber;
 use sp_runtime::{traits::*, ModuleId};
 use sp_std::{convert::TryInto, vec::Vec};
 use vault_registry::CurrencySource;
@@ -132,31 +133,24 @@ decl_module! {
         fn on_runtime_upgrade() -> Weight {
             use frame_support::{migration::StorageKeyIterator, Blake2_128Concat};
 
-            if matches!(Self::storage_version(), Version::V0 | Version::V1) {
-                StorageKeyIterator::<H256, RedeemRequestV1<T::AccountId, T::BlockNumber, PolkaBTC<T>, DOT<T>>, Blake2_128Concat>::new(<RedeemRequests<T>>::module_prefix(), b"RedeemRequests")
+            if matches!(Self::storage_version(), Version::V2) {
+                StorageKeyIterator::<H256, RedeemRequestV2<T::AccountId, T::BlockNumber, PolkaBTC<T>, DOT<T>>, Blake2_128Concat>::new(<RedeemRequests<T>>::module_prefix(), b"RedeemRequests")
                     .drain()
-                    .for_each(|(id, request_v1)| {
-                        let status = match (request_v1.completed,request_v1.cancelled, request_v1.reimburse) {
-                            (false, false, false) => RedeemRequestStatus::Pending,
-                            (true, false, false) => RedeemRequestStatus::Completed,
-                            (false, true, true) => RedeemRequestStatus::Reimbursed(true),
-                            (false, true, false) => RedeemRequestStatus::Retried,
-                            _ => RedeemRequestStatus::Completed, // should never happen
+                    .for_each(|(id, old_request)| {
+                        let new_request = RedeemRequest {
+                            vault: old_request.vault,
+                            opentime: ActiveBlockNumber(old_request.opentime),
+                            fee: old_request.fee,
+                            amount_btc: old_request.amount_btc,
+                            premium_dot: old_request.premium_dot,
+                            redeemer: old_request.redeemer,
+                            btc_address: old_request.btc_address,
+                            status: old_request.status,
                         };
-                        let request_v2 = RedeemRequest {
-                            vault: request_v1.vault,
-                            opentime: request_v1.opentime,
-                            fee: request_v1.fee,
-                            amount_btc: request_v1.amount_btc,
-                            premium_dot: request_v1.premium_dot,
-                            redeemer: request_v1.redeemer,
-                            btc_address: request_v1.btc_address,
-                            status
-                        };
-                        <RedeemRequests<T>>::insert(id, request_v2);
+                        <RedeemRequests<T>>::insert(id, new_request);
                     });
 
-                StorageVersion::put(Version::V2);
+                StorageVersion::put(Version::V3);
             }
 
             0
@@ -341,7 +335,7 @@ impl<T: Config> Module<T> {
             redeem_id,
             RedeemRequest {
                 vault: vault_id.clone(),
-                opentime: height,
+                opentime: ext::security::active_block_number::<T>(),
                 fee: fee_polka_btc,
                 amount_btc: redeem_amount_polka_btc,
                 // TODO: reimplement partial redeem for system liquidation
@@ -397,7 +391,7 @@ impl<T: Config> Module<T> {
 
         // only executable before the request has expired
         ensure!(
-            !has_request_expired::<T>(redeem.opentime, Self::redeem_period()),
+            !ext::security::has_expired::<T>(&redeem.opentime, Self::redeem_period()),
             Error::<T>::CommitPeriodExpired
         );
 
@@ -447,7 +441,7 @@ impl<T: Config> Module<T> {
 
         // only cancellable after the request has expired
         ensure!(
-            has_request_expired::<T>(redeem.opentime, Self::redeem_period()),
+            ext::security::has_expired::<T>(&redeem.opentime, Self::redeem_period()),
             Error::<T>::TimeNotExpired
         );
 
@@ -688,11 +682,6 @@ impl<T: Config> Module<T> {
     fn u128_to_dot(x: u128) -> Result<DOT<T>, DispatchError> {
         TryInto::<DOT<T>>::try_into(x).map_err(|_| Error::<T>::TryIntoIntError.into())
     }
-}
-
-fn has_request_expired<T: Config>(opentime: T::BlockNumber, period: T::BlockNumber) -> bool {
-    let height = <frame_system::Pallet<T>>::block_number();
-    height > opentime + period
 }
 
 decl_error! {

--- a/crates/redeem/src/lib.rs
+++ b/crates/redeem/src/lib.rs
@@ -145,7 +145,7 @@ decl_module! {
                             premium_dot: old_request.premium_dot,
                             redeemer: old_request.redeemer,
                             btc_address: old_request.btc_address,
-                            open_bitcoin_height: 1969929, // extra conservative, testnet height at april 4th
+                            btc_height: 1969929, // extra conservative, testnet height at april 4th
                             status: old_request.status,
                         };
                         <RedeemRequests<T>>::insert(id, new_request);
@@ -343,7 +343,7 @@ impl<T: Config> Module<T> {
                 period: Self::redeem_period(),
                 redeemer: redeemer.clone(),
                 btc_address: btc_address.clone(),
-                open_bitcoin_height: ext::btc_relay::get_best_block_height::<T>(),
+                btc_height: ext::btc_relay::get_best_block_height::<T>(),
                 status: RedeemRequestStatus::Pending,
             },
         );

--- a/crates/redeem/src/mock.rs
+++ b/crates/redeem/src/mock.rs
@@ -278,6 +278,7 @@ where
         assert_ok!(<exchange_rate_oracle::Module<Test>>::_set_exchange_rate(
             FixedU128::one()
         ));
+        Security::set_active_block_number(1);
         System::set_block_number(1);
         test();
     });

--- a/crates/redeem/src/tests.rs
+++ b/crates/redeem/src/tests.rs
@@ -203,6 +203,7 @@ fn test_request_redeem_succeeds_with_normal_redeem() {
                 premium_dot: 0,
                 redeemer: redeemer.clone(),
                 btc_address: BtcAddress::P2PKH(H160::zero()),
+                open_bitcoin_height: 0,
                 status: RedeemRequestStatus::Pending,
             }
         );
@@ -287,6 +288,7 @@ fn test_execute_redeem_succeeds_with_another_account() {
                 premium_dot: 0,
                 redeemer: ALICE,
                 btc_address: BtcAddress::random(),
+                open_bitcoin_height: 0,
                 status: RedeemRequestStatus::Pending,
             },
         );
@@ -336,6 +338,7 @@ fn test_execute_redeem_fails_with_commit_period_expired() {
                 premium_dot: 0,
                 redeemer: ALICE,
                 btc_address: BtcAddress::random(),
+                open_bitcoin_height: 0,
                 status: RedeemRequestStatus::Pending,
             }))
         });
@@ -388,6 +391,7 @@ fn test_execute_redeem_succeeds() {
                 premium_dot: 0,
                 redeemer: ALICE,
                 btc_address: BtcAddress::random(),
+                open_bitcoin_height: 0,
                 status: RedeemRequestStatus::Pending,
             },
         );
@@ -447,6 +451,7 @@ fn test_cancel_redeem_fails_with_time_not_expired() {
                 premium_dot: 0,
                 redeemer: ALICE,
                 btc_address: BtcAddress::random(),
+                open_bitcoin_height: 0,
                 status: RedeemRequestStatus::Pending,
             }))
         });
@@ -473,6 +478,7 @@ fn test_cancel_redeem_fails_with_unauthorized_caller() {
                 premium_dot: 0,
                 redeemer: ALICE,
                 btc_address: BtcAddress::random(),
+                open_bitcoin_height: 0,
                 status: RedeemRequestStatus::Pending,
             }))
         });
@@ -498,6 +504,7 @@ fn test_cancel_redeem_succeeds() {
                 premium_dot: 0,
                 redeemer: ALICE,
                 btc_address: BtcAddress::random(),
+                open_bitcoin_height: 0,
                 status: RedeemRequestStatus::Pending,
             },
         );

--- a/crates/redeem/src/tests.rs
+++ b/crates/redeem/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{ext, has_request_expired, mock::*};
+use crate::{ext, mock::*};
 
 use crate::types::{PolkaBTC, RedeemRequest, RedeemRequestStatus, DOT};
 use bitcoin::types::H256Le;
@@ -6,6 +6,7 @@ use btc_relay::{BtcAddress, BtcPublicKey};
 use frame_support::{assert_err, assert_noop, assert_ok, dispatch::DispatchError};
 use mocktopus::mocking::*;
 use primitive_types::H256;
+use security::Module as Security;
 use sp_core::H160;
 use sp_std::convert::TryInto;
 use vault_registry::{VaultStatus, Wallet};
@@ -113,7 +114,7 @@ fn test_request_redeem_fails_with_vault_not_found() {
 fn test_request_redeem_fails_with_vault_banned() {
     run_test(|| {
         ext::vault_registry::ensure_not_banned::<Test>
-            .mock_safe(|_, _| MockResult::Return(Err(VaultRegistryError::VaultBanned.into())));
+            .mock_safe(|_| MockResult::Return(Err(VaultRegistryError::VaultBanned.into())));
 
         assert_err!(
             Redeem::request_redeem(Origin::signed(ALICE), 0, BtcAddress::default(), BOB),
@@ -125,7 +126,7 @@ fn test_request_redeem_fails_with_vault_banned() {
 #[test]
 fn test_request_redeem_fails_with_vault_liquidated() {
     run_test(|| {
-        ext::vault_registry::ensure_not_banned::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
+        ext::vault_registry::ensure_not_banned::<Test>.mock_safe(|_| MockResult::Return(Ok(())));
         assert_err!(
             Redeem::request_redeem(Origin::signed(ALICE), 3, BtcAddress::random(), BOB),
             VaultRegistryError::VaultNotFound
@@ -194,6 +195,7 @@ fn test_request_redeem_succeeds_with_normal_redeem() {
         assert_ok!(
             Redeem::get_open_redeem_request_from_id(&H256([0; 32])),
             RedeemRequest {
+                period: Redeem::redeem_period(),
                 vault: BOB,
                 opentime: 1,
                 fee: redeem_fee,
@@ -254,7 +256,7 @@ fn test_execute_redeem_fails_with_redeem_id_not_found() {
 fn test_execute_redeem_succeeds_with_another_account() {
     run_test(|| {
         ext::oracle::btc_to_dots::<Test>.mock_safe(|x| MockResult::Return(btcdot_parity(x)));
-        System::set_block_number(40);
+        Security::<Test>::set_active_block_number(40);
         <vault_registry::Module<Test>>::insert_vault(
             &BOB,
             vault_registry::Vault {
@@ -277,6 +279,7 @@ fn test_execute_redeem_succeeds_with_another_account() {
         inject_redeem_request(
             H256([0u8; 32]),
             RedeemRequest {
+                period: 0,
                 vault: BOB,
                 opentime: 40,
                 fee: 0,
@@ -321,10 +324,11 @@ fn test_execute_redeem_succeeds_with_another_account() {
 #[test]
 fn test_execute_redeem_fails_with_commit_period_expired() {
     run_test(|| {
-        System::set_block_number(40);
+        Security::<Test>::set_active_block_number(40);
 
         Redeem::get_open_redeem_request_from_id.mock_safe(|_| {
             MockResult::Return(Ok(RedeemRequest {
+                period: 0,
                 vault: BOB,
                 opentime: 20,
                 fee: 0,
@@ -353,7 +357,7 @@ fn test_execute_redeem_fails_with_commit_period_expired() {
 fn test_execute_redeem_succeeds() {
     run_test(|| {
         ext::oracle::btc_to_dots::<Test>.mock_safe(|x| MockResult::Return(btcdot_parity(x)));
-        System::set_block_number(40);
+        Security::<Test>::set_active_block_number(40);
         <vault_registry::Module<Test>>::insert_vault(
             &BOB,
             vault_registry::Vault {
@@ -376,6 +380,7 @@ fn test_execute_redeem_succeeds() {
         inject_redeem_request(
             H256([0u8; 32]),
             RedeemRequest {
+                period: 0,
                 vault: BOB,
                 opentime: 40,
                 fee: 0,
@@ -430,10 +435,11 @@ fn test_cancel_redeem_fails_with_redeem_id_not_found() {
 #[test]
 fn test_cancel_redeem_fails_with_time_not_expired() {
     run_test(|| {
-        System::set_block_number(10);
+        Security::<Test>::set_active_block_number(10);
 
         Redeem::get_open_redeem_request_from_id.mock_safe(|_| {
             MockResult::Return(Ok(RedeemRequest {
+                period: 0,
                 vault: BOB,
                 opentime: 0,
                 fee: 0,
@@ -455,10 +461,11 @@ fn test_cancel_redeem_fails_with_time_not_expired() {
 #[test]
 fn test_cancel_redeem_fails_with_unauthorized_caller() {
     run_test(|| {
-        <frame_system::Pallet<Test>>::set_block_number(20);
+        Security::<Test>::set_active_block_number(20);
 
         Redeem::get_open_redeem_request_from_id.mock_safe(|_| {
             MockResult::Return(Ok(RedeemRequest {
+                period: 0,
                 vault: BOB,
                 opentime: 0,
                 fee: 0,
@@ -483,6 +490,7 @@ fn test_cancel_redeem_succeeds() {
         inject_redeem_request(
             H256([0u8; 32]),
             RedeemRequest {
+                period: 0,
                 vault: BOB,
                 opentime: 10,
                 fee: 0,
@@ -494,7 +502,8 @@ fn test_cancel_redeem_succeeds() {
             },
         );
 
-        System::set_block_number(System::block_number() + Redeem::redeem_period() + 10);
+        let current_block_number = ext::security::active_block_number::<Test>();
+        Security::<Test>::set_active_block_number(current_block_number + Redeem::redeem_period() + 10);
 
         ext::vault_registry::ban_vault::<Test>.mock_safe(move |vault| {
             assert_eq!(vault, BOB);
@@ -526,14 +535,5 @@ fn test_set_redeem_period_only_root() {
             DispatchError::BadOrigin
         );
         assert_ok!(Redeem::set_redeem_period(Origin::root(), 1));
-    })
-}
-
-#[test]
-fn test_has_request_expired() {
-    run_test(|| {
-        System::set_block_number(130);
-        assert!(has_request_expired::<Test>(50, 50));
-        assert!(!has_request_expired::<Test>(120, 50));
     })
 }

--- a/crates/redeem/src/tests.rs
+++ b/crates/redeem/src/tests.rs
@@ -203,7 +203,7 @@ fn test_request_redeem_succeeds_with_normal_redeem() {
                 premium_dot: 0,
                 redeemer: redeemer.clone(),
                 btc_address: BtcAddress::P2PKH(H160::zero()),
-                open_bitcoin_height: 0,
+                btc_height: 0,
                 status: RedeemRequestStatus::Pending,
             }
         );
@@ -288,7 +288,7 @@ fn test_execute_redeem_succeeds_with_another_account() {
                 premium_dot: 0,
                 redeemer: ALICE,
                 btc_address: BtcAddress::random(),
-                open_bitcoin_height: 0,
+                btc_height: 0,
                 status: RedeemRequestStatus::Pending,
             },
         );
@@ -338,7 +338,7 @@ fn test_execute_redeem_fails_with_commit_period_expired() {
                 premium_dot: 0,
                 redeemer: ALICE,
                 btc_address: BtcAddress::random(),
-                open_bitcoin_height: 0,
+                btc_height: 0,
                 status: RedeemRequestStatus::Pending,
             }))
         });
@@ -391,7 +391,7 @@ fn test_execute_redeem_succeeds() {
                 premium_dot: 0,
                 redeemer: ALICE,
                 btc_address: BtcAddress::random(),
-                open_bitcoin_height: 0,
+                btc_height: 0,
                 status: RedeemRequestStatus::Pending,
             },
         );
@@ -451,7 +451,7 @@ fn test_cancel_redeem_fails_with_time_not_expired() {
                 premium_dot: 0,
                 redeemer: ALICE,
                 btc_address: BtcAddress::random(),
-                open_bitcoin_height: 0,
+                btc_height: 0,
                 status: RedeemRequestStatus::Pending,
             }))
         });
@@ -478,7 +478,7 @@ fn test_cancel_redeem_fails_with_unauthorized_caller() {
                 premium_dot: 0,
                 redeemer: ALICE,
                 btc_address: BtcAddress::random(),
-                open_bitcoin_height: 0,
+                btc_height: 0,
                 status: RedeemRequestStatus::Pending,
             }))
         });
@@ -504,7 +504,7 @@ fn test_cancel_redeem_succeeds() {
                 premium_dot: 0,
                 redeemer: ALICE,
                 btc_address: BtcAddress::random(),
-                open_bitcoin_height: 0,
+                btc_height: 0,
                 status: RedeemRequestStatus::Pending,
             },
         );

--- a/crates/redeem/src/types.rs
+++ b/crates/redeem/src/types.rs
@@ -13,7 +13,7 @@ pub enum Version {
     V1,
     /// RedeemRequestStatus, removed amount_dot and amount_polka_btc
     V2,
-    /// ActiveBlockNumber
+    /// ActiveBlockNumber, open_bitcoin_height
     V3,
 }
 
@@ -66,6 +66,7 @@ pub struct RedeemRequest<AccountId, BlockNumber, PolkaBTC, DOT> {
     pub premium_dot: DOT,
     pub redeemer: AccountId,
     pub btc_address: BtcAddress,
+    pub open_bitcoin_height: u32,
     pub status: RedeemRequestStatus,
 }
 

--- a/crates/redeem/src/types.rs
+++ b/crates/redeem/src/types.rs
@@ -46,6 +46,7 @@ impl Default for RedeemRequestStatus {
 pub struct RedeemRequest<AccountId, BlockNumber, PolkaBTC, DOT> {
     pub vault: AccountId,
     pub opentime: ActiveBlockNumber<BlockNumber>,
+    pub period: BlockNumber,
     #[cfg_attr(feature = "std", serde(bound(deserialize = "PolkaBTC: std::str::FromStr")))]
     #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
     #[cfg_attr(feature = "std", serde(bound(serialize = "PolkaBTC: std::fmt::Display")))]

--- a/crates/redeem/src/types.rs
+++ b/crates/redeem/src/types.rs
@@ -13,7 +13,7 @@ pub enum Version {
     V1,
     /// RedeemRequestStatus, removed amount_dot and amount_polka_btc
     V2,
-    /// ActiveBlockNumber, open_bitcoin_height
+    /// ActiveBlockNumber, btc_height
     V3,
 }
 
@@ -66,7 +66,8 @@ pub struct RedeemRequest<AccountId, BlockNumber, PolkaBTC, DOT> {
     pub premium_dot: DOT,
     pub redeemer: AccountId,
     pub btc_address: BtcAddress,
-    pub open_bitcoin_height: u32,
+    /// The latest Bitcoin height as reported by the BTC-Relay at time of opening.
+    pub btc_height: u32,
     pub status: RedeemRequestStatus,
 }
 

--- a/crates/redeem/src/types.rs
+++ b/crates/redeem/src/types.rs
@@ -1,7 +1,6 @@
 use btc_relay::BtcAddress;
 use codec::{Decode, Encode};
 use frame_support::traits::Currency;
-use security::ActiveBlockNumber;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -45,7 +44,7 @@ impl Default for RedeemRequestStatus {
 #[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
 pub struct RedeemRequest<AccountId, BlockNumber, PolkaBTC, DOT> {
     pub vault: AccountId,
-    pub opentime: ActiveBlockNumber<BlockNumber>,
+    pub opentime: BlockNumber,
     pub period: BlockNumber,
     #[cfg_attr(feature = "std", serde(bound(deserialize = "PolkaBTC: std::str::FromStr")))]
     #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]

--- a/crates/refund/src/mock.rs
+++ b/crates/refund/src/mock.rs
@@ -195,6 +195,7 @@ where
             FixedU128::one()
         ));
         System::set_block_number(1);
+        Security::set_active_block_number(1);
         test();
     });
 }

--- a/crates/replace/src/benchmarking.rs
+++ b/crates/replace/src/benchmarking.rs
@@ -200,7 +200,7 @@ benchmarks! {
         replace_request.new_vault = new_vault_id.clone();
         replace_request.amount = amount.into();
         Replace::<T>::insert_replace_request(&replace_id, &replace_request);
-        System::<T>::set_block_number(System::<T>::block_number() + Replace::<T>::replace_period() + 10u32.into());
+        System::<T>::set_block_number(Security::active_block_number() + Replace::<T>::replace_period() + 10u32.into());
 
         VaultRegistry::<T>::set_secure_collateral_threshold(<T as vault_registry::Config>::UnsignedFixedPoint::checked_from_rational(1, 100000).unwrap());
 

--- a/crates/replace/src/benchmarking.rs
+++ b/crates/replace/src/benchmarking.rs
@@ -7,7 +7,8 @@ use bitcoin::{
 use btc_relay::{BtcAddress, BtcPublicKey, Module as BtcRelay};
 use exchange_rate_oracle::Module as ExchangeRateOracle;
 use frame_benchmarking::{account, benchmarks};
-use frame_system::{Pallet as System, RawOrigin};
+use frame_system::RawOrigin;
+use security::Module as Security;
 use sp_core::{H160, H256, U256};
 use sp_runtime::FixedPointNumber;
 use sp_std::prelude::*;
@@ -200,7 +201,7 @@ benchmarks! {
         replace_request.new_vault = new_vault_id.clone();
         replace_request.amount = amount.into();
         Replace::<T>::insert_replace_request(&replace_id, &replace_request);
-        System::<T>::set_block_number(Security::active_block_number() + Replace::<T>::replace_period() + 10u32.into());
+        Security::<T>::set_active_block_number(Security::<T>::active_block_number() + Replace::<T>::replace_period() + 10u32.into());
 
         VaultRegistry::<T>::set_secure_collateral_threshold(<T as vault_registry::Config>::UnsignedFixedPoint::checked_from_rational(1, 100000).unwrap());
 

--- a/crates/replace/src/ext.rs
+++ b/crates/replace/src/ext.rs
@@ -76,11 +76,8 @@ pub(crate) mod vault_registry {
         <vault_registry::Module<T>>::is_vault_below_auction_threshold(&vault_id)
     }
 
-    pub fn ensure_not_banned<T: vault_registry::Config>(
-        vault: &T::AccountId,
-        height: T::BlockNumber,
-    ) -> DispatchResult {
-        <vault_registry::Module<T>>::_ensure_not_banned(vault, height)
+    pub fn ensure_not_banned<T: vault_registry::Config>(vault: &T::AccountId) -> DispatchResult {
+        <vault_registry::Module<T>>::_ensure_not_banned(vault)
     }
 
     pub fn insert_vault_deposit_address<T: vault_registry::Config>(

--- a/crates/replace/src/ext.rs
+++ b/crates/replace/src/ext.rs
@@ -164,9 +164,8 @@ pub(crate) mod collateral {
 
 #[cfg_attr(test, mockable)]
 pub(crate) mod security {
-    use frame_support::dispatch::DispatchResult;
+    use frame_support::dispatch::{DispatchError, DispatchResult};
     use primitive_types::H256;
-    use security::ActiveBlockNumber;
 
     pub fn get_secure_id<T: security::Config>(id: &T::AccountId) -> H256 {
         <security::Module<T>>::get_secure_id(id)
@@ -176,15 +175,15 @@ pub(crate) mod security {
         <security::Module<T>>::ensure_parachain_status_running()
     }
 
-    pub fn active_block_number<T: security::Config>() -> ActiveBlockNumber<T::BlockNumber> {
+    pub fn active_block_number<T: security::Config>() -> T::BlockNumber {
         <security::Module<T>>::active_block_number()
     }
 
     pub fn has_expired<T: security::Config>(
-        open_time: &ActiveBlockNumber<T::BlockNumber>,
+        opentime: T::BlockNumber,
         period: T::BlockNumber,
-    ) -> bool {
-        <security::Module<T>>::has_expired(open_time, period)
+    ) -> Result<bool, DispatchError> {
+        <security::Module<T>>::has_expired(opentime, period)
     }
 }
 

--- a/crates/replace/src/ext.rs
+++ b/crates/replace/src/ext.rs
@@ -20,6 +20,10 @@ pub(crate) mod btc_relay {
     ) -> Result<(BtcAddress, i64), DispatchError> {
         <btc_relay::Module<T>>::_validate_transaction(raw_tx, minimum_btc, btc_address, replace_id)
     }
+
+    pub fn get_best_block_height<T: btc_relay::Config>() -> u32 {
+        <btc_relay::Module<T>>::get_best_block_height()
+    }
 }
 
 #[cfg_attr(test, mockable)]

--- a/crates/replace/src/ext.rs
+++ b/crates/replace/src/ext.rs
@@ -166,6 +166,7 @@ pub(crate) mod collateral {
 pub(crate) mod security {
     use frame_support::dispatch::DispatchResult;
     use primitive_types::H256;
+    use security::ActiveBlockNumber;
 
     pub fn get_secure_id<T: security::Config>(id: &T::AccountId) -> H256 {
         <security::Module<T>>::get_secure_id(id)
@@ -173,6 +174,17 @@ pub(crate) mod security {
 
     pub fn ensure_parachain_status_running<T: security::Config>() -> DispatchResult {
         <security::Module<T>>::ensure_parachain_status_running()
+    }
+
+    pub fn active_block_number<T: security::Config>() -> ActiveBlockNumber<T::BlockNumber> {
+        <security::Module<T>>::active_block_number()
+    }
+
+    pub fn has_expired<T: security::Config>(
+        open_time: &ActiveBlockNumber<T::BlockNumber>,
+        period: T::BlockNumber,
+    ) -> bool {
+        <security::Module<T>>::has_expired(open_time, period)
     }
 }
 

--- a/crates/replace/src/lib.rs
+++ b/crates/replace/src/lib.rs
@@ -307,7 +307,7 @@ impl<T: Config> Module<T> {
 
         // check vault is not banned
         let height = Self::current_height();
-        ext::vault_registry::ensure_not_banned::<T>(&vault_id, height)?;
+        ext::vault_registry::ensure_not_banned::<T>(&vault_id)?;
 
         let requestable_tokens = ext::vault_registry::requestable_to_be_replaced_tokens::<T>(&vault_id)?;
         let to_be_replaced_increase = amount_btc.min(requestable_tokens);
@@ -577,7 +577,7 @@ impl<T: Config> Module<T> {
 
         // Check that new vault is not currently banned
         let height = Self::current_height();
-        ext::vault_registry::ensure_not_banned::<T>(&new_vault_id, height)?;
+        ext::vault_registry::ensure_not_banned::<T>(&new_vault_id)?;
 
         // Add the new replace address to the vault's wallet,
         // this should also verify that the vault exists
@@ -698,7 +698,7 @@ impl<T: Config> Module<T> {
     }
 
     fn current_height() -> T::BlockNumber {
-        <frame_system::Pallet<T>>::block_number()
+        ext::security::active_block_number::<T>()
     }
 }
 

--- a/crates/replace/src/lib.rs
+++ b/crates/replace/src/lib.rs
@@ -161,6 +161,7 @@ decl_module! {
                                 griefing_collateral: request_v1.griefing_collateral,
                                 collateral: request_v1.collateral,
                                 accept_time: ActiveBlockNumber(request_v1.accept_time?),
+                                period: Self::replace_period(),
                                 btc_address: request_v1.btc_address?,
                                 status
                             })
@@ -464,7 +465,7 @@ impl<T: Config> Module<T> {
 
         // only executable before the request has expired
         ensure!(
-            !ext::security::has_expired::<T>(&replace.accept_time, Self::replace_period()),
+            !ext::security::has_expired::<T>(&replace.accept_time, Self::replace_period().max(replace.period)),
             Error::<T>::ReplacePeriodExpired
         );
 
@@ -513,7 +514,7 @@ impl<T: Config> Module<T> {
 
         // only cancellable after the request has expired
         ensure!(
-            ext::security::has_expired::<T>(&replace.accept_time, Self::replace_period()),
+            ext::security::has_expired::<T>(&replace.accept_time, Self::replace_period().max(replace.period)),
             Error::<T>::ReplacePeriodNotExpired
         );
 
@@ -625,6 +626,7 @@ impl<T: Config> Module<T> {
             btc_address: btc_address,
             griefing_collateral: if is_auction { 0u32.into() } else { griefing_collateral },
             amount: actual_btc,
+            period: Self::replace_period(),
             status: ReplaceRequestStatus::Pending,
         };
 

--- a/crates/replace/src/lib.rs
+++ b/crates/replace/src/lib.rs
@@ -162,7 +162,7 @@ decl_module! {
                                 accept_time: request_v1.accept_time?,
                                 period: Self::replace_period(),
                                 btc_address: request_v1.btc_address?,
-                                open_bitcoin_height: 1969929, // extra conservative, testnet height at april 4th
+                                btc_height: 1969929, // extra conservative, testnet height at april 4th
                                 status
                             })
                         };
@@ -625,7 +625,7 @@ impl<T: Config> Module<T> {
             griefing_collateral: if is_auction { 0u32.into() } else { griefing_collateral },
             amount: actual_btc,
             period: Self::replace_period(),
-            open_bitcoin_height: ext::btc_relay::get_best_block_height::<T>(),
+            btc_height: ext::btc_relay::get_best_block_height::<T>(),
             status: ReplaceRequestStatus::Pending,
         };
 

--- a/crates/replace/src/lib.rs
+++ b/crates/replace/src/lib.rs
@@ -306,7 +306,6 @@ impl<T: Config> Module<T> {
         ext::security::ensure_parachain_status_running::<T>()?;
 
         // check vault is not banned
-        let height = Self::current_height();
         ext::vault_registry::ensure_not_banned::<T>(&vault_id)?;
 
         let requestable_tokens = ext::vault_registry::requestable_to_be_replaced_tokens::<T>(&vault_id)?;
@@ -576,7 +575,6 @@ impl<T: Config> Module<T> {
         ext::security::ensure_parachain_status_running::<T>()?;
 
         // Check that new vault is not currently banned
-        let height = Self::current_height();
         ext::vault_registry::ensure_not_banned::<T>(&new_vault_id)?;
 
         // Add the new replace address to the vault's wallet,
@@ -695,10 +693,6 @@ impl<T: Config> Module<T> {
                 req.status = status;
             }
         });
-    }
-
-    fn current_height() -> T::BlockNumber {
-        ext::security::active_block_number::<T>()
     }
 }
 

--- a/crates/replace/src/lib.rs
+++ b/crates/replace/src/lib.rs
@@ -162,6 +162,7 @@ decl_module! {
                                 accept_time: request_v1.accept_time?,
                                 period: Self::replace_period(),
                                 btc_address: request_v1.btc_address?,
+                                open_bitcoin_height: 1969929, // extra conservative, testnet height at april 4th
                                 status
                             })
                         };
@@ -624,6 +625,7 @@ impl<T: Config> Module<T> {
             griefing_collateral: if is_auction { 0u32.into() } else { griefing_collateral },
             amount: actual_btc,
             period: Self::replace_period(),
+            open_bitcoin_height: ext::btc_relay::get_best_block_height::<T>(),
             status: ReplaceRequestStatus::Pending,
         };
 

--- a/crates/replace/src/mock.rs
+++ b/crates/replace/src/mock.rs
@@ -244,6 +244,7 @@ where
             FixedU128::one()
         ));
         System::set_block_number(1);
+        Security::set_active_block_number(1);
         test();
     });
 }

--- a/crates/replace/src/tests.rs
+++ b/crates/replace/src/tests.rs
@@ -43,6 +43,7 @@ fn test_request() -> ReplaceRequest<u64, u64, u64, u64> {
         griefing_collateral: 0,
         btc_address: BtcAddress::default(),
         collateral: 20,
+        open_bitcoin_height: 0,
         status: ReplaceRequestStatus::Pending,
     }
 }

--- a/crates/replace/src/tests.rs
+++ b/crates/replace/src/tests.rs
@@ -43,7 +43,7 @@ fn test_request() -> ReplaceRequest<u64, u64, u64, u64> {
         griefing_collateral: 0,
         btc_address: BtcAddress::default(),
         collateral: 20,
-        open_bitcoin_height: 0,
+        btc_height: 0,
         status: ReplaceRequestStatus::Pending,
     }
 }

--- a/crates/replace/src/tests.rs
+++ b/crates/replace/src/tests.rs
@@ -35,6 +35,7 @@ macro_rules! assert_event_matches {
 }
 fn test_request() -> ReplaceRequest<u64, u64, u64, u64> {
     ReplaceRequest {
+        period: 0,
         new_vault: NEW_VAULT,
         old_vault: OLD_VAULT,
         accept_time: 1,
@@ -50,7 +51,7 @@ mod request_replace_tests {
     use super::*;
 
     fn setup_mocks() {
-        ext::vault_registry::ensure_not_banned::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
+        ext::vault_registry::ensure_not_banned::<Test>.mock_safe(|_| MockResult::Return(Ok(())));
         ext::vault_registry::requestable_to_be_replaced_tokens::<Test>
             .mock_safe(move |_| MockResult::Return(Ok(1000000)));
         ext::vault_registry::try_increase_to_be_replaced_tokens::<Test>
@@ -109,7 +110,7 @@ mod accept_replace_tests {
     use super::*;
 
     fn setup_mocks() {
-        ext::vault_registry::ensure_not_banned::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
+        ext::vault_registry::ensure_not_banned::<Test>.mock_safe(|_| MockResult::Return(Ok(())));
         ext::vault_registry::insert_vault_deposit_address::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
         ext::vault_registry::decrease_to_be_replaced_tokens::<Test>.mock_safe(|_, _| MockResult::Return(Ok((5, 10))));
         ext::vault_registry::try_lock_additional_collateral::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
@@ -170,7 +171,7 @@ mod auction_replace_tests {
 
     fn setup_mocks() {
         ext::vault_registry::is_vault_below_auction_threshold::<Test>.mock_safe(|_| MockResult::Return(Ok(true)));
-        ext::vault_registry::ensure_not_banned::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
+        ext::vault_registry::ensure_not_banned::<Test>.mock_safe(|_| MockResult::Return(Ok(())));
         ext::vault_registry::insert_vault_deposit_address::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
         ext::vault_registry::decrease_to_be_replaced_tokens::<Test>.mock_safe(|_, _| MockResult::Return(Ok((5, 10))));
         ext::collateral::release_collateral::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
@@ -192,7 +193,7 @@ mod auction_replace_tests {
                 10,
                 BtcAddress::default()
             ));
-            assert_event_matches!(Event::AuctionReplace(_, OLD_VAULT, NEW_VAULT, 5, 10, _, _, _, addr) if addr == BtcAddress::default());
+            assert_event_matches!(Event::AuctionReplace(_, OLD_VAULT, NEW_VAULT, 5, 10, _, _, addr) if addr == BtcAddress::default());
         })
     }
 
@@ -209,7 +210,7 @@ mod auction_replace_tests {
                 10,
                 BtcAddress::default()
             ));
-            assert_event_matches!(Event::AuctionReplace(_, OLD_VAULT, NEW_VAULT, 4, 8, _, _, _, addr) if addr == BtcAddress::default());
+            assert_event_matches!(Event::AuctionReplace(_, OLD_VAULT, NEW_VAULT, 4, 8, _, _, addr) if addr == BtcAddress::default());
         })
     }
 
@@ -261,7 +262,7 @@ mod execute_replace_test {
         });
 
         Replace::replace_period.mock_safe(|| MockResult::Return(20));
-        Replace::has_request_expired.mock_safe(|_, _| MockResult::Return(false));
+        ext::security::has_expired::<Test>.mock_safe(|_, _| MockResult::Return(Ok(false)));
         ext::btc_relay::verify_transaction_inclusion::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
         ext::btc_relay::validate_transaction::<Test>
             .mock_safe(|_, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 0))));
@@ -287,7 +288,7 @@ mod execute_replace_test {
     fn test_execute_replace_after_expiry_fails() {
         run_test(|| {
             setup_mocks();
-            Replace::has_request_expired.mock_safe(|_, _| MockResult::Return(true));
+            ext::security::has_expired::<Test>.mock_safe(|_, _| MockResult::Return(Ok(true)));
 
             assert_err!(
                 Replace::_execute_replace(H256::zero(), H256Le::zero(), Vec::new(), Vec::new()),
@@ -309,7 +310,7 @@ mod cancel_replace_tests {
         });
 
         Replace::replace_period.mock_safe(|| MockResult::Return(20));
-        Replace::has_request_expired.mock_safe(|_, _| MockResult::Return(true));
+        ext::security::has_expired::<Test>.mock_safe(|_, _| MockResult::Return(Ok(true)));
         ext::vault_registry::is_vault_liquidated::<Test>.mock_safe(|_| MockResult::Return(Ok(false)));
         ext::vault_registry::cancel_replace_tokens::<Test>.mock_safe(|_, _, _| MockResult::Return(Ok(())));
         ext::vault_registry::slash_collateral::<Test>.mock_safe(|_, _, _| MockResult::Return(Ok(())));
@@ -322,19 +323,6 @@ mod cancel_replace_tests {
             setup_mocks();
             assert_ok!(Replace::_cancel_replace(NEW_VAULT, H256::zero(),));
             assert_event_matches!(Event::CancelReplace(_, NEW_VAULT, OLD_VAULT, _));
-        })
-    }
-
-    #[test]
-    fn test_cancel_replace_after_expiry_fails() {
-        run_test(|| {
-            setup_mocks();
-            Replace::has_request_expired.mock_safe(|_, _| MockResult::Return(false));
-
-            assert_err!(
-                Replace::_cancel_replace(NEW_VAULT, H256::zero(),),
-                TestError::ReplacePeriodNotExpired
-            );
         })
     }
 

--- a/crates/replace/src/types.rs
+++ b/crates/replace/src/types.rs
@@ -1,6 +1,7 @@
 use btc_relay::BtcAddress;
 use codec::{Decode, Encode};
 use frame_support::traits::Currency;
+use security::ActiveBlockNumber;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sp_core::H160;
@@ -14,6 +15,8 @@ pub enum Version {
     V1,
     /// Status, make all fields non-optional, remove open_time
     V2,
+    /// active block number
+    V3,
 }
 
 pub(crate) type DOT<T> = <<T as collateral::Config>::DOT as Currency<<T as frame_system::Config>::AccountId>>::Balance;
@@ -38,6 +41,31 @@ impl Default for ReplaceRequestStatus {
 #[derive(Encode, Decode, Default, Clone, PartialEq)]
 #[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
 pub struct ReplaceRequest<AccountId, BlockNumber, PolkaBTC, DOT> {
+    pub old_vault: AccountId,
+    pub new_vault: AccountId,
+    #[cfg_attr(feature = "std", serde(bound(deserialize = "PolkaBTC: std::str::FromStr")))]
+    #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
+    #[cfg_attr(feature = "std", serde(bound(serialize = "PolkaBTC: std::fmt::Display")))]
+    #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
+    pub amount: PolkaBTC,
+    #[cfg_attr(feature = "std", serde(bound(deserialize = "DOT: std::str::FromStr")))]
+    #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
+    #[cfg_attr(feature = "std", serde(bound(serialize = "DOT: std::fmt::Display")))]
+    #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
+    pub griefing_collateral: DOT,
+    #[cfg_attr(feature = "std", serde(bound(deserialize = "DOT: std::str::FromStr")))]
+    #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
+    #[cfg_attr(feature = "std", serde(bound(serialize = "DOT: std::fmt::Display")))]
+    #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
+    pub collateral: DOT,
+    pub accept_time: ActiveBlockNumber<BlockNumber>,
+    pub btc_address: BtcAddress,
+    pub status: ReplaceRequestStatus,
+}
+
+#[derive(Encode, Decode, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
+pub struct ReplaceRequestV2<AccountId, BlockNumber, PolkaBTC, DOT> {
     pub old_vault: AccountId,
     pub new_vault: AccountId,
     #[cfg_attr(feature = "std", serde(bound(deserialize = "PolkaBTC: std::str::FromStr")))]

--- a/crates/replace/src/types.rs
+++ b/crates/replace/src/types.rs
@@ -14,7 +14,7 @@ pub enum Version {
     V1,
     /// Status, make all fields non-optional, remove open_time
     V2,
-    /// active block number, open_bitcoin_height
+    /// active block number, btc_height
     V3,
 }
 
@@ -60,7 +60,7 @@ pub struct ReplaceRequest<AccountId, BlockNumber, PolkaBTC, DOT> {
     pub accept_time: BlockNumber,
     pub period: BlockNumber,
     pub btc_address: BtcAddress,
-    pub open_bitcoin_height: u32,
+    pub btc_height: u32,
     pub status: ReplaceRequestStatus,
 }
 

--- a/crates/replace/src/types.rs
+++ b/crates/replace/src/types.rs
@@ -59,6 +59,7 @@ pub struct ReplaceRequest<AccountId, BlockNumber, PolkaBTC, DOT> {
     #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
     pub collateral: DOT,
     pub accept_time: ActiveBlockNumber<BlockNumber>,
+    pub period: BlockNumber,
     pub btc_address: BtcAddress,
     pub status: ReplaceRequestStatus,
 }

--- a/crates/replace/src/types.rs
+++ b/crates/replace/src/types.rs
@@ -1,7 +1,6 @@
 use btc_relay::BtcAddress;
 use codec::{Decode, Encode};
 use frame_support::traits::Currency;
-use security::ActiveBlockNumber;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sp_core::H160;
@@ -58,7 +57,7 @@ pub struct ReplaceRequest<AccountId, BlockNumber, PolkaBTC, DOT> {
     #[cfg_attr(feature = "std", serde(bound(serialize = "DOT: std::fmt::Display")))]
     #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
     pub collateral: DOT,
-    pub accept_time: ActiveBlockNumber<BlockNumber>,
+    pub accept_time: BlockNumber,
     pub period: BlockNumber,
     pub btc_address: BtcAddress,
     pub status: ReplaceRequestStatus,

--- a/crates/replace/src/types.rs
+++ b/crates/replace/src/types.rs
@@ -14,7 +14,7 @@ pub enum Version {
     V1,
     /// Status, make all fields non-optional, remove open_time
     V2,
-    /// active block number
+    /// active block number, open_bitcoin_height
     V3,
 }
 
@@ -60,6 +60,7 @@ pub struct ReplaceRequest<AccountId, BlockNumber, PolkaBTC, DOT> {
     pub accept_time: BlockNumber,
     pub period: BlockNumber,
     pub btc_address: BtcAddress,
+    pub open_bitcoin_height: u32,
     pub status: ReplaceRequestStatus,
 }
 

--- a/crates/security/Cargo.toml
+++ b/crates/security/Cargo.toml
@@ -13,6 +13,7 @@ sha2 = { version = "0.8.2", default-features = false }
 # Substrate dependencies
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 

--- a/crates/security/src/lib.rs
+++ b/crates/security/src/lib.rs
@@ -57,7 +57,11 @@ decl_storage! {
         /// for e.g. issue, redeem or replace requests (for OP_RETURN field in Bitcoin).
         Nonce: U256;
 
-        /// like frame_system::block_number, but this one only if the parachain status is RUNNING.
+        /// Like frame_system::block_number, but this one only increments if the parachain status is RUNNING.
+        /// This variable is used to keep track of durations, such as the issue/redeem/replace expiry. If the
+        /// parachain is not RUNNING, no payment proofs can be submitted, and it wouldn't be fair to punish
+        /// the user/vault. By using this variable we ensure that they have sufficient time to submit their
+        /// proof.
         ActiveBlockCount get(fn active_block_number): T::BlockNumber;
     }
 }

--- a/crates/security/src/lib.rs
+++ b/crates/security/src/lib.rs
@@ -5,6 +5,8 @@
 #![cfg_attr(test, feature(proc_macro_hygiene))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use crate::sp_api_hidden_includes_decl_storage::hidden_include::sp_runtime::traits::Saturating;
+
 pub mod types;
 
 #[cfg(test)]
@@ -20,10 +22,12 @@ extern crate mocktopus;
 use mocktopus::macros::mockable;
 
 #[doc(inline)]
-pub use crate::types::{ErrorCode, StatusCode};
+pub use crate::types::{ActiveBlockNumber, ErrorCode, StatusCode};
 
 use codec::Encode;
-use frame_support::{decl_error, decl_event, decl_module, decl_storage, dispatch::DispatchResult, transactional};
+use frame_support::{
+    decl_error, decl_event, decl_module, decl_storage, dispatch::DispatchResult, transactional, weights::Weight,
+};
 use frame_system::ensure_root;
 use primitive_types::H256;
 use sha2::{Digest, Sha256};
@@ -49,6 +53,9 @@ decl_storage! {
         /// Integer increment-only counter, used to prevent collisions when generating identifiers
         /// for e.g. issue, redeem or replace requests (for OP_RETURN field in Bitcoin).
         Nonce: U256;
+
+        /// like frame_system::block_number, but this one only if the parachain status is RUNNING.
+        ActiveBlockCount get(fn active_block_number): ActiveBlockNumber<T::BlockNumber>;
     }
 }
 
@@ -58,6 +65,23 @@ decl_module! {
         type Error = Error<T>;
 
         fn deposit_event() = default;
+
+        /// Upgrade the runtime depending on the current `StorageVersion`.
+        fn on_runtime_upgrade() -> Weight {
+            if !ActiveBlockCount::<T>::exists() {
+                let chain_height = <frame_system::Pallet<T>>::block_number();
+                ActiveBlockCount::<T>::set(ActiveBlockNumber(chain_height));
+            }
+            0
+        }
+
+        fn on_initialize(_chain_height: T::BlockNumber) -> Weight {
+            <ActiveBlockCount<T>>::mutate(|n| {
+                n.0 = n.0.saturating_add(1u32.into());
+            });
+
+            0
+        }
 
         /// Set the parachain status code.
         ///
@@ -226,6 +250,10 @@ impl<T: Config> Module<T> {
         })
     }
 
+    pub fn has_expired(open_time: &ActiveBlockNumber<T::BlockNumber>, period: T::BlockNumber) -> bool {
+        Self::active_block_number().0 > open_time.0 + period
+    }
+
     fn recover_from_(error_codes: Vec<ErrorCode>) {
         for error_code in error_codes.clone() {
             Self::remove_error(error_code);
@@ -276,6 +304,11 @@ impl<T: Config> Module<T> {
         let mut result = [0; 32];
         result.copy_from_slice(&hasher.result()[..]);
         H256(result)
+    }
+
+    /// for testing purposes only!
+    pub fn set_active_block_number(n: T::BlockNumber) {
+        ActiveBlockCount::<T>::set(ActiveBlockNumber(n));
     }
 }
 

--- a/crates/security/src/mock.rs
+++ b/crates/security/src/mock.rs
@@ -81,6 +81,7 @@ where
     clear_mocks();
     ExtBuilder::build().execute_with(|| {
         System::set_block_number(1);
+        Security::set_active_block_number(1);
         test();
     });
 }

--- a/crates/security/src/types.rs
+++ b/crates/security/src/types.rs
@@ -1,6 +1,13 @@
 use codec::{Decode, Encode};
 use sp_std::{cmp::Ord, fmt::Debug};
 
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
+
+#[derive(Encode, Decode, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
+pub struct ActiveBlockNumber<T>(pub T);
+
 /// Enum indicating the status of the BTC Parachain.
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug)]
 pub enum StatusCode {

--- a/crates/security/src/types.rs
+++ b/crates/security/src/types.rs
@@ -1,13 +1,6 @@
 use codec::{Decode, Encode};
 use sp_std::{cmp::Ord, fmt::Debug};
 
-#[cfg(feature = "std")]
-use serde::{Deserialize, Serialize};
-
-#[derive(Encode, Decode, Clone, Default, PartialEq, Eq)]
-#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
-pub struct ActiveBlockNumber<T>(pub T);
-
 /// Enum indicating the status of the BTC Parachain.
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug)]
 pub enum StatusCode {

--- a/crates/sla/src/mock.rs
+++ b/crates/sla/src/mock.rs
@@ -192,6 +192,7 @@ where
     clear_mocks();
     ExtBuilder::build().execute_with(|| {
         System::set_block_number(1);
+        Security::set_active_block_number(1);
         test();
     });
 }

--- a/crates/staked-relayers/src/benchmarking.rs
+++ b/crates/staked-relayers/src/benchmarking.rs
@@ -36,7 +36,7 @@ benchmarks! {
             .with_timestamp(1588813835)
             .mine(U256::from(2).pow(254.into())).unwrap();
         let block_header = RawBlockHeader::from_bytes(&block.header.try_format().unwrap()).unwrap();
-        <ActiveStakedRelayers<T>>::insert(&origin, StakedRelayer { stake: stake.into(), height: System::<T>::block_number() });
+        <ActiveStakedRelayers<T>>::insert(&origin, StakedRelayer { stake: stake.into(), height: Security::active_block_number() });
     }: _(RawOrigin::Signed(origin), block_header, height.into())
 
     store_block_header {
@@ -56,7 +56,7 @@ benchmarks! {
         let raw_block_header = RawBlockHeader::from_bytes(&init_block.header.try_format().unwrap())
             .expect("could not serialize block header");
 
-            <ActiveStakedRelayers<T>>::insert(&origin, StakedRelayer { stake: stake.into(), height: System::<T>::block_number() });
+            <ActiveStakedRelayers<T>>::insert(&origin, StakedRelayer { stake: stake.into(), height: Security::active_block_number() });
 
         BtcRelay::<T>::initialize(origin.clone(), raw_block_header, height).unwrap();
 
@@ -83,7 +83,7 @@ benchmarks! {
     deregister_staked_relayer {
         let origin: T::AccountId = account("Origin", 0, 0);
         let stake: u32 = 100;
-        <ActiveStakedRelayers<T>>::insert(&origin, StakedRelayer { stake: stake.into(), height: System::<T>::block_number() });
+        <ActiveStakedRelayers<T>>::insert(&origin, StakedRelayer { stake: stake.into(), height: Security::active_block_number() });
         Collateral::<T>::lock_collateral(&origin, stake.into()).unwrap();
     }: _(RawOrigin::Signed(origin))
 
@@ -92,13 +92,13 @@ benchmarks! {
         let stake: u32 = 100;
         let deposit: u32 = 1000;
         let status_code = StatusCode::Error;
-        StakedRelayers::<T>::insert_active_staked_relayer(&origin, stake.into(), System::<T>::block_number());
+        StakedRelayers::<T>::insert_active_staked_relayer(&origin, stake.into(), Security::active_block_number());
     }: _(RawOrigin::Signed(origin), deposit.into(), status_code, None, None, None, vec![])
 
     vote_on_status_update {
         let origin: T::AccountId = account("Origin", 0, 0);
         let stake: u32 = 100;
-        StakedRelayers::<T>::insert_active_staked_relayer(&origin, stake.into(), System::<T>::block_number());
+        StakedRelayers::<T>::insert_active_staked_relayer(&origin, stake.into(), Security::active_block_number());
         let status_update = StatusUpdate::default();
         let status_update_id = StakedRelayers::<T>::insert_active_status_update(status_update);
     }: _(RawOrigin::Signed(origin), status_update_id, true)
@@ -112,7 +112,7 @@ benchmarks! {
         let origin: T::AccountId = account("Origin", 0, 0);
         let staked_relayer: T::AccountId = account("Vault", 0, 0);
         let stake: u32 = 100;
-        StakedRelayers::<T>::insert_active_staked_relayer(&staked_relayer, stake.into(), System::<T>::block_number());
+        StakedRelayers::<T>::insert_active_staked_relayer(&staked_relayer, stake.into(), Security::active_block_number());
         Collateral::<T>::lock_collateral(&staked_relayer, stake.into()).unwrap();
 
     }: _(RawOrigin::Signed(origin), staked_relayer)
@@ -122,7 +122,7 @@ benchmarks! {
         let relayer_id: T::AccountId = account("Relayer", 0, 0);
 
         let stake: u32 = 100;
-        StakedRelayers::<T>::insert_active_staked_relayer(&origin, stake.into(), System::<T>::block_number());
+        StakedRelayers::<T>::insert_active_staked_relayer(&origin, stake.into(), Security::active_block_number());
 
         let vault_address = BtcAddress::P2PKH(H160::from_slice(&[
             126, 125, 148, 208, 221, 194, 29, 131, 191, 188, 252, 119, 152, 228, 84, 126, 223, 8,

--- a/crates/staked-relayers/src/benchmarking.rs
+++ b/crates/staked-relayers/src/benchmarking.rs
@@ -7,7 +7,8 @@ use bitcoin::{
 use btc_relay::{BtcAddress, BtcPublicKey, Module as BtcRelay};
 use collateral::Module as Collateral;
 use frame_benchmarking::{account, benchmarks};
-use frame_system::{Pallet as System, RawOrigin};
+use frame_system::RawOrigin;
+use security::Module as Security;
 use sp_core::{H160, U256};
 use sp_std::prelude::*;
 use vault_registry::{
@@ -36,7 +37,7 @@ benchmarks! {
             .with_timestamp(1588813835)
             .mine(U256::from(2).pow(254.into())).unwrap();
         let block_header = RawBlockHeader::from_bytes(&block.header.try_format().unwrap()).unwrap();
-        <ActiveStakedRelayers<T>>::insert(&origin, StakedRelayer { stake: stake.into(), height: Security::active_block_number() });
+        <ActiveStakedRelayers<T>>::insert(&origin, StakedRelayer { stake: stake.into(), height: Security::<T>::active_block_number() });
     }: _(RawOrigin::Signed(origin), block_header, height.into())
 
     store_block_header {
@@ -56,7 +57,7 @@ benchmarks! {
         let raw_block_header = RawBlockHeader::from_bytes(&init_block.header.try_format().unwrap())
             .expect("could not serialize block header");
 
-            <ActiveStakedRelayers<T>>::insert(&origin, StakedRelayer { stake: stake.into(), height: Security::active_block_number() });
+            <ActiveStakedRelayers<T>>::insert(&origin, StakedRelayer { stake: stake.into(), height: Security::<T>::active_block_number() });
 
         BtcRelay::<T>::initialize(origin.clone(), raw_block_header, height).unwrap();
 
@@ -83,7 +84,7 @@ benchmarks! {
     deregister_staked_relayer {
         let origin: T::AccountId = account("Origin", 0, 0);
         let stake: u32 = 100;
-        <ActiveStakedRelayers<T>>::insert(&origin, StakedRelayer { stake: stake.into(), height: Security::active_block_number() });
+        <ActiveStakedRelayers<T>>::insert(&origin, StakedRelayer { stake: stake.into(), height: Security::<T>::active_block_number() });
         Collateral::<T>::lock_collateral(&origin, stake.into()).unwrap();
     }: _(RawOrigin::Signed(origin))
 
@@ -92,13 +93,13 @@ benchmarks! {
         let stake: u32 = 100;
         let deposit: u32 = 1000;
         let status_code = StatusCode::Error;
-        StakedRelayers::<T>::insert_active_staked_relayer(&origin, stake.into(), Security::active_block_number());
+        StakedRelayers::<T>::insert_active_staked_relayer(&origin, stake.into(), Security::<T>::active_block_number());
     }: _(RawOrigin::Signed(origin), deposit.into(), status_code, None, None, None, vec![])
 
     vote_on_status_update {
         let origin: T::AccountId = account("Origin", 0, 0);
         let stake: u32 = 100;
-        StakedRelayers::<T>::insert_active_staked_relayer(&origin, stake.into(), Security::active_block_number());
+        StakedRelayers::<T>::insert_active_staked_relayer(&origin, stake.into(), Security::<T>::active_block_number());
         let status_update = StatusUpdate::default();
         let status_update_id = StakedRelayers::<T>::insert_active_status_update(status_update);
     }: _(RawOrigin::Signed(origin), status_update_id, true)
@@ -112,7 +113,7 @@ benchmarks! {
         let origin: T::AccountId = account("Origin", 0, 0);
         let staked_relayer: T::AccountId = account("Vault", 0, 0);
         let stake: u32 = 100;
-        StakedRelayers::<T>::insert_active_staked_relayer(&staked_relayer, stake.into(), Security::active_block_number());
+        StakedRelayers::<T>::insert_active_staked_relayer(&staked_relayer, stake.into(), Security::<T>::active_block_number());
         Collateral::<T>::lock_collateral(&staked_relayer, stake.into()).unwrap();
 
     }: _(RawOrigin::Signed(origin), staked_relayer)
@@ -122,7 +123,7 @@ benchmarks! {
         let relayer_id: T::AccountId = account("Relayer", 0, 0);
 
         let stake: u32 = 100;
-        StakedRelayers::<T>::insert_active_staked_relayer(&origin, stake.into(), Security::active_block_number());
+        StakedRelayers::<T>::insert_active_staked_relayer(&origin, stake.into(), Security::<T>::active_block_number());
 
         let vault_address = BtcAddress::P2PKH(H160::from_slice(&[
             126, 125, 148, 208, 221, 194, 29, 131, 191, 188, 252, 119, 152, 228, 84, 126, 223, 8,

--- a/crates/staked-relayers/src/ext.rs
+++ b/crates/staked-relayers/src/ext.rs
@@ -71,6 +71,10 @@ pub(crate) mod security {
     pub(crate) fn get_errors<T: security::Config>() -> BTreeSet<ErrorCode> {
         <security::Module<T>>::get_errors()
     }
+
+    pub fn active_block_number<T: security::Config>() -> T::BlockNumber {
+        <security::Module<T>>::active_block_number()
+    }
 }
 
 #[cfg_attr(test, mockable)]

--- a/crates/staked-relayers/src/lib.rs
+++ b/crates/staked-relayers/src/lib.rs
@@ -211,7 +211,7 @@ decl_module! {
             ext::collateral::lock_collateral::<T>(&signer, stake)?;
             ext::sla::initialize_relayer_stake::<T>(&signer, stake)?;
 
-            let height = <frame_system::Pallet<T>>::block_number();
+            let height = ext::security::active_block_number::<T>();
             let maturity = height + Self::get_maturity_period();
             Self::insert_inactive_staked_relayer(&signer, stake, maturity);
             Self::deposit_event(<Event<T>>::RegisterStakedRelayer(signer, maturity, stake));
@@ -364,7 +364,7 @@ decl_module! {
             let mut tally = Tally::default();
             tally.aye.insert(signer.clone(), staked_relayer.stake);
 
-            let height = <frame_system::Pallet<T>>::block_number();
+            let height = ext::security::active_block_number::<T>();
             let status_update_id = Self::insert_active_status_update(StatusUpdate{
                 new_status_code: status_code.clone(),
                 old_status_code: ext::security::get_parachain_status::<T>(),
@@ -679,7 +679,7 @@ impl<T: Config> Module<T> {
     /// * `id` - AccountId of the caller.
     pub fn activate_staked_relayer(id: &T::AccountId) -> DispatchResult {
         let staked_relayer = Self::get_inactive_staked_relayer(id)?;
-        let height = <frame_system::Pallet<T>>::block_number();
+        let height = ext::security::active_block_number::<T>();
         Self::try_bond_staked_relayer(id, staked_relayer.stake, height, staked_relayer.height)?;
         Ok(())
     }

--- a/crates/staked-relayers/src/mock.rs
+++ b/crates/staked-relayers/src/mock.rs
@@ -282,6 +282,7 @@ where
     clear_mocks();
     ExtBuilder::build().execute_with(|| {
         System::set_block_number(1);
+        Security::set_active_block_number(1);
         test();
     });
 }

--- a/crates/staked-relayers/src/tests.rs
+++ b/crates/staked-relayers/src/tests.rs
@@ -1080,7 +1080,7 @@ fn test_is_transaction_invalid_fails_with_valid_request_or_redeem() {
                 premium_dot: 0,
                 redeemer: ALICE,
                 btc_address: recipient_address,
-                open_bitcoin_height: 0,
+                btc_height: 0,
                 status: RedeemRequestStatus::Pending,
             }))
         });
@@ -1133,7 +1133,7 @@ fn test_is_transaction_invalid_fails_with_valid_request_or_redeem() {
                 collateral: 0,
                 accept_time: 1,
                 btc_address: recipient_address,
-                open_bitcoin_height: 0,
+                btc_height: 0,
                 status: ReplaceRequestStatus::Pending,
             }))
         });

--- a/crates/staked-relayers/src/tests.rs
+++ b/crates/staked-relayers/src/tests.rs
@@ -1072,6 +1072,7 @@ fn test_is_transaction_invalid_fails_with_valid_request_or_redeem() {
 
         ext::redeem::get_open_or_completed_redeem_request_from_id::<Test>.mock_safe(move |_| {
             MockResult::Return(Ok(RedeemRequest {
+                period: 0,
                 vault: BOB,
                 opentime: 0,
                 fee: 0,
@@ -1123,6 +1124,7 @@ fn test_is_transaction_invalid_fails_with_valid_request_or_redeem() {
 
         ext::replace::get_open_or_completed_replace_request::<Test>.mock_safe(move |_| {
             MockResult::Return(Ok(ReplaceRequest {
+                period: 0,
                 old_vault: BOB,
                 amount: 100,
                 griefing_collateral: 0,

--- a/crates/staked-relayers/src/tests.rs
+++ b/crates/staked-relayers/src/tests.rs
@@ -1080,6 +1080,7 @@ fn test_is_transaction_invalid_fails_with_valid_request_or_redeem() {
                 premium_dot: 0,
                 redeemer: ALICE,
                 btc_address: recipient_address,
+                open_bitcoin_height: 0,
                 status: RedeemRequestStatus::Pending,
             }))
         });
@@ -1132,6 +1133,7 @@ fn test_is_transaction_invalid_fails_with_valid_request_or_redeem() {
                 collateral: 0,
                 accept_time: 1,
                 btc_address: recipient_address,
+                open_bitcoin_height: 0,
                 status: ReplaceRequestStatus::Pending,
             }))
         });

--- a/crates/vault-registry/src/ext.rs
+++ b/crates/vault-registry/src/ext.rs
@@ -74,4 +74,8 @@ pub(crate) mod security {
     pub fn ensure_parachain_does_not_have_errors<T: security::Config>(error_codes: Vec<ErrorCode>) -> DispatchResult {
         <security::Module<T>>::ensure_parachain_does_not_have_errors(error_codes)
     }
+
+    pub fn active_block_number<T: security::Config>() -> T::BlockNumber {
+        <security::Module<T>>::active_block_number()
+    }
 }

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -988,15 +988,15 @@ impl<T: Config> Module<T> {
     }
 
     pub fn ban_vault(vault_id: T::AccountId) -> DispatchResult {
-        let height = <frame_system::Pallet<T>>::block_number();
+        let height = ext::security::active_block_number::<T>();
         let mut vault = Self::get_active_rich_vault_from_id(&vault_id)?;
         vault.ban_until(height + Self::punishment_delay());
         Ok(())
     }
 
-    pub fn _ensure_not_banned(vault_id: &T::AccountId, height: T::BlockNumber) -> DispatchResult {
+    pub fn _ensure_not_banned(vault_id: &T::AccountId) -> DispatchResult {
         let vault = Self::get_active_rich_vault_from_id(&vault_id)?;
-        vault.ensure_not_banned(height)
+        vault.ensure_not_banned()
     }
 
     /// Threshold checks

--- a/crates/vault-registry/src/mock.rs
+++ b/crates/vault-registry/src/mock.rs
@@ -211,6 +211,7 @@ where
     ext::oracle::btc_to_dots::<Test>.mock_safe(|v| MockResult::Return(Ok(v)));
     ExtBuilder::build().execute_with(|| {
         System::set_block_number(1);
+        Security::set_active_block_number(1);
         test()
     })
 }

--- a/crates/vault-registry/src/tests.rs
+++ b/crates/vault-registry/src/tests.rs
@@ -12,11 +12,11 @@ use crate::{
 use frame_support::{assert_err, assert_noop, assert_ok, StorageMap};
 use mocktopus::mocking::*;
 use primitive_types::U256;
+use security::Module as Security;
 use sp_arithmetic::{FixedPointNumber, FixedU128};
 use sp_runtime::traits::Header;
 use sp_std::convert::TryInto;
 use std::{collections::HashMap, rc::Rc};
-
 type Event = crate::Event<Test>;
 
 // use macro to avoid messing up stack trace
@@ -1424,7 +1424,7 @@ fn setup_block(i: u64, parent_hash: H256) -> H256 {
     <pallet_randomness_collective_flip::Module<Test>>::on_initialize(i);
 
     let header = System::finalize();
-    System::set_block_number(*header.number());
+    Security::<Test>::set_active_block_number(*header.number());
     header.hash()
 }
 

--- a/crates/vault-registry/src/types.rs
+++ b/crates/vault-registry/src/types.rs
@@ -391,7 +391,7 @@ impl<T: Config> RichVault<T> {
 
     pub fn issuable_tokens(&self) -> Result<PolkaBTC<T>, DispatchError> {
         // unable to issue additional tokens when banned
-        if self.is_banned(<frame_system::Pallet<T>>::block_number()) {
+        if self.is_banned(ext::security::active_block_number::<T>()) {
             return Ok(0u32.into());
         }
 
@@ -407,7 +407,7 @@ impl<T: Config> RichVault<T> {
 
     pub fn redeemable_tokens(&self) -> Result<PolkaBTC<T>, DispatchError> {
         // unable to redeem additional tokens when banned
-        if self.is_banned(<frame_system::Pallet<T>>::block_number()) {
+        if self.is_banned(ext::security::active_block_number::<T>()) {
             return Ok(0u32.into());
         }
 

--- a/crates/vault-registry/src/types.rs
+++ b/crates/vault-registry/src/types.rs
@@ -391,7 +391,7 @@ impl<T: Config> RichVault<T> {
 
     pub fn issuable_tokens(&self) -> Result<PolkaBTC<T>, DispatchError> {
         // unable to issue additional tokens when banned
-        if self.is_banned(ext::security::active_block_number::<T>()) {
+        if self.is_banned() {
             return Ok(0u32.into());
         }
 
@@ -407,7 +407,7 @@ impl<T: Config> RichVault<T> {
 
     pub fn redeemable_tokens(&self) -> Result<PolkaBTC<T>, DispatchError> {
         // unable to redeem additional tokens when banned
-        if self.is_banned(ext::security::active_block_number::<T>()) {
+        if self.is_banned() {
             return Ok(0u32.into());
         }
 
@@ -494,18 +494,18 @@ impl<T: Config> RichVault<T> {
         Ok(())
     }
 
-    pub fn ensure_not_banned(&self, height: T::BlockNumber) -> DispatchResult {
-        if self.is_banned(height) {
+    pub fn ensure_not_banned(&self) -> DispatchResult {
+        if self.is_banned() {
             Err(Error::<T>::VaultBanned.into())
         } else {
             Ok(())
         }
     }
 
-    pub(crate) fn is_banned(&self, height: T::BlockNumber) -> bool {
+    pub(crate) fn is_banned(&self) -> bool {
         match self.data.banned_until {
             None => false,
-            Some(until) => height <= until,
+            Some(until) => ext::security::active_block_number::<T>() <= until,
         }
     }
 

--- a/parachain/runtime/tests/mock/issue_testing_utils.rs
+++ b/parachain/runtime/tests/mock/issue_testing_utils.rs
@@ -101,7 +101,7 @@ impl ExecuteIssueBuilder {
             .with_relayer(self.relayer)
             .mine();
 
-        SystemModule::set_block_number(1 + CONFIRMATIONS);
+        SecurityModule::set_active_block_number(1 + CONFIRMATIONS);
 
         if self.register_submitter_as_vault {
             try_register_vault(DEFAULT_COLLATERAL, self.submitter);
@@ -154,7 +154,7 @@ pub fn execute_refund(vault_id: [u8; 32]) -> (H256, RefundRequest<AccountId, u12
     let (tx_id, _height, proof, raw_tx) =
         generate_transaction_and_mine(refund_address, refund.amount_polka_btc, Some(refund_id));
 
-    SystemModule::set_block_number((1 + CONFIRMATIONS) * 2);
+    SecurityModule::set_active_block_number((1 + CONFIRMATIONS) * 2);
 
     assert_ok!(
         Call::Refund(RefundCall::execute_refund(refund_id, tx_id, proof, raw_tx))
@@ -166,7 +166,7 @@ pub fn execute_refund(vault_id: [u8; 32]) -> (H256, RefundRequest<AccountId, u12
 
 pub fn cancel_issue(issue_id: H256, vault: [u8; 32]) {
     // expire request without transferring btc
-    SystemModule::set_block_number(IssueModule::issue_period() + 1 + 1);
+    SecurityModule::set_active_block_number(IssueModule::issue_period() + 1 + 1);
 
     // cancel issue request
     assert_ok!(Call::Issue(IssueCall::cancel_issue(issue_id)).dispatch(origin_of(account_of(vault))));

--- a/parachain/runtime/tests/mock/mod.rs
+++ b/parachain/runtime/tests/mock/mod.rs
@@ -7,7 +7,7 @@ pub use bitcoin::{
 };
 pub use btc_parachain_runtime::{AccountId, Call, Event, Runtime};
 pub use btc_relay::{BtcAddress, BtcPublicKey};
-pub use frame_support::{assert_noop, assert_ok, dispatch::DispatchResultWithPostInfo};
+pub use frame_support::{assert_err, assert_noop, assert_ok, dispatch::DispatchResultWithPostInfo};
 pub use mocktopus::mocking::*;
 pub use primitive_types::{H256, U256};
 pub use security::{ErrorCode, StatusCode};
@@ -18,6 +18,7 @@ pub use sp_std::convert::TryInto;
 pub use vault_registry::CurrencySource;
 
 pub use issue::IssueRequest;
+pub use redeem::RedeemRequest;
 pub use refund::RefundRequest;
 pub use replace::ReplaceRequest;
 pub use sp_runtime::AccountId32;
@@ -108,6 +109,10 @@ pub fn default_vault_state() -> CoreVaultData {
         replace_collateral: DEFAULT_VAULT_REPLACE_COLLATERAL,
         to_be_replaced: DEFAULT_VAULT_TO_BE_REPLACED,
     }
+}
+
+pub fn root() -> <Runtime as frame_system::Config>::Origin {
+    <Runtime as frame_system::Config>::Origin::root()
 }
 
 pub fn origin_of(account_id: AccountId) -> <Runtime as frame_system::Config>::Origin {

--- a/parachain/runtime/tests/mock/redeem_testing_utils.rs
+++ b/parachain/runtime/tests/mock/redeem_testing_utils.rs
@@ -8,7 +8,7 @@ pub fn setup_cancelable_redeem(user: [u8; 32], vault: [u8; 32], collateral: u128
     let redeem_id = setup_redeem(polka_btc, user, vault, collateral);
 
     // expire request without transferring btc
-    SystemModule::set_block_number(RedeemModule::redeem_period() + 1 + 1);
+    SecurityModule::set_active_block_number(RedeemModule::redeem_period() + 1 + 1);
 
     // bob cannot execute past expiry
     assert_noop!(
@@ -57,7 +57,7 @@ pub fn execute_redeem(polka_btc: u128, redeem_id: H256) {
     let (tx_id, _tx_block_height, merkle_proof, raw_tx) =
         generate_transaction_and_mine(USER_BTC_ADDRESS, polka_btc, Some(redeem_id));
 
-    SystemModule::set_block_number(1 + CONFIRMATIONS);
+    SecurityModule::set_active_block_number(1 + CONFIRMATIONS);
 
     assert_ok!(
         Call::Redeem(RedeemCall::execute_redeem(redeem_id, tx_id, merkle_proof, raw_tx))

--- a/parachain/runtime/tests/mock/redeem_testing_utils.rs
+++ b/parachain/runtime/tests/mock/redeem_testing_utils.rs
@@ -1,8 +1,58 @@
 use crate::*;
+use frame_support::transactional;
 
 pub const USER: [u8; 32] = ALICE;
 pub const VAULT: [u8; 32] = BOB;
 pub const USER_BTC_ADDRESS: BtcAddress = BtcAddress::P2PKH(H160([2u8; 20]));
+
+pub struct ExecuteRedeemBuilder {
+    redeem_id: H256,
+    redeem: RedeemRequest<AccountId32, u32, u128, u128>,
+    amount: u128,
+    submitter: AccountId32,
+}
+
+impl ExecuteRedeemBuilder {
+    pub fn new(redeem_id: H256) -> Self {
+        let redeem = RedeemModule::get_open_redeem_request_from_id(&redeem_id).unwrap();
+        Self {
+            redeem_id,
+            redeem: redeem.clone(),
+            amount: redeem.fee + redeem.amount_btc,
+            submitter: redeem.redeemer,
+        }
+    }
+
+    pub fn with_amount(&mut self, amount: u128) -> &mut Self {
+        self.amount = amount;
+        self
+    }
+
+    pub fn with_submitter(&mut self, submitter: [u8; 32]) -> &mut Self {
+        self.submitter = account_of(submitter);
+        self
+    }
+
+    #[transactional]
+    pub fn execute(&self) -> DispatchResultWithPostInfo {
+        // send the btc from the user to the vault
+        let (tx_id, _height, proof, raw_tx) = TransactionGenerator::new()
+            .with_address(self.redeem.btc_address.clone())
+            .with_amount(self.amount)
+            .with_op_return(Some(self.redeem_id))
+            .mine();
+
+        SecurityModule::set_active_block_number(SecurityModule::active_block_number() + CONFIRMATIONS);
+
+        // alice executes the redeemrequest by confirming the btc transaction
+        Call::Redeem(RedeemCall::execute_redeem(self.redeem_id, tx_id, proof, raw_tx))
+            .dispatch(origin_of(self.submitter.clone()))
+    }
+
+    pub fn assert_execute(&self) {
+        assert_ok!(self.execute());
+    }
+}
 
 pub fn setup_cancelable_redeem(user: [u8; 32], vault: [u8; 32], collateral: u128, polka_btc: u128) -> H256 {
     let redeem_id = setup_redeem(polka_btc, user, vault, collateral);
@@ -52,17 +102,8 @@ pub fn assert_redeem_request_event() -> H256 {
     ids[0].clone()
 }
 
-pub fn execute_redeem(polka_btc: u128, redeem_id: H256) {
-    // send the btc from the vault to the user
-    let (tx_id, _tx_block_height, merkle_proof, raw_tx) =
-        generate_transaction_and_mine(USER_BTC_ADDRESS, polka_btc, Some(redeem_id));
-
-    SecurityModule::set_active_block_number(1 + CONFIRMATIONS);
-
-    assert_ok!(
-        Call::Redeem(RedeemCall::execute_redeem(redeem_id, tx_id, merkle_proof, raw_tx))
-            .dispatch(origin_of(account_of(VAULT)))
-    );
+pub fn execute_redeem(redeem_id: H256) {
+    ExecuteRedeemBuilder::new(redeem_id).assert_execute();
 }
 
 pub fn cancel_redeem(redeem_id: H256, redeemer: [u8; 32], reimburse: bool) {

--- a/parachain/runtime/tests/test_btc_relay.rs
+++ b/parachain/runtime/tests/test_btc_relay.rs
@@ -12,7 +12,7 @@ fn integration_test_submit_block_headers_and_verify_transaction_inclusion() {
         // load blocks with transactions
         let test_data = get_bitcoin_testdata();
 
-        SystemModule::set_block_number(1);
+        SecurityModule::set_active_block_number(1);
 
         // store all block headers. parachain_genesis is the first block
         // known in the parachain. Any block before will be rejected
@@ -34,7 +34,7 @@ fn integration_test_submit_block_headers_and_verify_transaction_inclusion() {
 
             assert_store_main_chain_header_event(block.height, block.get_block_hash(), account_of(ALICE));
         }
-        SystemModule::set_block_number(1 + CONFIRMATIONS);
+        SecurityModule::set_active_block_number(1 + CONFIRMATIONS);
         // verify all transaction
         let current_height = btc_relay::Module::<Runtime>::get_best_block_height();
         for block in test_data.iter() {

--- a/parachain/runtime/tests/test_fee_pool.rs
+++ b/parachain/runtime/tests/test_fee_pool.rs
@@ -13,13 +13,13 @@ const RELAYER_2: [u8; 32] = GRACE;
 
 fn test_with(execute: impl Fn(Currency) -> ()) {
     ExtBuilder::build().execute_with(|| {
-        SystemModule::set_block_number(1);
+        SecurityModule::set_active_block_number(1);
         assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
         setup_dot_reward();
         execute(Currency::DOT);
     });
     ExtBuilder::build().execute_with(|| {
-        SystemModule::set_block_number(1);
+        SecurityModule::set_active_block_number(1);
         assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
         execute(Currency::PolkaBTC);
     });
@@ -111,7 +111,7 @@ fn setup_dot_reward() {
 }
 
 fn set_issued_and_backing(vault: [u8; 32], amount_issued: u128, backing: u128) {
-    SystemModule::set_block_number(1);
+    SecurityModule::set_active_block_number(1);
 
     // we want issued to be 100 times amount_issued, _including fees_
     let request_amount = 100 * amount_issued;

--- a/parachain/runtime/tests/test_issue.rs
+++ b/parachain/runtime/tests/test_issue.rs
@@ -5,7 +5,7 @@ use mock::{issue_testing_utils::*, *};
 
 fn test_with<R>(execute: impl FnOnce() -> R) -> R {
     ExtBuilder::build().execute_with(|| {
-        SystemModule::set_block_number(1);
+        SecurityModule::set_active_block_number(1);
         assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
         UserData::force_to(USER, default_user_state());
         execute()
@@ -128,7 +128,7 @@ fn integration_test_issue_polka_btc_execute_succeeds() {
         // send the btc from the user to the vault
         let (tx_id, _height, proof, raw_tx) = generate_transaction_and_mine(vault_btc_address, total_amount_btc, None);
 
-        SystemModule::set_block_number(1 + CONFIRMATIONS);
+        SecurityModule::set_active_block_number(1 + CONFIRMATIONS);
 
         // alice executes the issue by confirming the btc transaction
         assert_ok!(Call::Issue(IssueCall::execute_issue(issue_id, tx_id, proof, raw_tx))
@@ -324,7 +324,7 @@ fn integration_test_issue_polka_btc_cancel() {
         // random non-zero starting state
         let (issue_id, issue) = RequestIssueBuilder::new(10_000).request();
 
-        SystemModule::set_block_number(IssueModule::issue_period() + 1 + 1);
+        SecurityModule::set_active_block_number(IssueModule::issue_period() + 1 + 1);
 
         // alice cannot execute past expiry
         assert_noop!(
@@ -356,7 +356,7 @@ fn integration_test_issue_polka_btc_cancel_liquidated() {
     test_with_initialized_vault(|| {
         let (issue_id, issue) = RequestIssueBuilder::new(10_000).request();
 
-        SystemModule::set_block_number(IssueModule::issue_period() + 1 + 1);
+        SecurityModule::set_active_block_number(IssueModule::issue_period() + 1 + 1);
 
         // alice cannot execute past expiry
         assert_noop!(

--- a/parachain/runtime/tests/test_redeem.rs
+++ b/parachain/runtime/tests/test_redeem.rs
@@ -109,6 +109,85 @@ mod request_redeem_tests {
     }
 }
 
+mod expiry_test {
+    use super::*;
+
+    fn set_redeem_period(period: u32) {
+        assert_ok!(Call::Redeem(RedeemCall::set_redeem_period(period)).dispatch(root()));
+    }
+
+    fn request_redeem() -> H256 {
+        assert_ok!(Call::Redeem(RedeemCall::request_redeem(
+            4_000,
+            BtcAddress::default(),
+            account_of(VAULT)
+        ))
+        .dispatch(origin_of(account_of(USER))));
+        // get the redeem id
+        assert_redeem_request_event()
+    }
+
+    fn execute_redeem(redeem_id: H256) -> DispatchResultWithPostInfo {
+        ExecuteRedeemBuilder::new(redeem_id).execute()
+    }
+
+    fn cancel_redeem(redeem_id: H256) -> DispatchResultWithPostInfo {
+        Call::Redeem(RedeemCall::cancel_redeem(redeem_id, true)).dispatch(origin_of(account_of(USER)))
+    }
+
+    #[test]
+    fn integration_test_redeem_expiry_no_period_change_pre_expiry() {
+        test_with(|| {
+            set_redeem_period(100);
+            let redeem_id = request_redeem();
+            SecurityModule::set_active_block_number(75);
+
+            assert_noop!(cancel_redeem(redeem_id), RedeemError::TimeNotExpired);
+            assert_ok!(execute_redeem(redeem_id));
+        });
+    }
+
+    #[test]
+    fn integration_test_redeem_expiry_no_period_change_post_expiry() {
+        test_with(|| {
+            set_redeem_period(100);
+            let redeem_id = request_redeem();
+            SecurityModule::set_active_block_number(110);
+
+            assert_noop!(execute_redeem(redeem_id), RedeemError::CommitPeriodExpired);
+            assert_ok!(cancel_redeem(redeem_id));
+        });
+    }
+
+    #[test]
+    fn integration_test_redeem_expiry_with_period_decrease() {
+        test_with(|| {
+            set_redeem_period(200);
+            let redeem_id = request_redeem();
+            SecurityModule::set_active_block_number(110);
+            set_redeem_period(100);
+
+            // request still uses period = 200, so cancel fails and execute succeeds
+            assert_noop!(cancel_redeem(redeem_id), RedeemError::TimeNotExpired);
+            assert_ok!(execute_redeem(redeem_id));
+        });
+    }
+
+    #[test]
+    fn integration_test_redeem_expiry_with_period_increase() {
+        test_with(|| {
+            set_redeem_period(100);
+            let redeem_id = request_redeem();
+            SecurityModule::set_active_block_number(110);
+            set_redeem_period(200);
+
+            // request uses period = 200, so execute succeeds and cancel fails
+            assert_noop!(cancel_redeem(redeem_id), RedeemError::TimeNotExpired);
+            assert_ok!(execute_redeem(redeem_id));
+        });
+    }
+}
+
 #[test]
 fn integration_test_redeem_polka_btc_execute() {
     test_with(|| {
@@ -118,7 +197,7 @@ fn integration_test_redeem_polka_btc_execute() {
         let redeem_id = setup_redeem(polka_btc, USER, VAULT, collateral_vault);
         let redeem = RedeemModule::get_open_redeem_request_from_id(&redeem_id).unwrap();
 
-        execute_redeem(polka_btc, redeem_id);
+        execute_redeem(redeem_id);
 
         assert_eq!(
             ParachainState::get(),
@@ -506,7 +585,7 @@ fn integration_test_redeem_polka_btc_execute_liquidated() {
 
         let post_liquidation_state = ParachainState::get();
 
-        execute_redeem(polka_btc, redeem_id);
+        execute_redeem(redeem_id);
 
         // NOTE: changes are relative the the post liquidation state
         assert_eq!(

--- a/parachain/runtime/tests/test_redeem.rs
+++ b/parachain/runtime/tests/test_redeem.rs
@@ -4,7 +4,7 @@ use mock::{redeem_testing_utils::*, *};
 
 fn test_with<R>(execute: impl FnOnce() -> R) -> R {
     ExtBuilder::build().execute_with(|| {
-        SystemModule::set_block_number(1);
+        SecurityModule::set_active_block_number(1);
         assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
         set_default_thresholds();
         UserData::force_to(USER, default_user_state());
@@ -159,7 +159,7 @@ fn integration_test_premium_redeem_polka_btc_execute() {
         let (tx_id, _tx_block_height, merkle_proof, raw_tx) =
             generate_transaction_and_mine(user_btc_address, polka_btc, Some(redeem_id));
 
-        SystemModule::set_block_number(1 + CONFIRMATIONS);
+        SecurityModule::set_active_block_number(1 + CONFIRMATIONS);
 
         assert_ok!(
             Call::Redeem(RedeemCall::execute_redeem(redeem_id, tx_id, merkle_proof, raw_tx))
@@ -319,7 +319,7 @@ fn integration_test_redeem_polka_btc_cancel_reimburse_insufficient_collateral_fo
             })
         );
 
-        SystemModule::set_block_number(100000000);
+        SecurityModule::set_active_block_number(100000000);
         CoreVaultData::force_to(
             VAULT,
             CoreVaultData {
@@ -608,7 +608,7 @@ fn integration_test_redeem_banning() {
         );
 
         // check that the ban is not permanent
-        SystemModule::set_block_number(100000000);
+        SecurityModule::set_active_block_number(100000000);
         assert_ok!(
             Call::Issue(IssueCall::request_issue(50, account_of(VAULT), 50)).dispatch(origin_of(account_of(USER)))
         );

--- a/parachain/runtime/tests/test_replace.rs
+++ b/parachain/runtime/tests/test_replace.rs
@@ -17,7 +17,6 @@ pub const DEFAULT_GRIEFING_COLLATERAL: u128 = 5_000;
 
 fn test_with<R>(execute: impl FnOnce() -> R) -> R {
     ExtBuilder::build().execute_with(|| {
-        SecurityModule::set_active_block_number(1);
         assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
         set_default_thresholds();
         UserData::force_to(USER, default_user_state());

--- a/parachain/runtime/tests/test_replace.rs
+++ b/parachain/runtime/tests/test_replace.rs
@@ -17,7 +17,6 @@ pub const DEFAULT_GRIEFING_COLLATERAL: u128 = 5_000;
 
 fn test_with<R>(execute: impl FnOnce() -> R) -> R {
     ExtBuilder::build().execute_with(|| {
-        SystemModule::set_block_number(1);
         SecurityModule::set_active_block_number(1);
         assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
         set_default_thresholds();
@@ -683,7 +682,6 @@ fn integration_test_replace_execute_replace() {
     ExtBuilder::build().execute_with(|| {
         assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
         set_default_thresholds();
-        SystemModule::set_block_number(1);
         SecurityModule::set_active_block_number(1);
 
         let user = CAROL;
@@ -727,7 +725,7 @@ fn integration_test_replace_execute_replace() {
         let (tx_id, _tx_block_height, merkle_proof, raw_tx) =
             generate_transaction_and_mine(new_vault_btc_address, polkabtc, Some(replace_id));
 
-        SystemModule::set_block_number(1 + CONFIRMATIONS);
+        SecurityModule::set_active_block_number(1 + CONFIRMATIONS);
         let r = Call::Replace(ReplaceCall::execute_replace(replace_id, tx_id, merkle_proof, raw_tx))
             .dispatch(origin_of(account_of(old_vault)));
         assert_ok!(r);
@@ -739,7 +737,6 @@ fn integration_test_replace_cancel_replace() {
     ExtBuilder::build().execute_with(|| {
         assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
         set_default_thresholds();
-        SystemModule::set_block_number(1);
         SecurityModule::set_active_block_number(1);
 
         let amount = 1000;
@@ -781,7 +778,6 @@ fn integration_test_replace_cancel_auction_replace() {
     ExtBuilder::build().execute_with(|| {
         assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
         set_default_thresholds();
-        SystemModule::set_block_number(1);
         SecurityModule::set_active_block_number(1);
         let new_vault_btc_address = BtcAddress::P2PKH(H160([2; 20]));
 
@@ -941,7 +937,6 @@ fn integration_test_replace_cancel_repeatedly_fails() {
 fn setup_replace(polkabtc: u128) -> H256 {
     assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
     set_default_thresholds();
-    SystemModule::set_block_number(1);
     SecurityModule::set_active_block_number(1);
 
     // burn surplus free balance to make checking easier
@@ -1001,7 +996,7 @@ fn execute_replace(replace_id: H256) {
     let (tx_id, _tx_block_height, merkle_proof, raw_tx) =
         generate_transaction_and_mine(replace.btc_address, replace.amount, Some(replace_id));
 
-    SystemModule::set_block_number(1 + CONFIRMATIONS);
+    SecurityModule::set_active_block_number(1 + CONFIRMATIONS);
     assert_ok!(
         Call::Replace(ReplaceCall::execute_replace(replace_id, tx_id, merkle_proof, raw_tx,))
             .dispatch(origin_of(account_of(OLD_VAULT)))

--- a/parachain/runtime/tests/test_replace.rs
+++ b/parachain/runtime/tests/test_replace.rs
@@ -18,6 +18,7 @@ pub const DEFAULT_GRIEFING_COLLATERAL: u128 = 5_000;
 fn test_with<R>(execute: impl FnOnce() -> R) -> R {
     ExtBuilder::build().execute_with(|| {
         SystemModule::set_block_number(1);
+        SecurityModule::set_active_block_number(1);
         assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
         set_default_thresholds();
         UserData::force_to(USER, default_user_state());
@@ -55,7 +56,7 @@ pub fn assert_auction_event() -> H256 {
         .iter()
         .rev()
         .find_map(|record| match record.event {
-            Event::replace(ReplaceEvent::AuctionReplace(id, _, _, _, _, _, _, _, _)) => Some(id),
+            Event::replace(ReplaceEvent::AuctionReplace(id, _, _, _, _, _, _, _)) => Some(id),
             _ => None,
         })
         .unwrap()
@@ -630,7 +631,7 @@ fn integration_test_replace_auction_replace() {
     ExtBuilder::build().execute_with(|| {
         assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
         set_default_thresholds();
-        SystemModule::set_block_number(1);
+        SecurityModule::set_active_block_number(1);
 
         let user = CAROL;
         let old_vault = ALICE;
@@ -683,6 +684,7 @@ fn integration_test_replace_execute_replace() {
         assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
         set_default_thresholds();
         SystemModule::set_block_number(1);
+        SecurityModule::set_active_block_number(1);
 
         let user = CAROL;
         let old_vault = ALICE;
@@ -738,6 +740,7 @@ fn integration_test_replace_cancel_replace() {
         assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
         set_default_thresholds();
         SystemModule::set_block_number(1);
+        SecurityModule::set_active_block_number(1);
 
         let amount = 1000;
         //FIXME: get this from storage
@@ -768,7 +771,7 @@ fn integration_test_replace_cancel_replace() {
 
         // set block height
         // alice cancels replacement
-        SystemModule::set_block_number(30);
+        SecurityModule::set_active_block_number(30);
         assert_ok!(Call::Replace(ReplaceCall::cancel_replace(replace_id)).dispatch(origin_of(account_of(ALICE))));
     });
 }
@@ -779,6 +782,7 @@ fn integration_test_replace_cancel_auction_replace() {
         assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
         set_default_thresholds();
         SystemModule::set_block_number(1);
+        SecurityModule::set_active_block_number(1);
         let new_vault_btc_address = BtcAddress::P2PKH(H160([2; 20]));
 
         let user = CAROL;
@@ -833,7 +837,7 @@ fn integration_test_replace_cancel_auction_replace() {
 
         let replace_id = assert_auction_event();
 
-        SystemModule::set_block_number(30);
+        SecurityModule::set_active_block_number(30);
 
         assert_ok!(Call::Replace(ReplaceCall::cancel_replace(replace_id)).dispatch(origin_of(account_of(BOB))));
 
@@ -857,7 +861,7 @@ fn integration_test_replace_cancel_repeatedly_fails() {
     ExtBuilder::build().execute_with(|| {
         assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
         set_default_thresholds();
-        SystemModule::set_block_number(1);
+        SecurityModule::set_active_block_number(1);
 
         let user = CAROL;
         let old_vault = ALICE;
@@ -938,6 +942,7 @@ fn setup_replace(polkabtc: u128) -> H256 {
     assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
     set_default_thresholds();
     SystemModule::set_block_number(1);
+    SecurityModule::set_active_block_number(1);
 
     // burn surplus free balance to make checking easier
     CollateralModule::transfer(
@@ -1006,7 +1011,7 @@ fn execute_replace(replace_id: H256) {
 fn cancel_replace(replace_id: H256) {
     // set block height
     // alice cancels replacement
-    SystemModule::set_block_number(30);
+    SecurityModule::set_active_block_number(30);
     assert_ok!(Call::Replace(ReplaceCall::cancel_replace(replace_id)).dispatch(origin_of(account_of(NEW_VAULT))));
 }
 #[test]
@@ -1529,7 +1534,7 @@ fn integration_test_issue_using_griefing_collateral_fails() {
     ExtBuilder::build().execute_with(|| {
         assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
         set_default_thresholds();
-        SystemModule::set_block_number(1);
+        SecurityModule::set_active_block_number(1);
 
         let amount = 1000;
         let collateral = amount * 2;

--- a/parachain/runtime/tests/test_staked_relayers.rs
+++ b/parachain/runtime/tests/test_staked_relayers.rs
@@ -20,7 +20,7 @@ fn test_vault_theft(submit_by_relayer: bool) {
         ]));
         let other_btc_address = BtcAddress::P2SH(H160([1; 20]));
 
-        SystemModule::set_block_number(1);
+        SecurityModule::set_active_block_number(1);
 
         assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
         VaultRegistryModule::insert_vault(&account_of(LIQUIDATION_VAULT), Vault::default());
@@ -38,7 +38,7 @@ fn test_vault_theft(submit_by_relayer: bool) {
         assert_ok!(Call::StakedRelayers(StakedRelayersCall::register_staked_relayer(100))
             .dispatch(origin_of(account_of(user))));
 
-        SystemModule::set_block_number(StakedRelayersModule::get_maturity_period() + 100);
+        SecurityModule::set_active_block_number(StakedRelayersModule::get_maturity_period() + 100);
 
         // manually activate
         assert_ok!(StakedRelayersModule::activate_staked_relayer(&account_of(user)));
@@ -61,7 +61,7 @@ fn test_vault_theft(submit_by_relayer: bool) {
                 .unwrap();
         assert_eq!(SlaModule::relayer_sla(account_of(ALICE)), expected_sla);
 
-        SystemModule::set_block_number(1000);
+        SecurityModule::set_active_block_number(1000);
 
         if submit_by_relayer {
             assert_ok!(Call::StakedRelayers(StakedRelayersCall::report_vault_theft(

--- a/parachain/runtime/tests/test_vault_sla.rs
+++ b/parachain/runtime/tests/test_vault_sla.rs
@@ -16,7 +16,7 @@ fn initial_sla() -> FixedI128 {
 
 fn test_with<R>(execute: impl FnOnce() -> R) -> R {
     ExtBuilder::build().execute_with(|| {
-        SystemModule::set_block_number(1);
+        SecurityModule::set_active_block_number(1);
         assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
         set_default_thresholds();
 


### PR DESCRIPTION
Breaking changes:
- issue/redeem/replace request struct: 
    - opentime is now _active_ block number, so it no longer equals the parachain height
    - added `btc_height` - this is what the clients will need to use for resuming open requests upon startup
- removed `opentime` from auction event
