### PR TITLE
chore: auto-fix clippy warnings

### DIFF
--- a/crates/bitcoin/examples/run-proof.rs
+++ b/crates/bitcoin/examples/run-proof.rs
@@ -1,7 +1,6 @@
 extern crate bitcoin;
 
 use bitcoin::merkle::MerkleProof;
-use hex;
 
 // Proving that the transaction
 // 8d30eb0f3e65b8d8a9f26f6f73fc5aafa5c0372f9bb38aa38dd4c9dd1933e090
@@ -12,7 +11,7 @@ use hex;
 const PROOF_HEX: &str = "010000006fd2c5a8fac33dbe89bb2a2947a73eed2afc3b1d4f886942df08000000000000b152eca4364850f3424c7ac2b337d606c5ca0a3f96f1554f8db33d2f6f130bbed325a04e4b6d0b1a85790e6b0a000000038d9d737b484e96eed701c4b3728aea80aa7f2a7f57125790ed9998f9050a1bef90e03319ddc9d48da38ab39b2f37c0a5af5afc736f6ff2a9d8b8653e0feb308d84251842a4c0f0e188e1c2bf643ec37a1402dd86a25a9ab5004633467d16e313013d";
 
 fn main() {
-    let raw_proof = hex::decode(&PROOF_HEX[..]).unwrap();
+    let raw_proof = hex::decode(PROOF_HEX).unwrap();
     let proof = MerkleProof::parse(&raw_proof).unwrap();
     let result = proof.verify_proof().unwrap();
     println!(

--- a/crates/bitcoin/src/address.rs
+++ b/crates/bitcoin/src/address.rs
@@ -277,7 +277,7 @@ mod tests {
         let vault_public_key = PublicKey(vault_public_key.serialize());
 
         // D = V * c
-        let deposit_public_key = vault_public_key.new_deposit_public_key(secure_id.clone()).unwrap();
+        let deposit_public_key = vault_public_key.new_deposit_public_key(secure_id).unwrap();
 
         // d = v * c
         vault_secret_key

--- a/crates/bitcoin/src/formatter.rs
+++ b/crates/bitcoin/src/formatter.rs
@@ -464,7 +464,7 @@ mod tests {
 
     #[test]
     fn test_format_merkle_proof() {
-        let proof = MerkleProof::parse(&hex::decode(&PROOF_HEX[..]).unwrap()).unwrap();
+        let proof = MerkleProof::parse(&hex::decode(PROOF_HEX).unwrap()).unwrap();
         let expected = hex::decode(PROOF_HEX).unwrap();
         assert_eq!(proof.try_format().unwrap(), expected);
     }

--- a/crates/bitcoin/src/merkle.rs
+++ b/crates/bitcoin/src/merkle.rs
@@ -315,7 +315,7 @@ mod tests {
     fn test_mock_verify_proof() {
         let mock_proof_result = sample_valid_proof_result();
 
-        let proof = MerkleProof::parse(&hex::decode(&PROOF_HEX[..]).unwrap()).unwrap();
+        let proof = MerkleProof::parse(&hex::decode(PROOF_HEX).unwrap()).unwrap();
         MerkleProof::verify_proof.mock_safe(move |_| MockResult::Return(Ok(mock_proof_result)));
 
         let res = MerkleProof::verify_proof(&proof).unwrap();
@@ -324,7 +324,7 @@ mod tests {
 
     #[test]
     fn test_parse_proof() {
-        let raw_proof = hex::decode(&PROOF_HEX[..]).unwrap();
+        let raw_proof = hex::decode(PROOF_HEX).unwrap();
         let proof = MerkleProof::parse(&raw_proof).unwrap();
         let expected_merkle_root =
             H256::from_str("a0e8ab249b25ef31da538262ab8b2885ce63ca82a22fd0efdce76ea6920d1f90").unwrap();
@@ -349,7 +349,7 @@ mod tests {
 
     #[test]
     fn test_compute_tree_width() {
-        let proof = MerkleProof::parse(&hex::decode(&PROOF_HEX[..]).unwrap()).unwrap();
+        let proof = MerkleProof::parse(&hex::decode(PROOF_HEX).unwrap()).unwrap();
         assert_eq!(proof.compute_partial_tree_width(0), proof.transactions_count);
         assert_eq!(proof.compute_partial_tree_width(1), proof.transactions_count / 2 + 1);
         assert_eq!(proof.compute_partial_tree_width(12), 1);
@@ -357,13 +357,13 @@ mod tests {
 
     #[test]
     fn test_compute_merkle_proof_tree_height() {
-        let proof = MerkleProof::parse(&hex::decode(&PROOF_HEX[..]).unwrap()).unwrap();
+        let proof = MerkleProof::parse(&hex::decode(PROOF_HEX).unwrap()).unwrap();
         assert_eq!(proof.compute_partial_tree_height(), 12);
     }
 
     #[test]
     fn test_extract_hash() {
-        let proof = MerkleProof::parse(&hex::decode(&PROOF_HEX[..]).unwrap()).unwrap();
+        let proof = MerkleProof::parse(&hex::decode(PROOF_HEX).unwrap()).unwrap();
         let merkle_root = H256Le::from_bytes_le(&proof.block_header.merkle_root.to_bytes_le());
         let result = proof.verify_proof().unwrap();
         assert_eq!(result.extracted_root, merkle_root);

--- a/crates/bitcoin/src/types.rs
+++ b/crates/bitcoin/src/types.rs
@@ -970,7 +970,7 @@ mod tests {
             .unwrap();
 
         // FIXME: flag_bits incorrect
-        let proof = block.merkle_proof(&vec![transaction.tx_id()]).unwrap();
+        let proof = block.merkle_proof(&[transaction.tx_id()]).unwrap();
         let bytes = proof.try_format().unwrap();
         MerkleProof::parse(&bytes).unwrap();
     }

--- a/crates/btc-relay/src/benchmarking.rs
+++ b/crates/btc-relay/src/benchmarking.rs
@@ -86,7 +86,7 @@ benchmarks! {
         let (block, transaction) = mine_block_with_one_tx::<T>(origin.clone(), block, &address, value, &op_return);
 
         let tx_id = transaction.tx_id();
-        let proof = block.merkle_proof(&vec![tx_id]).unwrap().try_format().unwrap();
+        let proof = block.merkle_proof(&[tx_id]).unwrap().try_format().unwrap();
         let raw_tx = transaction.format_with(true);
 
         Security::<T>::set_active_block_number(100u32.into());
@@ -107,7 +107,7 @@ benchmarks! {
 
         let tx_id = transaction.tx_id();
         let tx_block_height = height;
-        let proof = block.merkle_proof(&vec![tx_id]).unwrap().try_format().unwrap();
+        let proof = block.merkle_proof(&[tx_id]).unwrap().try_format().unwrap();
 
         Security::<T>::set_active_block_number(100u32.into());
 

--- a/crates/btc-relay/src/ext.rs
+++ b/crates/btc-relay/src/ext.rs
@@ -33,12 +33,12 @@ pub(crate) mod security {
     }
 
     #[cfg(test)]
-    pub fn set_status<T: security::Config>(status: StatusCode) -> () {
+    pub fn set_status<T: security::Config>(status: StatusCode) {
         <security::Module<T>>::set_status(status)
     }
 
     #[cfg(test)]
-    pub fn insert_error<T: security::Config>(error: ErrorCode) -> () {
+    pub fn insert_error<T: security::Config>(error: ErrorCode) {
         <security::Module<T>>::insert_error(error)
     }
 

--- a/crates/btc-relay/src/mock.rs
+++ b/crates/btc-relay/src/mock.rs
@@ -185,9 +185,9 @@ impl ExtBuilder {
     }
 }
 
-pub fn run_test<T>(test: T) -> ()
+pub fn run_test<T>(test: T)
 where
-    T: FnOnce() -> (),
+    T: FnOnce(),
 {
     clear_mocks();
     ExtBuilder::build().execute_with(|| {

--- a/crates/btc-relay/src/tests.rs
+++ b/crates/btc-relay/src/tests.rs
@@ -45,8 +45,8 @@ fn get_block_header_from_hash_succeeds() {
         let rich_header = RichBlockHeader::<AccountId, BlockNumber> {
             block_hash: H256Le::zero(),
             block_header: BlockHeader::from_le_bytes(&block_header).unwrap(),
-            block_height: block_height,
-            chain_ref: chain_ref,
+            block_height,
+            chain_ref,
             account_id: Default::default(),
             para_height: Default::default(),
         };
@@ -145,8 +145,8 @@ fn store_block_header_on_mainchain_succeeds() {
         let rich_header = RichBlockHeader::<AccountId, BlockNumber> {
             block_hash: H256Le::zero(),
             block_header: parse_block_header(&block_header).unwrap(),
-            block_height: block_height,
-            chain_ref: chain_ref,
+            block_height,
+            chain_ref,
             account_id: Default::default(),
             para_height: Default::default(),
         };
@@ -184,7 +184,7 @@ fn store_block_header_on_fork_succeeds() {
             block_hash: H256Le::zero(),
             block_header: parse_block_header(&block_header).unwrap(),
             block_height: block_height - 1,
-            chain_ref: chain_ref,
+            chain_ref,
             account_id: Default::default(),
             para_height: Default::default(),
         };
@@ -953,8 +953,7 @@ fn test_verify_and_validate_transaction_succeeds() {
             BtcAddress::P2SH(H160::from_str(&"66c7060feb882664ae62ffad0051fe843e318e85").unwrap());
         let op_return_id =
             hex::decode("aa21a9ede5c17d15b8b1fa2811b7e6da66ffa5e1aaa05922c69068bf90cd585b95bb4675".to_owned()).unwrap();
-        BTCRelay::_validate_transaction
-            .mock_safe(move |_, _, _, _| MockResult::Return(Ok((recipient_btc_address.clone(), 0))));
+        BTCRelay::_validate_transaction.mock_safe(move |_, _, _, _| MockResult::Return(Ok((recipient_btc_address, 0))));
         BTCRelay::_verify_transaction_inclusion.mock_safe(move |_, _, _| MockResult::Return(Ok(())));
 
         assert_ok!(BTCRelay::verify_and_validate_transaction(
@@ -982,8 +981,8 @@ fn test_flag_block_error_succeeds() {
         let rich_header = RichBlockHeader::<AccountId, BlockNumber> {
             block_hash: H256Le::zero(),
             block_header: BlockHeader::from_le_bytes(&block_header).unwrap(),
-            block_height: block_height,
-            chain_ref: chain_ref,
+            block_height,
+            chain_ref,
             account_id: Default::default(),
             para_height: Default::default(),
         };
@@ -1022,8 +1021,8 @@ fn test_flag_block_error_fails() {
         let rich_header = RichBlockHeader::<AccountId, BlockNumber> {
             block_hash: H256Le::zero(),
             block_header: BlockHeader::from_le_bytes(&block_header).unwrap(),
-            block_height: block_height,
-            chain_ref: chain_ref,
+            block_height,
+            chain_ref,
             account_id: Default::default(),
             para_height: Default::default(),
         };
@@ -1055,8 +1054,8 @@ fn test_clear_block_error_succeeds() {
         let rich_header = RichBlockHeader::<AccountId, BlockNumber> {
             block_hash: H256Le::zero(),
             block_header: BlockHeader::from_le_bytes(&block_header).unwrap(),
-            block_height: block_height,
-            chain_ref: chain_ref,
+            block_height,
+            chain_ref,
             account_id: Default::default(),
             para_height: Default::default(),
         };
@@ -1080,8 +1079,7 @@ fn test_clear_block_error_succeeds() {
             } else if error == ErrorCode::InvalidBTCRelay {
                 assert!(!curr_chain.invalid.contains(&block_height));
             };
-            let error_event =
-                TestEvent::btc_relay(Event::ClearBlockError(rich_header.block_hash, chain_ref, error.clone()));
+            let error_event = TestEvent::btc_relay(Event::ClearBlockError(rich_header.block_hash, chain_ref, error));
             assert!(System::events().iter().any(|a| a.event == error_event));
         };
 
@@ -1111,8 +1109,8 @@ fn test_clear_block_error_fails() {
         let rich_header = RichBlockHeader::<AccountId, BlockNumber> {
             block_hash: H256Le::zero(),
             block_header: BlockHeader::from_le_bytes(&block_header).unwrap(),
-            block_height: block_height,
-            chain_ref: chain_ref,
+            block_height,
+            chain_ref,
             account_id: Default::default(),
             para_height: Default::default(),
         };
@@ -1224,12 +1222,12 @@ fn test_verify_transaction_inclusion_succeeds() {
 
         let fork = get_empty_block_chain_from_chain_id_and_height(fork_ref, start, fork_chain_height);
 
-        BTCRelay::get_chain_id_from_position.mock_safe(move |_| MockResult::Return(Ok(fork_ref.clone())));
+        BTCRelay::get_chain_id_from_position.mock_safe(move |_| MockResult::Return(Ok(fork_ref)));
         BTCRelay::get_block_chain_from_id.mock_safe(move |id| {
-            if id == chain_ref.clone() {
-                return MockResult::Return(Ok(main.clone()));
+            if id == chain_ref {
+                MockResult::Return(Ok(main.clone()))
             } else {
-                return MockResult::Return(Ok(fork.clone()));
+                MockResult::Return(Ok(fork.clone()))
             }
         });
 
@@ -1270,10 +1268,10 @@ fn test_verify_transaction_inclusion_empty_fork_succeeds() {
         let main = get_empty_block_chain_from_chain_id_and_height(chain_ref, start, main_chain_height);
 
         BTCRelay::get_block_chain_from_id.mock_safe(move |id| {
-            if id == chain_ref.clone() {
-                return MockResult::Return(Ok(main.clone()));
+            if id == chain_ref {
+                MockResult::Return(Ok(main.clone()))
             } else {
-                return MockResult::Return(Err(TestError::InvalidChainID.into()));
+                MockResult::Return(Err(TestError::InvalidChainID.into()))
             }
         });
 
@@ -1322,12 +1320,12 @@ fn test_verify_transaction_inclusion_invalid_tx_id_fails() {
 
         let fork = get_empty_block_chain_from_chain_id_and_height(fork_ref, start, fork_chain_height);
 
-        BTCRelay::get_chain_id_from_position.mock_safe(move |_| MockResult::Return(Ok(fork_ref.clone())));
+        BTCRelay::get_chain_id_from_position.mock_safe(move |_| MockResult::Return(Ok(fork_ref)));
         BTCRelay::get_block_chain_from_id.mock_safe(move |id| {
-            if id == chain_ref.clone() {
-                return MockResult::Return(Ok(main.clone()));
+            if id == chain_ref {
+                MockResult::Return(Ok(main.clone()))
             } else {
-                return MockResult::Return(Ok(fork.clone()));
+                MockResult::Return(Ok(fork.clone()))
             }
         });
 
@@ -1375,12 +1373,12 @@ fn test_verify_transaction_inclusion_invalid_merkle_root_fails() {
 
         let fork = get_empty_block_chain_from_chain_id_and_height(fork_ref, start, fork_chain_height);
 
-        BTCRelay::get_chain_id_from_position.mock_safe(move |_| MockResult::Return(Ok(fork_ref.clone())));
+        BTCRelay::get_chain_id_from_position.mock_safe(move |_| MockResult::Return(Ok(fork_ref)));
         BTCRelay::get_block_chain_from_id.mock_safe(move |id| {
-            if id == chain_ref.clone() {
-                return MockResult::Return(Ok(main.clone()));
+            if id == chain_ref {
+                MockResult::Return(Ok(main.clone()))
             } else {
-                return MockResult::Return(Ok(fork.clone()));
+                MockResult::Return(Ok(fork.clone()))
             }
         });
 
@@ -1789,9 +1787,9 @@ fn test_remove_blockchain_from_chain() {
 
 /// # Util functions
 
-const SAMPLE_TX_ID: &'static str = "c8589f304d3b9df1d4d8b3d15eb6edaaa2af9d796e9d9ace12b31f293705c5e9";
+const SAMPLE_TX_ID: &str = "c8589f304d3b9df1d4d8b3d15eb6edaaa2af9d796e9d9ace12b31f293705c5e9";
 
-const SAMPLE_MERKLE_ROOT: &'static str = "1EE1FB90996CA1D5DCD12866BA9066458BF768641215933D7D8B3A10EF79D090";
+const SAMPLE_MERKLE_ROOT: &str = "1EE1FB90996CA1D5DCD12866BA9066458BF768641215933D7D8B3A10EF79D090";
 
 fn sample_merkle_proof() -> MerkleProof {
     MerkleProof {
@@ -1826,8 +1824,8 @@ fn sample_valid_proof_result() -> ProofResult {
 
 fn get_empty_block_chain_from_chain_id_and_height(chain_id: u32, start_height: u32, block_height: u32) -> BlockChain {
     let blockchain = BlockChain {
-        chain_id: chain_id,
-        start_height: start_height,
+        chain_id,
+        start_height,
         max_height: block_height,
         no_data: BTreeSet::new(),
         invalid: BTreeSet::new(),
@@ -1869,7 +1867,7 @@ fn store_blockchain_and_random_headers(id: u32, start_height: u32, max_height: u
         let block_hash = H256Le::from_bytes_be(fake_block.as_slice());
 
         let rich_header = RichBlockHeader::<AccountId, BlockNumber> {
-            block_hash: block_hash,
+            block_hash,
             block_header: BlockHeader::from_le_bytes(&block_header).unwrap(),
             block_height: height,
             chain_ref: id,
@@ -1896,8 +1894,8 @@ fn sample_parsed_genesis_header(chain_ref: u32, block_height: u32) -> RichBlockH
     RichBlockHeader::<AccountId, BlockNumber> {
         block_hash: genesis_header.hash(),
         block_header: parse_block_header(&genesis_header).unwrap(),
-        block_height: block_height,
-        chain_ref: chain_ref,
+        block_height,
+        chain_ref,
         account_id: Default::default(),
         para_height: Default::default(),
     }
@@ -1921,8 +1919,8 @@ fn sample_parsed_first_block(chain_ref: u32, block_height: u32) -> RichBlockHead
     RichBlockHeader::<AccountId, BlockNumber> {
         block_hash: block_header.hash(),
         block_header: parse_block_header(&block_header).unwrap(),
-        block_height: block_height,
-        chain_ref: chain_ref,
+        block_height,
+        chain_ref,
         account_id: Default::default(),
         para_height: Default::default(),
     }
@@ -1970,8 +1968,8 @@ fn sample_rich_tx_block_header(chain_ref: u32, block_height: u32) -> RichBlockHe
     RichBlockHeader::<AccountId, BlockNumber> {
         block_hash: raw_header.hash(),
         block_header: parse_block_header(&raw_header).unwrap(),
-        block_height: block_height,
-        chain_ref: chain_ref,
+        block_height,
+        chain_ref,
         account_id: Default::default(),
         para_height: Default::default(),
     }
@@ -2036,7 +2034,7 @@ fn sample_transaction_parsed(outputs: &Vec<TransactionOutput>) -> Transaction {
 
     Transaction {
         version: 2,
-        inputs: inputs,
+        inputs,
         outputs: outputs.to_vec(),
         block_height: Some(203),
         locktime: Some(0),

--- a/crates/btc-relay/src/weights.rs
+++ b/crates/btc-relay/src/weights.rs
@@ -44,25 +44,25 @@ pub trait WeightInfo {
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
     fn verify_and_validate_transaction() -> Weight {
-        (99_474_000 as Weight).saturating_add(T::DbWeight::get().reads(9 as Weight))
+        99_474_000_u64.saturating_add(T::DbWeight::get().reads(9_u64))
     }
     fn verify_transaction_inclusion() -> Weight {
-        (55_622_000 as Weight).saturating_add(T::DbWeight::get().reads(8 as Weight))
+        55_622_000_u64.saturating_add(T::DbWeight::get().reads(8_u64))
     }
     fn validate_transaction() -> Weight {
-        (15_739_000 as Weight).saturating_add(T::DbWeight::get().reads(1 as Weight))
+        15_739_000_u64.saturating_add(T::DbWeight::get().reads(1_u64))
     }
 }
 
 // For backwards compatibility and tests
 impl WeightInfo for () {
     fn verify_and_validate_transaction() -> Weight {
-        (99_474_000 as Weight).saturating_add(RocksDbWeight::get().reads(9 as Weight))
+        99_474_000_u64.saturating_add(RocksDbWeight::get().reads(9_u64))
     }
     fn verify_transaction_inclusion() -> Weight {
-        (55_622_000 as Weight).saturating_add(RocksDbWeight::get().reads(8 as Weight))
+        55_622_000_u64.saturating_add(RocksDbWeight::get().reads(8_u64))
     }
     fn validate_transaction() -> Weight {
-        (15_739_000 as Weight).saturating_add(RocksDbWeight::get().reads(1 as Weight))
+        15_739_000_u64.saturating_add(RocksDbWeight::get().reads(1_u64))
     }
 }

--- a/crates/collateral/src/mock.rs
+++ b/crates/collateral/src/mock.rs
@@ -102,9 +102,9 @@ impl ExtBuilder {
     }
 }
 
-pub fn run_test<T>(test: T) -> ()
+pub fn run_test<T>(test: T)
 where
-    T: FnOnce() -> (),
+    T: FnOnce(),
 {
     ExtBuilder::build().execute_with(|| {
         System::set_block_number(1);

--- a/crates/exchange-rate-oracle/src/default_weights.rs
+++ b/crates/exchange-rate-oracle/src/default_weights.rs
@@ -8,19 +8,19 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 impl crate::WeightInfo for () {
     // WARNING! Some components were not used: ["u"]
     fn set_exchange_rate() -> Weight {
-        (42_788_000 as Weight)
-            .saturating_add(DbWeight::get().reads(5 as Weight))
-            .saturating_add(DbWeight::get().writes(2 as Weight))
+        42_788_000_u64
+            .saturating_add(DbWeight::get().reads(5_u64))
+            .saturating_add(DbWeight::get().writes(2_u64))
     }
     fn set_btc_tx_fees_per_byte() -> Weight {
-        (30_015_705 as Weight)
-            .saturating_add(DbWeight::get().reads(2 as Weight))
-            .saturating_add(DbWeight::get().writes(1 as Weight))
+        30_015_705_u64
+            .saturating_add(DbWeight::get().reads(2_u64))
+            .saturating_add(DbWeight::get().writes(1_u64))
     }
     fn insert_authorized_oracle() -> Weight {
-        (6_788_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
+        6_788_000_u64.saturating_add(DbWeight::get().writes(1_u64))
     }
     fn remove_authorized_oracle() -> Weight {
-        (6_021_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
+        6_021_000_u64.saturating_add(DbWeight::get().writes(1_u64))
     }
 }

--- a/crates/exchange-rate-oracle/src/lib.rs
+++ b/crates/exchange-rate-oracle/src/lib.rs
@@ -139,7 +139,7 @@ decl_module! {
                 }
 
                 if let Some(account_id) = take_storage_value::<T::AccountId>(b"ExchangeRateOracle", b"AuthorizedOracle") {
-                    let name = take_storage_item::<T::AccountId, Vec<u8>, Twox128>(b"ExchangeRateOracle", b"OracleNames", account_id.clone()).unwrap_or(vec![]);
+                    let name = take_storage_item::<T::AccountId, Vec<u8>, Twox128>(b"ExchangeRateOracle", b"OracleNames", account_id.clone()).unwrap_or_default();
                     <AuthorizedOracles<T>>::insert(account_id, name);
                 }
 

--- a/crates/exchange-rate-oracle/src/mock.rs
+++ b/crates/exchange-rate-oracle/src/mock.rs
@@ -132,9 +132,9 @@ impl ExtBuilder {
     }
 }
 
-pub fn run_test<T>(test: T) -> ()
+pub fn run_test<T>(test: T)
 where
-    T: FnOnce() -> (),
+    T: FnOnce(),
 {
     clear_mocks();
     ExtBuilder::build().execute_with(|| {

--- a/crates/fee/src/default_weights.rs
+++ b/crates/fee/src/default_weights.rs
@@ -7,13 +7,13 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 
 impl crate::WeightInfo for () {
     fn withdraw_polka_btc() -> Weight {
-        (124_557_000 as Weight)
-            .saturating_add(DbWeight::get().reads(5 as Weight))
-            .saturating_add(DbWeight::get().writes(4 as Weight))
+        124_557_000_u64
+            .saturating_add(DbWeight::get().reads(5_u64))
+            .saturating_add(DbWeight::get().writes(4_u64))
     }
     fn withdraw_dot() -> Weight {
-        (127_327_000 as Weight)
-            .saturating_add(DbWeight::get().reads(5 as Weight))
-            .saturating_add(DbWeight::get().writes(4 as Weight))
+        127_327_000_u64
+            .saturating_add(DbWeight::get().reads(5_u64))
+            .saturating_add(DbWeight::get().writes(4_u64))
     }
 }

--- a/crates/fee/src/lib.rs
+++ b/crates/fee/src/lib.rs
@@ -312,7 +312,7 @@ impl<T: Config> Module<T> {
         let total_maintainer_rewards_in_dot = Self::maintainer_rewards_for_epoch_in_dot()?;
         <TotalRewardsDOT<T>>::insert(
             maintainer_account_id.clone(),
-            <TotalRewardsDOT<T>>::get(maintainer_account_id.clone())
+            <TotalRewardsDOT<T>>::get(maintainer_account_id)
                 .checked_add(&total_maintainer_rewards_in_dot)
                 .ok_or(Error::<T>::ArithmeticOverflow)?,
         );

--- a/crates/fee/src/mock.rs
+++ b/crates/fee/src/mock.rs
@@ -174,9 +174,9 @@ impl ExtBuilder {
     }
 }
 
-pub fn run_test<T>(test: T) -> ()
+pub fn run_test<T>(test: T)
 where
-    T: FnOnce() -> (),
+    T: FnOnce(),
 {
     clear_mocks();
     ExtBuilder::build().execute_with(|| {

--- a/crates/issue/src/benchmarking.rs
+++ b/crates/issue/src/benchmarking.rs
@@ -96,7 +96,7 @@ benchmarks! {
             .mine(U256::from(2).pow(254.into())).unwrap();
 
         let tx_id = transaction.tx_id();
-        let proof = block.merkle_proof(&vec![tx_id]).unwrap().try_format().unwrap();
+        let proof = block.merkle_proof(&[tx_id]).unwrap().try_format().unwrap();
         let raw_tx = transaction.format_with(true);
 
         let block_header = RawBlockHeader::from_bytes(&block.header.try_format().unwrap()).unwrap();

--- a/crates/issue/src/default_weights.rs
+++ b/crates/issue/src/default_weights.rs
@@ -7,21 +7,21 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 
 impl crate::WeightInfo for () {
     fn request_issue() -> Weight {
-        (452_088_000 as Weight)
-            .saturating_add(DbWeight::get().reads(13 as Weight))
-            .saturating_add(DbWeight::get().writes(5 as Weight))
+        452_088_000_u64
+            .saturating_add(DbWeight::get().reads(13_u64))
+            .saturating_add(DbWeight::get().writes(5_u64))
     }
     fn execute_issue() -> Weight {
-        (211_260_000 as Weight)
-            .saturating_add(DbWeight::get().reads(14 as Weight))
-            .saturating_add(DbWeight::get().writes(3 as Weight))
+        211_260_000_u64
+            .saturating_add(DbWeight::get().reads(14_u64))
+            .saturating_add(DbWeight::get().writes(3_u64))
     }
     fn cancel_issue() -> Weight {
-        (120_760_000 as Weight)
-            .saturating_add(DbWeight::get().reads(6 as Weight))
-            .saturating_add(DbWeight::get().writes(3 as Weight))
+        120_760_000_u64
+            .saturating_add(DbWeight::get().reads(6_u64))
+            .saturating_add(DbWeight::get().writes(3_u64))
     }
     fn set_issue_period() -> Weight {
-        (3_480_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
+        3_480_000_u64.saturating_add(DbWeight::get().writes(1_u64))
     }
 }

--- a/crates/issue/src/lib.rs
+++ b/crates/issue/src/lib.rs
@@ -415,7 +415,7 @@ impl<T: Config> Module<T> {
 
         // if it was a vault that did the execution on behalf of someone else, reward it by
         // increasing its SLA score
-        if &requester != &executor {
+        if requester != executor {
             if let Ok(vault) = ext::vault_registry::get_active_vault_from_id::<T>(&executor) {
                 ext::sla::event_update_vault_sla::<T>(&vault.id, ext::sla::VaultEvent::SubmittedIssueProof)?;
             }
@@ -526,7 +526,7 @@ impl<T: Config> Module<T> {
         });
 
         Self::deposit_event(<Event<T>>::IssueAmountChange(
-            issue_id.clone(),
+            *issue_id,
             issue.amount,
             issue.fee,
             confiscated_griefing_collateral,

--- a/crates/issue/src/mock.rs
+++ b/crates/issue/src/mock.rs
@@ -236,9 +236,9 @@ impl ExtBuilder {
     }
 }
 
-pub fn run_test<T>(test: T) -> ()
+pub fn run_test<T>(test: T)
 where
-    T: FnOnce() -> (),
+    T: FnOnce(),
 {
     clear_mocks();
     ExtBuilder::build().execute_with(|| {

--- a/crates/issue/src/tests.rs
+++ b/crates/issue/src/tests.rs
@@ -59,7 +59,7 @@ fn init_zero_vault<T: Config>(id: T::AccountId) -> Vault<T::AccountId, T::BlockN
 }
 
 fn get_dummy_request_id() -> H256 {
-    return H256::zero();
+    H256::zero()
 }
 
 #[test]

--- a/crates/parachain-tokens/src/lib.rs
+++ b/crates/parachain-tokens/src/lib.rs
@@ -90,7 +90,7 @@ decl_module! {
                     CurrencyId::DOT,
                     raw_amount
                 ),
-            ).map_err(|err| Error::<T>::from(err))?;
+            ).map_err(Error::<T>::from)?;
 
             Self::deposit_event(Event::<T>::TransferDOT(
                 who,
@@ -131,7 +131,7 @@ decl_module! {
                     CurrencyId::PolkaBTC,
                     raw_amount
                 ),
-            ).map_err(|err| Error::<T>::from(err))?;
+            ).map_err(Error::<T>::from)?;
 
             Self::deposit_event(Event::<T>::TransferPolkaBTC(
                 who,

--- a/crates/redeem/src/benchmarking.rs
+++ b/crates/redeem/src/benchmarking.rs
@@ -106,7 +106,7 @@ benchmarks! {
             .mine(U256::from(2).pow(254.into())).unwrap();
 
         let tx_id = transaction.tx_id();
-        let proof = block.merkle_proof(&vec![tx_id]).unwrap().try_format().unwrap();
+        let proof = block.merkle_proof(&[tx_id]).unwrap().try_format().unwrap();
         let raw_tx = transaction.format_with(true);
 
         let block_header = RawBlockHeader::from_bytes(&block.header.try_format().unwrap()).unwrap();

--- a/crates/redeem/src/default_weights.rs
+++ b/crates/redeem/src/default_weights.rs
@@ -7,32 +7,32 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 
 impl crate::WeightInfo for () {
     fn request_redeem() -> Weight {
-        (179_175_000 as Weight)
-            .saturating_add(DbWeight::get().reads(12 as Weight))
-            .saturating_add(DbWeight::get().writes(5 as Weight))
+        179_175_000_u64
+            .saturating_add(DbWeight::get().reads(12_u64))
+            .saturating_add(DbWeight::get().writes(5_u64))
     }
     fn liquidation_redeem() -> Weight {
-        (179_175_000 as Weight)
-            .saturating_add(DbWeight::get().reads(12 as Weight))
-            .saturating_add(DbWeight::get().writes(5 as Weight))
+        179_175_000_u64
+            .saturating_add(DbWeight::get().reads(12_u64))
+            .saturating_add(DbWeight::get().writes(5_u64))
     }
     fn execute_redeem() -> Weight {
-        (188_681_000 as Weight)
-            .saturating_add(DbWeight::get().reads(14 as Weight))
-            .saturating_add(DbWeight::get().writes(4 as Weight))
+        188_681_000_u64
+            .saturating_add(DbWeight::get().reads(14_u64))
+            .saturating_add(DbWeight::get().writes(4_u64))
     }
     fn cancel_redeem() -> Weight {
-        (168_952_000 as Weight)
-            .saturating_add(DbWeight::get().reads(14 as Weight))
-            .saturating_add(DbWeight::get().writes(5 as Weight))
+        168_952_000_u64
+            .saturating_add(DbWeight::get().reads(14_u64))
+            .saturating_add(DbWeight::get().writes(5_u64))
     }
     fn set_redeem_period() -> Weight {
-        (3_376_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
+        3_376_000_u64.saturating_add(DbWeight::get().writes(1_u64))
     }
     // note: placeholder value
     fn mint_tokens_for_reimbursed_redeem() -> Weight {
-        (168_952_000 as Weight)
-            .saturating_add(DbWeight::get().reads(14 as Weight))
-            .saturating_add(DbWeight::get().writes(5 as Weight))
+        168_952_000_u64
+            .saturating_add(DbWeight::get().reads(14_u64))
+            .saturating_add(DbWeight::get().writes(5_u64))
     }
 }

--- a/crates/redeem/src/lib.rs
+++ b/crates/redeem/src/lib.rs
@@ -342,7 +342,7 @@ impl<T: Config> Module<T> {
                 premium_dot,
                 period: Self::redeem_period(),
                 redeemer: redeemer.clone(),
-                btc_address: btc_address.clone(),
+                btc_address,
                 btc_height: ext::btc_relay::get_best_block_height::<T>(),
                 status: RedeemRequestStatus::Pending,
             },
@@ -487,13 +487,12 @@ impl<T: Config> Module<T> {
                 )?
             } else {
                 // user chose to keep his PolkaBTC - only transfer it the punishment fee
-                let slashed_punishment_fee = ext::vault_registry::slash_collateral_saturated::<T>(
+                // returns the amount actually slashed
+                ext::vault_registry::slash_collateral_saturated::<T>(
                     CurrencySource::Backing(vault_id.clone()),
                     CurrencySource::FreeBalance(redeemer.clone()),
                     punishment_fee_in_dot,
-                )?;
-
-                slashed_punishment_fee
+                )?
             };
             // calculate additional amount to slash, a high SLA means we slash less
             let slashing_amount_in_dot =

--- a/crates/redeem/src/mock.rs
+++ b/crates/redeem/src/mock.rs
@@ -270,9 +270,9 @@ impl ExtBuilder {
     }
 }
 
-pub fn run_test<T>(test: T) -> ()
+pub fn run_test<T>(test: T)
 where
-    T: FnOnce() -> (),
+    T: FnOnce(),
 {
     clear_mocks();
     ExtBuilder::build().execute_with(|| {

--- a/crates/redeem/src/tests.rs
+++ b/crates/redeem/src/tests.rs
@@ -94,7 +94,7 @@ fn test_request_redeem_fails_with_amount_below_minimum() {
         });
 
         assert_err!(
-            Redeem::request_redeem(Origin::signed(redeemer.clone()), 1, BtcAddress::random(), BOB),
+            Redeem::request_redeem(Origin::signed(redeemer), 1, BtcAddress::random(), BOB),
             TestError::AmountBelowDustAmount
         );
     })
@@ -177,7 +177,7 @@ fn test_request_redeem_succeeds_with_normal_redeem() {
         ext::fee::get_redeem_fee::<Test>.mock_safe(move |_| MockResult::Return(Ok(redeem_fee)));
 
         assert_ok!(Redeem::request_redeem(
-            Origin::signed(redeemer.clone()),
+            Origin::signed(redeemer),
             amount,
             BtcAddress::P2PKH(H160::zero()),
             BOB
@@ -185,7 +185,7 @@ fn test_request_redeem_succeeds_with_normal_redeem() {
 
         assert_emitted!(Event::RequestRedeem(
             H256([0; 32]),
-            redeemer.clone(),
+            redeemer,
             amount - redeem_fee,
             redeem_fee,
             0,
@@ -201,7 +201,7 @@ fn test_request_redeem_succeeds_with_normal_redeem() {
                 fee: redeem_fee,
                 amount_btc: amount - redeem_fee,
                 premium_dot: 0,
-                redeemer: redeemer.clone(),
+                redeemer,
                 btc_address: BtcAddress::P2PKH(H160::zero()),
                 btc_height: 0,
                 status: RedeemRequestStatus::Pending,

--- a/crates/refund/src/default_weights.rs
+++ b/crates/refund/src/default_weights.rs
@@ -7,6 +7,6 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 
 impl crate::WeightInfo for () {
     fn execute_refund() -> Weight {
-        (100_000_000 as Weight)
+        100_000_000_u64
     }
 }

--- a/crates/refund/src/lib.rs
+++ b/crates/refund/src/lib.rs
@@ -139,19 +139,19 @@ impl<T: Config> Module<T> {
         let refund_id = ext::security::get_secure_id::<T>(&issuer);
 
         let request = RefundRequest {
-            vault: vault_id.clone(),
+            vault: vault_id,
             amount_polka_btc: net_refund_amount_polka_btc,
             fee: fee_polka_btc,
             amount_btc: total_amount_btc,
             issuer,
-            btc_address: btc_address.clone(),
+            btc_address,
             issue_id,
             completed: false,
         };
         <RefundRequests<T>>::insert(refund_id, request.clone());
 
         Self::deposit_event(<Event<T>>::RequestRefund(
-            refund_id.clone(),
+            refund_id,
             request.issuer,
             request.amount_polka_btc,
             request.vault,

--- a/crates/refund/src/mock.rs
+++ b/crates/refund/src/mock.rs
@@ -186,9 +186,9 @@ impl ExtBuilder {
     }
 }
 
-pub fn run_test<T>(test: T) -> ()
+pub fn run_test<T>(test: T)
 where
-    T: FnOnce() -> (),
+    T: FnOnce(),
 {
     clear_mocks();
     ExtBuilder::build().execute_with(|| {

--- a/crates/replace/src/benchmarking.rs
+++ b/crates/replace/src/benchmarking.rs
@@ -182,7 +182,7 @@ benchmarks! {
             .mine(U256::from(2).pow(254.into())).unwrap();
 
         let tx_id = transaction.tx_id();
-        let proof = block.merkle_proof(&vec![tx_id]).unwrap().try_format().unwrap();
+        let proof = block.merkle_proof(&[tx_id]).unwrap().try_format().unwrap();
         let raw_tx = transaction.format_with(true);
 
         let block_header = RawBlockHeader::from_bytes(&block.header.try_format().unwrap()).unwrap();

--- a/crates/replace/src/default_weights.rs
+++ b/crates/replace/src/default_weights.rs
@@ -7,36 +7,36 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 
 impl crate::WeightInfo for () {
     fn request_replace() -> Weight {
-        (142_819_000 as Weight)
-            .saturating_add(DbWeight::get().reads(6 as Weight))
-            .saturating_add(DbWeight::get().writes(5 as Weight))
+        142_819_000_u64
+            .saturating_add(DbWeight::get().reads(6_u64))
+            .saturating_add(DbWeight::get().writes(5_u64))
     }
     fn withdraw_replace() -> Weight {
-        (132_256_000 as Weight)
-            .saturating_add(DbWeight::get().reads(10 as Weight))
-            .saturating_add(DbWeight::get().writes(3 as Weight))
+        132_256_000_u64
+            .saturating_add(DbWeight::get().reads(10_u64))
+            .saturating_add(DbWeight::get().writes(3_u64))
     }
     fn accept_replace() -> Weight {
-        (124_104_000 as Weight)
-            .saturating_add(DbWeight::get().reads(10 as Weight))
-            .saturating_add(DbWeight::get().writes(3 as Weight))
+        124_104_000_u64
+            .saturating_add(DbWeight::get().reads(10_u64))
+            .saturating_add(DbWeight::get().writes(3_u64))
     }
     fn auction_replace() -> Weight {
-        (188_428_000 as Weight)
-            .saturating_add(DbWeight::get().reads(13 as Weight))
-            .saturating_add(DbWeight::get().writes(5 as Weight))
+        188_428_000_u64
+            .saturating_add(DbWeight::get().reads(13_u64))
+            .saturating_add(DbWeight::get().writes(5_u64))
     }
     fn execute_replace() -> Weight {
-        (218_546_000 as Weight)
-            .saturating_add(DbWeight::get().reads(12 as Weight))
-            .saturating_add(DbWeight::get().writes(3 as Weight))
+        218_546_000_u64
+            .saturating_add(DbWeight::get().reads(12_u64))
+            .saturating_add(DbWeight::get().writes(3_u64))
     }
     fn cancel_replace() -> Weight {
-        (97_129_000 as Weight)
-            .saturating_add(DbWeight::get().reads(5 as Weight))
-            .saturating_add(DbWeight::get().writes(3 as Weight))
+        97_129_000_u64
+            .saturating_add(DbWeight::get().reads(5_u64))
+            .saturating_add(DbWeight::get().writes(3_u64))
     }
     fn set_replace_period() -> Weight {
-        (3_300_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
+        3_300_000_u64.saturating_add(DbWeight::get().writes(1_u64))
     }
 }

--- a/crates/replace/src/lib.rs
+++ b/crates/replace/src/lib.rs
@@ -489,8 +489,8 @@ impl<T: Config> Module<T> {
         ext::vault_registry::replace_tokens::<T>(
             old_vault_id.clone(),
             new_vault_id.clone(),
-            replace.amount.clone(),
-            replace.collateral.clone(),
+            replace.amount,
+            replace.collateral,
         )?;
 
         // if the old vault has not been liquidated, give it back its griefing collateral
@@ -545,10 +545,10 @@ impl<T: Config> Module<T> {
 
         // if the new_vault locked additional collateral especially for this replace,
         // release it if it does not cause him to be undercollateralized
-        if !ext::vault_registry::is_vault_liquidated::<T>(&new_vault_id)? {
-            if ext::vault_registry::is_allowed_to_withdraw_collateral::<T>(&new_vault_id, replace.collateral)? {
-                ext::vault_registry::force_withdraw_collateral::<T>(&new_vault_id, replace.collateral)?;
-            }
+        if !ext::vault_registry::is_vault_liquidated::<T>(&new_vault_id)?
+            && ext::vault_registry::is_allowed_to_withdraw_collateral::<T>(&new_vault_id, replace.collateral)?
+        {
+            ext::vault_registry::force_withdraw_collateral::<T>(&new_vault_id, replace.collateral)?;
         }
 
         // Remove the ReplaceRequest from ReplaceRequests
@@ -583,7 +583,7 @@ impl<T: Config> Module<T> {
 
         // Add the new replace address to the vault's wallet,
         // this should also verify that the vault exists
-        ext::vault_registry::insert_vault_deposit_address::<T>(&new_vault_id, btc_address.clone())?;
+        ext::vault_registry::insert_vault_deposit_address::<T>(&new_vault_id, btc_address)?;
 
         // decrease old-vault's to-be-replaced tokens
         let (freely_redeemable_tokens, griefing_collateral) =
@@ -624,7 +624,7 @@ impl<T: Config> Module<T> {
             new_vault: new_vault_id,
             accept_time: ext::security::active_block_number::<T>(),
             collateral: actual_new_vault_collateral,
-            btc_address: btc_address,
+            btc_address,
             griefing_collateral: if is_auction { 0u32.into() } else { griefing_collateral },
             amount: actual_btc,
             period: Self::replace_period(),

--- a/crates/replace/src/mock.rs
+++ b/crates/replace/src/mock.rs
@@ -235,9 +235,9 @@ impl ExtBuilder {
     }
 }
 
-pub fn run_test<T>(test: T) -> ()
+pub fn run_test<T>(test: T)
 where
-    T: FnOnce() -> (),
+    T: FnOnce(),
 {
     clear_mocks();
     ExtBuilder::build().execute_with(|| {

--- a/crates/security/src/mock.rs
+++ b/crates/security/src/mock.rs
@@ -3,7 +3,7 @@ use crate::{Config, Error};
 use frame_support::parameter_types;
 use mocktopus::mocking::clear_mocks;
 use sp_core::H256;
-use sp_io;
+
 use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup},
@@ -75,9 +75,9 @@ impl ExtBuilder {
     }
 }
 
-pub fn run_test<T>(test: T) -> ()
+pub fn run_test<T>(test: T)
 where
-    T: FnOnce() -> (),
+    T: FnOnce(),
 {
     clear_mocks();
     ExtBuilder::build().execute_with(|| {

--- a/crates/sla/src/lib.rs
+++ b/crates/sla/src/lib.rs
@@ -289,7 +289,7 @@ impl<T: Config> Module<T> {
         };
 
         <VaultSla<T>>::iter()
-            .filter_map(|(account_id, _)| calculate_reward(account_id.clone()).transpose())
+            .filter_map(|(account_id, _)| calculate_reward(account_id).transpose())
             .collect()
     }
 
@@ -408,7 +408,7 @@ impl<T: Config> Module<T> {
             stake_scaling_factor.checked_mul_int(stake)
         };
         let slashed_raw = calculate_slashed_collateral().ok_or(Error::<T>::InvalidSlashedAmount)?;
-        Ok(Self::u128_to_dot(slashed_raw)?)
+        Self::u128_to_dot(slashed_raw)
     }
 
     /// Calculates the potential sla change for when an issue has been completed on the given vault.

--- a/crates/sla/src/mock.rs
+++ b/crates/sla/src/mock.rs
@@ -186,9 +186,9 @@ impl ExtBuilder {
     }
 }
 
-pub fn run_test<T>(test: T) -> ()
+pub fn run_test<T>(test: T)
 where
-    T: FnOnce() -> (),
+    T: FnOnce(),
 {
     clear_mocks();
     ExtBuilder::build().execute_with(|| {

--- a/crates/staked-relayers/src/benchmarking.rs
+++ b/crates/staked-relayers/src/benchmarking.rs
@@ -38,7 +38,7 @@ benchmarks! {
             .mine(U256::from(2).pow(254.into())).unwrap();
         let block_header = RawBlockHeader::from_bytes(&block.header.try_format().unwrap()).unwrap();
         <ActiveStakedRelayers<T>>::insert(&origin, StakedRelayer { stake: stake.into(), height: Security::<T>::active_block_number() });
-    }: _(RawOrigin::Signed(origin), block_header, height.into())
+    }: _(RawOrigin::Signed(origin), block_header, height)
 
     store_block_header {
         let origin: T::AccountId = account("Origin", 0, 0);
@@ -188,7 +188,7 @@ benchmarks! {
             .mine(U256::from(2).pow(254.into())).unwrap();
 
         let tx_id = transaction.tx_id();
-        let proof = block.merkle_proof(&vec![tx_id]).unwrap().try_format().unwrap();
+        let proof = block.merkle_proof(&[tx_id]).unwrap().try_format().unwrap();
         let raw_tx = transaction.format_with(true);
 
         let block_header = RawBlockHeader::from_bytes(&block.header.try_format().unwrap()).unwrap();

--- a/crates/staked-relayers/src/mock.rs
+++ b/crates/staked-relayers/src/mock.rs
@@ -276,9 +276,9 @@ impl ExtBuilder {
     }
 }
 
-pub fn run_test<T>(test: T) -> ()
+pub fn run_test<T>(test: T)
 where
-    T: FnOnce() -> (),
+    T: FnOnce(),
 {
     clear_mocks();
     ExtBuilder::build().execute_with(|| {

--- a/crates/staked-relayers/src/types.rs
+++ b/crates/staked-relayers/src/types.rs
@@ -103,13 +103,13 @@ impl<AccountId: Ord + Clone, Balance: Clone + PartialOrd + Saturating> Tally<Acc
     /// Returns false if the account has already voted.
     pub(crate) fn vote(&mut self, id: AccountId, stake: Balance, approve: bool) -> bool {
         if self.contains(&id) {
-            return false;
+            false
         } else if approve {
             self.aye.insert(id, stake);
-            return true;
+            true
         } else {
             self.nay.insert(id, stake);
-            return true;
+            true
         }
     }
 }

--- a/crates/treasury/src/mock.rs
+++ b/crates/treasury/src/mock.rs
@@ -105,9 +105,9 @@ impl ExtBuilder {
     }
 }
 
-pub fn run_test<T>(test: T) -> ()
+pub fn run_test<T>(test: T)
 where
-    T: FnOnce() -> (),
+    T: FnOnce(),
 {
     clear_mocks();
     ExtBuilder::build().execute_with(|| {

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -263,7 +263,7 @@ decl_module! {
             let vault = Self::get_active_rich_vault_from_id(&sender)?;
 
             Self::deposit_event(Event::<T>::WithdrawCollateral(
-                sender.clone(),
+                sender,
                 amount,
                 vault.get_collateral(),
             ));
@@ -290,7 +290,7 @@ decl_module! {
         fn register_address(origin, btc_address: BtcAddress) -> DispatchResult {
             let account_id = ensure_signed(origin)?;
             ext::security::ensure_parachain_status_running::<T>()?;
-            Self::insert_vault_deposit_address(&account_id, btc_address.clone())?;
+            Self::insert_vault_deposit_address(&account_id, btc_address)?;
             Self::deposit_event(Event::<T>::RegisterAddress(account_id, btc_address));
             Ok(())
         }
@@ -348,7 +348,7 @@ impl<T: Config> Module<T> {
         );
         ensure!(!Self::vault_exists(vault_id), Error::<T>::VaultAlreadyRegistered);
 
-        let vault = Vault::new(vault_id.clone(), public_key).into();
+        let vault = Vault::new(vault_id.clone(), public_key);
         Self::insert_vault(vault_id, vault);
 
         Self::try_lock_additional_collateral(vault_id, collateral)?;
@@ -1464,7 +1464,7 @@ impl<T: Config> Module<T> {
             .ok_or(Error::<T>::ArithmeticUnderflow)?;
         let max_btc_raw = UniqueSaturatedInto::<u128>::unique_saturated_into(max_btc_as_inner);
 
-        Ok(Self::u128_to_polkabtc(max_btc_raw)?)
+        Self::u128_to_polkabtc(max_btc_raw)
     }
 
     fn polkabtc_to_u128(x: PolkaBTC<T>) -> Result<u128, DispatchError> {

--- a/crates/vault-registry/src/mock.rs
+++ b/crates/vault-registry/src/mock.rs
@@ -215,9 +215,9 @@ fn set_default_thresholds() {
     VaultRegistry::set_liquidation_collateral_threshold(liquidation);
 }
 
-pub fn run_test<T>(test: T) -> ()
+pub fn run_test<T>(test: T)
 where
-    T: FnOnce() -> (),
+    T: FnOnce(),
 {
     clear_mocks();
     ext::oracle::dots_to_btc::<Test>.mock_safe(|v| MockResult::Return(Ok(v)));

--- a/crates/vault-registry/src/tests.rs
+++ b/crates/vault-registry/src/tests.rs
@@ -73,7 +73,7 @@ fn create_vault_and_issue_tokens(
     let id = create_vault_with_collateral(id, collateral);
 
     // exchange rate 1 Satoshi = 10 Planck (smallest unit of DOT)
-    ext::oracle::dots_to_btc::<Test>.mock_safe(move |x| MockResult::Return(Ok((x / 10).into())));
+    ext::oracle::dots_to_btc::<Test>.mock_safe(move |x| MockResult::Return(Ok(x / 10)));
 
     // issue PolkaBTC with 200% collateralization of DEFAULT_COLLATERAL
     assert_ok!(VaultRegistry::try_increase_to_be_issued_tokens(&id, issue_tokens,));
@@ -762,7 +762,7 @@ fn is_collateral_below_threshold_true_succeeds() {
         let btc_amount = 50;
         let threshold = FixedU128::checked_from_rational(201, 100).unwrap(); // 201%
 
-        ext::oracle::dots_to_btc::<Test>.mock_safe(move |_| MockResult::Return(Ok(collateral.clone())));
+        ext::oracle::dots_to_btc::<Test>.mock_safe(move |_| MockResult::Return(Ok(collateral)));
 
         assert_eq!(
             VaultRegistry::is_collateral_below_threshold(collateral, btc_amount, threshold),
@@ -829,7 +829,7 @@ fn is_collateral_below_threshold_false_succeeds() {
         let btc_amount = 50;
         let threshold = FixedU128::checked_from_rational(200, 100).unwrap(); // 200%
 
-        ext::oracle::dots_to_btc::<Test>.mock_safe(move |_| MockResult::Return(Ok(collateral.clone())));
+        ext::oracle::dots_to_btc::<Test>.mock_safe(move |_| MockResult::Return(Ok(collateral)));
 
         assert_eq!(
             VaultRegistry::is_collateral_below_threshold(collateral, btc_amount, threshold),
@@ -844,7 +844,7 @@ fn calculate_max_polkabtc_from_collateral_for_threshold_succeeds() {
         let collateral: u128 = u64::MAX as u128;
         let threshold = FixedU128::checked_from_rational(200, 100).unwrap(); // 200%
 
-        ext::oracle::dots_to_btc::<Test>.mock_safe(move |_| MockResult::Return(Ok(collateral.clone())));
+        ext::oracle::dots_to_btc::<Test>.mock_safe(move |_| MockResult::Return(Ok(collateral)));
 
         assert_eq!(
             VaultRegistry::calculate_max_polkabtc_from_collateral_for_threshold(collateral, threshold),
@@ -874,15 +874,15 @@ fn test_threshold_equivalent_to_legacy_calculation() {
             .checked_div(threshold.into())
             .unwrap_or(0.into());
 
-        Ok(VaultRegistry::u128_to_polkabtc(scaled_max_tokens.try_into()?)?)
+        VaultRegistry::u128_to_polkabtc(scaled_max_tokens.try_into()?)
     }
 
     run_test(|| {
         let threshold = FixedU128::checked_from_rational(199999, 100000).unwrap(); // 199.999%
         let random_start = 987529462328 as u128;
         for btc in random_start..random_start + 199999 {
-            ext::oracle::dots_to_btc::<Test>.mock_safe(move |x| MockResult::Return(Ok(x.clone())));
-            ext::oracle::btc_to_dots::<Test>.mock_safe(move |x| MockResult::Return(Ok(x.clone())));
+            ext::oracle::dots_to_btc::<Test>.mock_safe(move |x| MockResult::Return(Ok(x)));
+            ext::oracle::btc_to_dots::<Test>.mock_safe(move |x| MockResult::Return(Ok(x)));
             let old = legacy_calculate_max_polkabtc_from_collateral_for_threshold(btc, 199999).unwrap();
             let new = VaultRegistry::calculate_max_polkabtc_from_collateral_for_threshold(btc, threshold).unwrap();
             assert_eq!(old, new);
@@ -925,8 +925,8 @@ fn test_get_required_collateral_threshold_equivalent_to_legacy_calculation_() {
         let threshold = FixedU128::checked_from_rational(199999, 100000).unwrap(); // 199.999%
         let random_start = 987529462328 as u128;
         for btc in random_start..random_start + 199999 {
-            ext::oracle::dots_to_btc::<Test>.mock_safe(move |x| MockResult::Return(Ok(x.clone())));
-            ext::oracle::btc_to_dots::<Test>.mock_safe(move |x| MockResult::Return(Ok(x.clone())));
+            ext::oracle::dots_to_btc::<Test>.mock_safe(move |x| MockResult::Return(Ok(x)));
+            ext::oracle::btc_to_dots::<Test>.mock_safe(move |x| MockResult::Return(Ok(x)));
             let old = legacy_get_required_collateral_for_polkabtc_with_threshold(btc, 199999);
             let new = VaultRegistry::get_required_collateral_for_polkabtc_with_threshold(btc, threshold);
             assert_eq!(old, new);
@@ -940,8 +940,8 @@ fn get_required_collateral_for_polkabtc_with_threshold_succeeds() {
         let threshold = FixedU128::checked_from_rational(19999, 10000).unwrap(); // 199.99%
         let random_start = 987529387592 as u128;
         for btc in random_start..random_start + 19999 {
-            ext::oracle::dots_to_btc::<Test>.mock_safe(move |x| MockResult::Return(Ok(x.clone())));
-            ext::oracle::btc_to_dots::<Test>.mock_safe(move |x| MockResult::Return(Ok(x.clone())));
+            ext::oracle::dots_to_btc::<Test>.mock_safe(move |x| MockResult::Return(Ok(x)));
+            ext::oracle::btc_to_dots::<Test>.mock_safe(move |x| MockResult::Return(Ok(x)));
 
             let min_collateral =
                 VaultRegistry::get_required_collateral_for_polkabtc_with_threshold(btc, threshold).unwrap();
@@ -1177,14 +1177,14 @@ mod get_vaults_with_issuable_tokens_tests {
             let id1 = 3;
             let collateral1 = 100;
             create_vault_with_collateral(id1, collateral1);
-            let issuable_tokens1 = VaultRegistry::get_issuable_tokens_from_vault(id1.clone())
-                .expect("Sample vault is unable to issue tokens");
+            let issuable_tokens1 =
+                VaultRegistry::get_issuable_tokens_from_vault(id1).expect("Sample vault is unable to issue tokens");
 
             let id2 = 4;
             let collateral2 = 50;
             create_vault_with_collateral(id2, collateral2);
-            let issuable_tokens2 = VaultRegistry::get_issuable_tokens_from_vault(id2.clone())
-                .expect("Sample vault is unable to issue tokens");
+            let issuable_tokens2 =
+                VaultRegistry::get_issuable_tokens_from_vault(id2).expect("Sample vault is unable to issue tokens");
 
             // Check result is ordered in descending order
             assert_eq!(issuable_tokens1.gt(&issuable_tokens2), true);
@@ -1200,8 +1200,8 @@ mod get_vaults_with_issuable_tokens_tests {
             let id1 = 3;
             let collateral1 = 100;
             create_vault_with_collateral(id1, collateral1);
-            let issuable_tokens1 = VaultRegistry::get_issuable_tokens_from_vault(id1.clone())
-                .expect("Sample vault is unable to issue tokens");
+            let issuable_tokens1 =
+                VaultRegistry::get_issuable_tokens_from_vault(id1).expect("Sample vault is unable to issue tokens");
 
             let id2 = 4;
             let collateral2 = 50;
@@ -1226,8 +1226,8 @@ mod get_vaults_with_issuable_tokens_tests {
             let id1 = 3;
             let collateral1 = 100;
             create_vault_with_collateral(id1, collateral1);
-            let issuable_tokens1 = VaultRegistry::get_issuable_tokens_from_vault(id1.clone())
-                .expect("Sample vault is unable to issue tokens");
+            let issuable_tokens1 =
+                VaultRegistry::get_issuable_tokens_from_vault(id1).expect("Sample vault is unable to issue tokens");
 
             let id2 = 4;
             let collateral2 = 50;
@@ -1237,8 +1237,8 @@ mod get_vaults_with_issuable_tokens_tests {
             let mut vault = VaultRegistry::get_rich_vault_from_id(&id2).unwrap();
             vault.ban_until(1000);
 
-            let issuable_tokens2 = VaultRegistry::get_issuable_tokens_from_vault(id2.clone())
-                .expect("Sample vault is unable to issue tokens");
+            let issuable_tokens2 =
+                VaultRegistry::get_issuable_tokens_from_vault(id2).expect("Sample vault is unable to issue tokens");
 
             assert_eq!(issuable_tokens2, 0);
 
@@ -1256,8 +1256,8 @@ mod get_vaults_with_issuable_tokens_tests {
             let id1 = 3;
             let collateral1 = 100;
             create_vault_with_collateral(id1, collateral1);
-            let issuable_tokens1 = VaultRegistry::get_issuable_tokens_from_vault(id1.clone())
-                .expect("Sample vault is unable to issue tokens");
+            let issuable_tokens1 =
+                VaultRegistry::get_issuable_tokens_from_vault(id1).expect("Sample vault is unable to issue tokens");
 
             let id2 = 4;
             let collateral2 = 50;
@@ -1286,7 +1286,7 @@ mod get_vaults_with_issuable_tokens_tests {
             assert_eq!(vault.data.to_be_redeemed_tokens, 0);
 
             // update the exchange rate
-            ext::oracle::dots_to_btc::<Test>.mock_safe(move |x| MockResult::Return(Ok((x / 2).into())));
+            ext::oracle::dots_to_btc::<Test>.mock_safe(move |x| MockResult::Return(Ok(x / 2)));
 
             assert_err!(
                 VaultRegistry::get_vaults_with_issuable_tokens(),

--- a/parachain/rpc/src/lib.rs
+++ b/parachain/rpc/src/lib.rs
@@ -103,7 +103,7 @@ where
 
     io.extend_with(RefundApi::to_delegate(Refund::new(client.clone())));
 
-    io.extend_with(ReplaceApi::to_delegate(Replace::new(client.clone())));
+    io.extend_with(ReplaceApi::to_delegate(Replace::new(client)));
 
     io
 }

--- a/parachain/runtime/tests/bitcoin_data.rs
+++ b/parachain/runtime/tests/bitcoin_data.rs
@@ -2,8 +2,8 @@ use bitcoin::types::{H256Le, RawBlockHeader};
 use serde::Deserialize;
 use std::{fs, path::PathBuf};
 
-const ERR_FILE_NOT_FOUND: &'static str = "Testdata not found. Please run the python script under the parachain/scripts folder to obtain bitcoin blocks and transactions.";
-const ERR_JSON_FORMAT: &'static str = "JSON was not well-formatted";
+const ERR_FILE_NOT_FOUND: &str = "Testdata not found. Please run the python script under the parachain/scripts folder to obtain bitcoin blocks and transactions.";
+const ERR_JSON_FORMAT: &str = "JSON was not well-formatted";
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Block {

--- a/parachain/runtime/tests/mock/issue_testing_utils.rs
+++ b/parachain/runtime/tests/mock/issue_testing_utils.rs
@@ -96,7 +96,7 @@ impl ExecuteIssueBuilder {
     pub fn execute(&self) -> DispatchResultWithPostInfo {
         // send the btc from the user to the vault
         let (tx_id, _height, proof, raw_tx) = TransactionGenerator::new()
-            .with_address(self.issue.btc_address.clone())
+            .with_address(self.issue.btc_address)
             .with_amount(self.amount)
             .with_op_return(None)
             .with_relayer(self.relayer)
@@ -134,16 +134,17 @@ pub fn assert_issue_amount_change_event(issue_id: H256, amount: u128, fee: u128,
 
 pub fn assert_issue_request_event() -> H256 {
     let events = SystemModule::events();
-    let record = events.iter().rev().find(|record| match record.event {
-        Event::issue(IssueEvent::RequestIssue(_, _, _, _, _, _, _, _)) => true,
-        _ => false,
+    let record = events.iter().rev().find(|record| {
+        matches!(
+            record.event,
+            Event::issue(IssueEvent::RequestIssue(_, _, _, _, _, _, _, _))
+        )
     });
-    let id = if let Event::issue(IssueEvent::RequestIssue(id, _, _, _, _, _, _, _)) = record.unwrap().event {
+    if let Event::issue(IssueEvent::RequestIssue(id, _, _, _, _, _, _, _)) = record.unwrap().event {
         id
     } else {
         panic!("request issue event not found")
-    };
-    id
+    }
 }
 
 pub fn assert_refund_request_event() -> H256 {

--- a/parachain/runtime/tests/mock/redeem_testing_utils.rs
+++ b/parachain/runtime/tests/mock/redeem_testing_utils.rs
@@ -37,7 +37,7 @@ impl ExecuteRedeemBuilder {
     pub fn execute(&self) -> DispatchResultWithPostInfo {
         // send the btc from the user to the vault
         let (tx_id, _height, proof, raw_tx) = TransactionGenerator::new()
-            .with_address(self.redeem.btc_address.clone())
+            .with_address(self.redeem.btc_address)
             .with_amount(self.amount)
             .with_op_return(Some(self.redeem_id))
             .mine();
@@ -94,12 +94,12 @@ pub fn assert_redeem_request_event() -> H256 {
     let ids = events
         .iter()
         .filter_map(|r| match r.event {
-            Event::redeem(RedeemEvent::RequestRedeem(id, _, _, _, _, _, _)) => Some(id.clone()),
+            Event::redeem(RedeemEvent::RequestRedeem(id, _, _, _, _, _, _)) => Some(id),
             _ => None,
         })
         .collect::<Vec<H256>>();
     assert_eq!(ids.len(), 1);
-    ids[0].clone()
+    ids[0]
 }
 
 pub fn execute_redeem(redeem_id: H256) {

--- a/parachain/runtime/tests/test_fee_pool.rs
+++ b/parachain/runtime/tests/test_fee_pool.rs
@@ -11,7 +11,7 @@ const ISSUE_RELAYER: [u8; 32] = EVE;
 const RELAYER_1: [u8; 32] = FRANK;
 const RELAYER_2: [u8; 32] = GRACE;
 
-fn test_with(execute: impl Fn(Currency) -> ()) {
+fn test_with(execute: impl Fn(Currency)) {
     ExtBuilder::build().execute_with(|| {
         SecurityModule::set_active_block_number(1);
         assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));

--- a/parachain/runtime/tests/test_replace.rs
+++ b/parachain/runtime/tests/test_replace.rs
@@ -28,14 +28,11 @@ fn test_with<R>(execute: impl FnOnce() -> R) -> R {
 
 fn assert_request_event() {
     let events = SystemModule::events();
-    let ids = events
-        .iter()
-        .filter_map(|r| match r.event {
-            Event::replace(ReplaceEvent::RequestReplace(_, _, _)) => Some(()),
-            _ => None,
-        })
-        .collect::<Vec<_>>();
-    assert_eq!(ids.len(), 1);
+    let ids = events.iter().filter_map(|r| match r.event {
+        Event::replace(ReplaceEvent::RequestReplace(_, _, _)) => Some(()),
+        _ => None,
+    });
+    assert_eq!(ids.count(), 1);
 }
 
 pub fn assert_accept_event() -> H256 {
@@ -672,7 +669,7 @@ mod expiry_test {
     use super::*;
 
     /// test replace created by accept and auction
-    fn test_with(initial_period: u32, execute: impl Fn(H256) -> ()) {
+    fn test_with(initial_period: u32, execute: impl Fn(H256)) {
         let amount_btc = 5_000;
         let griefing_collateral = 1000;
         super::test_with(|| {
@@ -1107,9 +1104,7 @@ fn setup_replace(polkabtc: u128) -> H256 {
     ))
     .dispatch(origin_of(account_of(NEW_VAULT))));
 
-    let replace_id = assert_accept_event();
-
-    replace_id
+    assert_accept_event()
 }
 
 fn execute_replace(replace_id: H256) -> DispatchResultWithPostInfo {

--- a/parachain/service/src/grandpa.rs
+++ b/parachain/service/src/grandpa.rs
@@ -80,7 +80,7 @@ pub fn new_partial(
 
     let import_queue = sc_consensus_aura::import_queue::<AuraPair, _, _, _, _, _>(ImportQueueParams {
         block_import: aura_block_import.clone(),
-        justification_import: Some(Box::new(grandpa_block_import.clone())),
+        justification_import: Some(Box::new(grandpa_block_import)),
         client: client.clone(),
         inherent_data_providers: inherent_data_providers.clone(),
         spawner: &task_manager.spawn_essential_handle(),
@@ -193,7 +193,7 @@ pub fn new_full(mut config: Configuration) -> Result<(TaskManager, RpcHandlers),
             select_chain,
             block_import,
             proposer_factory,
-            inherent_data_providers: inherent_data_providers.clone(),
+            inherent_data_providers,
             force_authoring,
             backoff_authoring_blocks,
             keystore: keystore_container.sync_keystore(),
@@ -297,7 +297,7 @@ pub fn new_light(mut config: Configuration) -> Result<(TaskManager, RpcHandlers)
     let (grandpa_block_import, _) = sc_finality_grandpa::block_import(
         client.clone(),
         &(client.clone() as Arc<_>),
-        select_chain.clone(),
+        select_chain,
         telemetry.as_ref().map(|x| x.handle()),
     )?;
 
@@ -305,8 +305,8 @@ pub fn new_light(mut config: Configuration) -> Result<(TaskManager, RpcHandlers)
         sc_consensus_aura::AuraBlockImport::<_, _, _, AuraPair>::new(grandpa_block_import.clone(), client.clone());
 
     let import_queue = sc_consensus_aura::import_queue::<AuraPair, _, _, _, _, _>(ImportQueueParams {
-        block_import: aura_block_import.clone(),
-        justification_import: Some(Box::new(grandpa_block_import.clone())),
+        block_import: aura_block_import,
+        justification_import: Some(Box::new(grandpa_block_import)),
         client: client.clone(),
         inherent_data_providers: InherentDataProviders::new(),
         spawner: &task_manager.spawn_essential_handle(),

--- a/parachain/src/cli.rs
+++ b/parachain/src/cli.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 
-use sc_cli;
 use structopt::StructOpt;
 
 /// Sub-commands supported by the collator.


### PR DESCRIPTION
I did not fix _all_ warnings. There are still a lot of warning remaining, many of which are in test code, but I did not feel it's worth the time right now to fix them. Also, there are tons of warning generated from inside macro's.