### PR TITLE
Fix: parachain status tests

### DIFF
--- a/crates/btc-relay/src/ext.rs
+++ b/crates/btc-relay/src/ext.rs
@@ -11,6 +11,11 @@ pub(crate) mod security {
     use frame_support::dispatch::DispatchError;
     type UnitResult = Result<(), DispatchError>;
 
+    #[cfg(test)]
+    pub fn ensure_parachain_status_running<T: security::Config>() -> UnitResult {
+        <security::Module<T>>::ensure_parachain_status_running()
+    }
+
     pub fn ensure_parachain_status_not_shutdown<T: security::Config>() -> UnitResult {
         <security::Pallet<T>>::ensure_parachain_status_not_shutdown()
     }

--- a/crates/btc-relay/src/ext.rs
+++ b/crates/btc-relay/src/ext.rs
@@ -11,10 +11,6 @@ pub(crate) mod security {
     use frame_support::dispatch::DispatchError;
     type UnitResult = Result<(), DispatchError>;
 
-    pub fn ensure_parachain_status_running<T: security::Config>() -> UnitResult {
-        <security::Pallet<T>>::ensure_parachain_status_running()
-    }
-
     pub fn ensure_parachain_status_not_shutdown<T: security::Config>() -> UnitResult {
         <security::Pallet<T>>::ensure_parachain_status_not_shutdown()
     }

--- a/crates/btc-relay/src/ext.rs
+++ b/crates/btc-relay/src/ext.rs
@@ -11,7 +11,6 @@ pub(crate) mod security {
     use frame_support::dispatch::DispatchError;
     type UnitResult = Result<(), DispatchError>;
 
-    #[cfg(test)]
     pub fn ensure_parachain_status_running<T: security::Config>() -> UnitResult {
         <security::Pallet<T>>::ensure_parachain_status_running()
     }

--- a/crates/btc-relay/src/ext.rs
+++ b/crates/btc-relay/src/ext.rs
@@ -13,7 +13,7 @@ pub(crate) mod security {
 
     #[cfg(test)]
     pub fn ensure_parachain_status_running<T: security::Config>() -> UnitResult {
-        <security::Module<T>>::ensure_parachain_status_running()
+        <security::Pallet<T>>::ensure_parachain_status_running()
     }
 
     pub fn ensure_parachain_status_not_shutdown<T: security::Config>() -> UnitResult {

--- a/crates/btc-relay/src/lib.rs
+++ b/crates/btc-relay/src/lib.rs
@@ -207,7 +207,7 @@ decl_module! {
             recipient_btc_address: BtcAddress,
             op_return_id: Option<Vec<u8>>)
         -> DispatchResult {
-            ext::security::ensure_parachain_status_running::<T>()?;
+            ext::security::ensure_parachain_status_not_shutdown::<T>()?;
             let _ = ensure_signed(origin)?;
 
             let transaction = Self::parse_transaction(&raw_tx)?;
@@ -252,14 +252,9 @@ decl_module! {
             origin,
             tx_id: H256Le,
             raw_merkle_proof: Vec<u8>,
-<<<<<<< HEAD
-            confirmations: Option<u32>
-        ) -> DispatchResult {
-=======
             confirmations: Option<u32>)
         -> DispatchResult {
-            ext::security::ensure_parachain_status_running::<T>()?;
->>>>>>> test: parachain shutdown check
+            ext::security::ensure_parachain_status_not_shutdown::<T>()?;
             let _ = ensure_signed(origin)?;
             Self::_verify_transaction_inclusion(tx_id, raw_merkle_proof, confirmations)?;
             Ok(())
@@ -284,7 +279,7 @@ decl_module! {
             recipient_btc_address: BtcAddress,
             op_return_id: Option<Vec<u8>>
         ) -> DispatchResult {
-            ext::security::ensure_parachain_status_running::<T>()?;
+            ext::security::ensure_parachain_status_not_shutdown::<T>()?;
             let _ = ensure_signed(origin)?;
             Self::_validate_transaction(raw_tx, Some(minimum_btc), recipient_btc_address, op_return_id)?;
             Ok(())

--- a/crates/btc-relay/src/lib.rs
+++ b/crates/btc-relay/src/lib.rs
@@ -205,8 +205,9 @@ decl_module! {
             raw_tx: Vec<u8>,
             minimum_btc: i64,
             recipient_btc_address: BtcAddress,
-            op_return_id: Option<Vec<u8>>
-        ) -> DispatchResult {
+            op_return_id: Option<Vec<u8>>)
+        -> DispatchResult {
+            ext::security::ensure_parachain_status_running::<T>()?;
             let _ = ensure_signed(origin)?;
 
             let transaction = Self::parse_transaction(&raw_tx)?;
@@ -251,8 +252,14 @@ decl_module! {
             origin,
             tx_id: H256Le,
             raw_merkle_proof: Vec<u8>,
+<<<<<<< HEAD
             confirmations: Option<u32>
         ) -> DispatchResult {
+=======
+            confirmations: Option<u32>)
+        -> DispatchResult {
+            ext::security::ensure_parachain_status_running::<T>()?;
+>>>>>>> test: parachain shutdown check
             let _ = ensure_signed(origin)?;
             Self::_verify_transaction_inclusion(tx_id, raw_merkle_proof, confirmations)?;
             Ok(())
@@ -277,6 +284,7 @@ decl_module! {
             recipient_btc_address: BtcAddress,
             op_return_id: Option<Vec<u8>>
         ) -> DispatchResult {
+            ext::security::ensure_parachain_status_running::<T>()?;
             let _ = ensure_signed(origin)?;
             Self::_validate_transaction(raw_tx, Some(minimum_btc), recipient_btc_address, op_return_id)?;
             Ok(())

--- a/crates/btc-relay/src/mock.rs
+++ b/crates/btc-relay/src/mock.rs
@@ -136,7 +136,7 @@ impl collateral::Config for Test {
 impl vault_registry::Config for Test {
     type Event = TestEvent;
     type UnsignedFixedPoint = FixedU128;
-    type RandomnessSource = pallet_randomness_collective_flip::Module<Test>;
+    type RandomnessSource = pallet_randomness_collective_flip::Pallet<Test>;
     type WeightInfo = ();
 }
 

--- a/crates/btc-relay/src/tests.rs
+++ b/crates/btc-relay/src/tests.rs
@@ -466,7 +466,7 @@ fn swap_main_blockchain_succeeds() {
         );
 
         // check that the parachain has recovered
-        assert_ok!(ext::security::ensure_parachain_status_running::<Test>());
+        assert_ok!(ext::security::ensure_parachain_status_not_shutdown::<Test>());
         assert!(!ext::security::is_parachain_error_no_data_btcrelay::<Test>());
 
         // check that the old main chain is stored in a old fork
@@ -1086,13 +1086,13 @@ fn test_clear_block_error_succeeds() {
         clear_error(ErrorCode::NoDataBTCRelay);
         // ensure not recovered while there are still invalid blocks
         assert_err!(
-            ext::security::ensure_parachain_status_running::<Test>(),
+            ext::security::ensure_parachain_status_not_shutdown::<Test>(),
             SecurityError::ParachainNotRunning
         );
         assert!(ext::security::is_parachain_error_invalid_btcrelay::<Test>());
         clear_error(ErrorCode::InvalidBTCRelay);
 
-        assert_ok!(ext::security::ensure_parachain_status_running::<Test>());
+        assert_ok!(ext::security::ensure_parachain_status_not_shutdown::<Test>());
         assert!(!ext::security::is_parachain_error_invalid_btcrelay::<Test>());
         assert!(!ext::security::is_parachain_error_no_data_btcrelay::<Test>());
     })

--- a/crates/btc-relay/src/tests.rs
+++ b/crates/btc-relay/src/tests.rs
@@ -466,7 +466,7 @@ fn swap_main_blockchain_succeeds() {
         );
 
         // check that the parachain has recovered
-        assert_ok!(ext::security::ensure_parachain_status_not_shutdown::<Test>());
+        assert_ok!(ext::security::ensure_parachain_status_running::<Test>());
         assert!(!ext::security::is_parachain_error_no_data_btcrelay::<Test>());
 
         // check that the old main chain is stored in a old fork
@@ -1086,13 +1086,13 @@ fn test_clear_block_error_succeeds() {
         clear_error(ErrorCode::NoDataBTCRelay);
         // ensure not recovered while there are still invalid blocks
         assert_err!(
-            ext::security::ensure_parachain_status_not_shutdown::<Test>(),
+            ext::security::ensure_parachain_status_running::<Test>(),
             SecurityError::ParachainNotRunning
         );
         assert!(ext::security::is_parachain_error_invalid_btcrelay::<Test>());
         clear_error(ErrorCode::InvalidBTCRelay);
 
-        assert_ok!(ext::security::ensure_parachain_status_not_shutdown::<Test>());
+        assert_ok!(ext::security::ensure_parachain_status_running::<Test>());
         assert!(!ext::security::is_parachain_error_invalid_btcrelay::<Test>());
         assert!(!ext::security::is_parachain_error_no_data_btcrelay::<Test>());
     })

--- a/crates/exchange-rate-oracle/src/tests.rs
+++ b/crates/exchange-rate-oracle/src/tests.rs
@@ -90,11 +90,12 @@ fn set_exchange_rate_fails_with_invalid_oracle_source() {
 }
 
 #[test]
-fn get_exchange_rate_fails_with_missing_exchange_rate() {
+fn getting_exchange_rate_fails_with_missing_exchange_rate() {
     run_test(|| {
         ExchangeRateOracle::is_max_delay_passed.mock_safe(|| MockResult::Return(true));
-        let result = ExchangeRateOracle::get_exchange_rate();
-        assert_err!(result, TestError::MissingExchangeRate);
+        assert_err!(ExchangeRateOracle::get_exchange_rate(), TestError::MissingExchangeRate);
+        assert_err!(ExchangeRateOracle::btc_to_dots(0), TestError::MissingExchangeRate);
+        assert_err!(ExchangeRateOracle::dots_to_btc(0), TestError::MissingExchangeRate);
     });
 }
 

--- a/crates/fee/Cargo.toml
+++ b/crates/fee/Cargo.toml
@@ -25,6 +25,7 @@ pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "r
 collateral = { path = "../collateral", default-features = false }
 treasury = { path = "../treasury", default-features = false }
 sla = { path = "../sla", default-features = false }
+security = { path = "../security", default-features = false }
 
 [dev-dependencies]
 mocktopus = "0.7.0"
@@ -32,7 +33,6 @@ frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch =
 pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 
-security = { path = "../security", default-features = false }
 exchange-rate-oracle = { path = "../exchange-rate-oracle", default-features = false }
 vault-registry = { path = "../vault-registry", default-features = false }
 
@@ -52,6 +52,7 @@ std = [
 	"pallet-balances/std",
 	"collateral/std",
 	"treasury/std",
+	"security/std",
 	"sla/std",
 ]
 runtime-benchmarks = [

--- a/crates/fee/src/ext.rs
+++ b/crates/fee/src/ext.rs
@@ -62,6 +62,6 @@ pub(crate) mod security {
     use frame_support::dispatch::DispatchError;
 
     pub fn ensure_parachain_status_not_shutdown<T: security::Config>() -> Result<(), DispatchError> {
-        <security::Module<T>>::ensure_parachain_status_not_shutdown()
+        <security::Pallet<T>>::ensure_parachain_status_not_shutdown()
     }
 }

--- a/crates/fee/src/ext.rs
+++ b/crates/fee/src/ext.rs
@@ -61,7 +61,7 @@ pub(crate) mod sla {
 pub(crate) mod security {
     use frame_support::dispatch::DispatchError;
 
-    pub fn ensure_parachain_status_running<T: security::Config>() -> Result<(), DispatchError> {
-        <security::Module<T>>::ensure_parachain_status_running()
+    pub fn ensure_parachain_status_not_shutdown<T: security::Config>() -> Result<(), DispatchError> {
+        <security::Module<T>>::ensure_parachain_status_not_shutdown()
     }
 }

--- a/crates/fee/src/ext.rs
+++ b/crates/fee/src/ext.rs
@@ -56,3 +56,12 @@ pub(crate) mod sla {
         )
     }
 }
+
+#[cfg_attr(test, mockable)]
+pub(crate) mod security {
+    use frame_support::dispatch::DispatchError;
+
+    pub fn ensure_parachain_status_running<T: security::Config>() -> Result<(), DispatchError> {
+        <security::Module<T>>::ensure_parachain_status_running()
+    }
+}

--- a/crates/fee/src/lib.rs
+++ b/crates/fee/src/lib.rs
@@ -39,7 +39,9 @@ use sp_std::{convert::TryInto, vec::*};
 use types::{Inner, PolkaBTC, UnsignedFixedPoint, DOT};
 
 /// The pallet's configuration trait.
-pub trait Config: frame_system::Config + collateral::Config + treasury::Config + sla::Config {
+pub trait Config:
+    frame_system::Config + collateral::Config + treasury::Config + sla::Config + security::Config
+{
     /// The overarching event type.
     type Event: From<Event<Self>> + Into<<Self as frame_system::Config>::Event>;
 
@@ -196,6 +198,7 @@ decl_module! {
         #[transactional]
         fn withdraw_polka_btc(origin, amount: PolkaBTC<T>) -> DispatchResult
         {
+            ext::security::ensure_parachain_status_running::<T>()?;
             let signer = ensure_signed(origin)?;
             <TotalRewardsPolkaBTC<T>>::insert(signer.clone(), <TotalRewardsPolkaBTC<T>>::get(signer.clone()).checked_sub(&amount).ok_or(Error::<T>::InsufficientFunds)?);
             ext::treasury::transfer::<T>(Self::fee_pool_account_id(), signer.clone(), amount)?;
@@ -216,6 +219,7 @@ decl_module! {
         #[transactional]
         fn withdraw_dot(origin, amount: DOT<T>) -> DispatchResult
         {
+            ext::security::ensure_parachain_status_running::<T>()?;
             let signer = ensure_signed(origin)?;
             <TotalRewardsDOT<T>>::insert(signer.clone(), <TotalRewardsDOT<T>>::get(signer.clone()).checked_sub(&amount).ok_or(Error::<T>::InsufficientFunds)?);
             ext::collateral::transfer::<T>(Self::fee_pool_account_id(), signer.clone(), amount)?;

--- a/crates/fee/src/lib.rs
+++ b/crates/fee/src/lib.rs
@@ -198,7 +198,7 @@ decl_module! {
         #[transactional]
         fn withdraw_polka_btc(origin, amount: PolkaBTC<T>) -> DispatchResult
         {
-            ext::security::ensure_parachain_status_running::<T>()?;
+            ext::security::ensure_parachain_status_not_shutdown::<T>()?;
             let signer = ensure_signed(origin)?;
             <TotalRewardsPolkaBTC<T>>::insert(signer.clone(), <TotalRewardsPolkaBTC<T>>::get(signer.clone()).checked_sub(&amount).ok_or(Error::<T>::InsufficientFunds)?);
             ext::treasury::transfer::<T>(Self::fee_pool_account_id(), signer.clone(), amount)?;
@@ -219,7 +219,7 @@ decl_module! {
         #[transactional]
         fn withdraw_dot(origin, amount: DOT<T>) -> DispatchResult
         {
-            ext::security::ensure_parachain_status_running::<T>()?;
+            ext::security::ensure_parachain_status_not_shutdown::<T>()?;
             let signer = ensure_signed(origin)?;
             <TotalRewardsDOT<T>>::insert(signer.clone(), <TotalRewardsDOT<T>>::get(signer.clone()).checked_sub(&amount).ok_or(Error::<T>::InsufficientFunds)?);
             ext::collateral::transfer::<T>(Self::fee_pool_account_id(), signer.clone(), amount)?;

--- a/crates/fee/src/mock.rs
+++ b/crates/fee/src/mock.rs
@@ -128,7 +128,7 @@ impl exchange_rate_oracle::Config for Test {
 
 impl vault_registry::Config for Test {
     type Event = TestEvent;
-    type RandomnessSource = pallet_randomness_collective_flip::Module<Test>;
+    type RandomnessSource = pallet_randomness_collective_flip::Pallet<Test>;
     type UnsignedFixedPoint = FixedU128;
     type WeightInfo = ();
 }

--- a/crates/issue/src/ext.rs
+++ b/crates/issue/src/ext.rs
@@ -129,8 +129,8 @@ pub(crate) mod security {
         <security::Pallet<T>>::get_secure_id(id)
     }
 
-    pub fn ensure_parachain_status_running<T: security::Config>() -> DispatchResult {
-        <security::Pallet<T>>::ensure_parachain_status_running()
+    pub fn ensure_parachain_status_not_shutdown<T: security::Config>() -> DispatchResult {
+        <security::Pallet<T>>::ensure_parachain_status_not_shutdown()
     }
 
     pub fn active_block_number<T: security::Config>() -> T::BlockNumber {

--- a/crates/issue/src/ext.rs
+++ b/crates/issue/src/ext.rs
@@ -29,7 +29,7 @@ pub(crate) mod btc_relay {
     }
 
     pub fn is_fully_initialized<T: btc_relay::Config>() -> Result<bool, DispatchError> {
-        <btc_relay::Module<T>>::is_fully_initialized()
+        <btc_relay::Pallet<T>>::is_fully_initialized()
     }
 }
 

--- a/crates/issue/src/lib.rs
+++ b/crates/issue/src/lib.rs
@@ -432,6 +432,9 @@ impl<T: Config> Module<T> {
 
     /// Cancels CBA issuance if time has expired and slashes collateral.
     fn _cancel_issue(requester: T::AccountId, issue_id: H256) -> Result<(), DispatchError> {
+        // Check that Parachain is RUNNING
+        ext::security::ensure_parachain_status_running::<T>()?;
+
         let issue = Self::get_issue_request_from_id(&issue_id)?;
 
         // only cancellable after the request has expired

--- a/crates/issue/src/lib.rs
+++ b/crates/issue/src/lib.rs
@@ -233,7 +233,7 @@ impl<T: Config> Module<T> {
         griefing_collateral: DOT<T>,
     ) -> Result<H256, DispatchError> {
         // Check that Parachain is RUNNING
-        ext::security::ensure_parachain_status_running::<T>()?;
+        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
 
         ensure!(
             ext::btc_relay::is_fully_initialized::<T>()?,
@@ -308,7 +308,7 @@ impl<T: Config> Module<T> {
         raw_tx: Vec<u8>,
     ) -> Result<(), DispatchError> {
         // Check that Parachain is RUNNING
-        ext::security::ensure_parachain_status_running::<T>()?;
+        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
 
         let mut issue = Self::get_issue_request_from_id(&issue_id)?;
         let mut maybe_refund_id = None;
@@ -433,7 +433,7 @@ impl<T: Config> Module<T> {
     /// Cancels CBA issuance if time has expired and slashes collateral.
     fn _cancel_issue(requester: T::AccountId, issue_id: H256) -> Result<(), DispatchError> {
         // Check that Parachain is RUNNING
-        ext::security::ensure_parachain_status_running::<T>()?;
+        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
 
         let issue = Self::get_issue_request_from_id(&issue_id)?;
 

--- a/crates/issue/src/mock.rs
+++ b/crates/issue/src/mock.rs
@@ -115,7 +115,7 @@ impl pallet_balances::Config<pallet_balances::Instance2> for Test {
 
 impl vault_registry::Config for Test {
     type Event = TestEvent;
-    type RandomnessSource = pallet_randomness_collective_flip::Module<Test>;
+    type RandomnessSource = pallet_randomness_collective_flip::Pallet<Test>;
     type UnsignedFixedPoint = FixedU128;
     type WeightInfo = ();
 }

--- a/crates/issue/src/tests.rs
+++ b/crates/issue/src/tests.rs
@@ -16,7 +16,7 @@ fn request_issue(
     collateral: Balance,
 ) -> Result<H256, DispatchError> {
     // Default: Parachain status is "RUNNING". Set manually for failure testing
-    ext::security::ensure_parachain_status_running::<Test>.mock_safe(|| MockResult::Return(Ok(())));
+    ext::security::ensure_parachain_status_not_shutdown::<Test>.mock_safe(|| MockResult::Return(Ok(())));
 
     ext::security::get_secure_id::<Test>.mock_safe(|_| MockResult::Return(get_dummy_request_id()));
 
@@ -31,7 +31,7 @@ fn request_issue_ok(origin: AccountId, amount: Balance, vault: AccountId, collat
     ext::vault_registry::ensure_not_banned::<Test>.mock_safe(|_| MockResult::Return(Ok(())));
 
     // Default: Parachain status is "RUNNING". Set manually for failure testing
-    ext::security::ensure_parachain_status_running::<Test>.mock_safe(|| MockResult::Return(Ok(())));
+    ext::security::ensure_parachain_status_not_shutdown::<Test>.mock_safe(|| MockResult::Return(Ok(())));
 
     ext::security::get_secure_id::<Test>.mock_safe(|_| MockResult::Return(get_dummy_request_id()));
 
@@ -43,7 +43,7 @@ fn request_issue_ok(origin: AccountId, amount: Balance, vault: AccountId, collat
 }
 
 fn execute_issue(origin: AccountId, issue_id: &H256) -> Result<(), DispatchError> {
-    ext::security::ensure_parachain_status_running::<Test>.mock_safe(|| MockResult::Return(Ok(())));
+    ext::security::ensure_parachain_status_not_shutdown::<Test>.mock_safe(|| MockResult::Return(Ok(())));
 
     Issue::_execute_issue(origin, *issue_id, vec![0u8; 100], vec![0u8; 100])
 }
@@ -165,7 +165,7 @@ fn test_execute_issue_succeeds() {
         let issue_id = request_issue_ok(ALICE, 3, BOB, 20);
         <security::Pallet<Test>>::set_active_block_number(5);
 
-        ext::security::ensure_parachain_status_running::<Test>.mock_safe(|| MockResult::Return(Ok(())));
+        ext::security::ensure_parachain_status_not_shutdown::<Test>.mock_safe(|| MockResult::Return(Ok(())));
         ext::btc_relay::verify_transaction_inclusion::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
         ext::btc_relay::validate_transaction::<Test>
             .mock_safe(|_, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 3))));
@@ -188,7 +188,7 @@ fn test_execute_issue_overpayment_succeeds() {
 
         let issue_id = request_issue_ok(ALICE, 3, BOB, 20);
         <security::Pallet<Test>>::set_active_block_number(5);
-        ext::security::ensure_parachain_status_running::<Test>.mock_safe(|| MockResult::Return(Ok(())));
+        ext::security::ensure_parachain_status_not_shutdown::<Test>.mock_safe(|| MockResult::Return(Ok(())));
 
         ext::btc_relay::verify_transaction_inclusion::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
 
@@ -230,7 +230,7 @@ fn test_execute_issue_refund_succeeds() {
 
         let issue_id = request_issue_ok(ALICE, 3, BOB, 20);
         <security::Pallet<Test>>::set_active_block_number(5);
-        ext::security::ensure_parachain_status_running::<Test>.mock_safe(|| MockResult::Return(Ok(())));
+        ext::security::ensure_parachain_status_not_shutdown::<Test>.mock_safe(|| MockResult::Return(Ok(())));
 
         ext::btc_relay::verify_transaction_inclusion::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
 
@@ -308,7 +308,7 @@ fn test_request_issue_parachain_not_running_fails() {
         let vault = BOB;
         let amount: Balance = 3;
 
-        ext::security::ensure_parachain_status_running::<Test>
+        ext::security::ensure_parachain_status_not_shutdown::<Test>
             .mock_safe(|| MockResult::Return(Err(SecurityError::ParachainNotRunning.into())));
 
         assert_noop!(
@@ -323,7 +323,7 @@ fn test_execute_issue_parachain_not_running_fails() {
     run_test(|| {
         let origin = ALICE;
 
-        ext::security::ensure_parachain_status_running::<Test>
+        ext::security::ensure_parachain_status_not_shutdown::<Test>
             .mock_safe(|| MockResult::Return(Err(SecurityError::ParachainNotRunning.into())));
 
         assert_noop!(

--- a/crates/redeem/src/ext.rs
+++ b/crates/redeem/src/ext.rs
@@ -208,8 +208,8 @@ pub(crate) mod security {
         <security::Pallet<T>>::get_secure_id(id)
     }
 
-    pub fn ensure_parachain_status_running<T: security::Config>() -> Result<(), DispatchError> {
-        <security::Pallet<T>>::ensure_parachain_status_running()
+    pub fn ensure_parachain_status_not_shutdown<T: security::Config>() -> Result<(), DispatchError> {
+        <security::Pallet<T>>::ensure_parachain_status_not_shutdown()
     }
 
     pub fn active_block_number<T: security::Config>() -> T::BlockNumber {

--- a/crates/redeem/src/lib.rs
+++ b/crates/redeem/src/lib.rs
@@ -259,7 +259,7 @@ decl_module! {
         fn mint_tokens_for_reimbursed_redeem(origin, redeem_id: H256)
             -> DispatchResult
         {
-            let redeemer = ensure_signed(origin)?;
+        let redeemer = ensure_signed(origin)?;
             Self::_mint_tokens_for_reimbursed_redeem(redeemer, redeem_id)?;
             Ok(())
         }
@@ -426,6 +426,8 @@ impl<T: Config> Module<T> {
     }
 
     fn _cancel_redeem(redeemer: T::AccountId, redeem_id: H256, reimburse: bool) -> DispatchResult {
+        ext::security::ensure_parachain_status_running::<T>()?;
+
         let redeem = Self::get_open_redeem_request_from_id(&redeem_id)?;
         ensure!(redeemer == redeem.redeemer, Error::<T>::UnauthorizedUser);
 
@@ -553,6 +555,7 @@ impl<T: Config> Module<T> {
     }
 
     fn _mint_tokens_for_reimbursed_redeem(vault_id: T::AccountId, redeem_id: H256) -> DispatchResult {
+        ext::security::ensure_parachain_status_running::<T>()?;
         ensure!(
             <RedeemRequests<T>>::contains_key(&redeem_id),
             Error::<T>::RedeemIdNotFound

--- a/crates/redeem/src/lib.rs
+++ b/crates/redeem/src/lib.rs
@@ -275,7 +275,7 @@ impl<T: Config> Module<T> {
         btc_address: BtcAddress,
         vault_id: T::AccountId,
     ) -> Result<H256, DispatchError> {
-        ext::security::ensure_parachain_status_running::<T>()?;
+        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
 
         let redeemer_balance = ext::treasury::get_balance::<T>(redeemer.clone());
         ensure!(
@@ -355,7 +355,7 @@ impl<T: Config> Module<T> {
     }
 
     fn _liquidation_redeem(redeemer: T::AccountId, amount_polka_btc: PolkaBTC<T>) -> Result<(), DispatchError> {
-        ext::security::ensure_parachain_status_running::<T>()?;
+        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
 
         let redeemer_balance = ext::treasury::get_balance::<T>(redeemer.clone());
         ensure!(
@@ -374,7 +374,7 @@ impl<T: Config> Module<T> {
     }
 
     fn _execute_redeem(redeem_id: H256, merkle_proof: Vec<u8>, raw_tx: Vec<u8>) -> Result<(), DispatchError> {
-        ext::security::ensure_parachain_status_running::<T>()?;
+        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
 
         let redeem = Self::get_open_redeem_request_from_id(&redeem_id)?;
 
@@ -426,7 +426,7 @@ impl<T: Config> Module<T> {
     }
 
     fn _cancel_redeem(redeemer: T::AccountId, redeem_id: H256, reimburse: bool) -> DispatchResult {
-        ext::security::ensure_parachain_status_running::<T>()?;
+        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
 
         let redeem = Self::get_open_redeem_request_from_id(&redeem_id)?;
         ensure!(redeemer == redeem.redeemer, Error::<T>::UnauthorizedUser);
@@ -555,7 +555,7 @@ impl<T: Config> Module<T> {
     }
 
     fn _mint_tokens_for_reimbursed_redeem(vault_id: T::AccountId, redeem_id: H256) -> DispatchResult {
-        ext::security::ensure_parachain_status_running::<T>()?;
+        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
         ensure!(
             <RedeemRequests<T>>::contains_key(&redeem_id),
             Error::<T>::RedeemIdNotFound

--- a/crates/redeem/src/mock.rs
+++ b/crates/redeem/src/mock.rs
@@ -114,7 +114,7 @@ impl pallet_balances::Config<pallet_balances::Instance2> for Test {
 
 impl vault_registry::Config for Test {
     type Event = TestEvent;
-    type RandomnessSource = pallet_randomness_collective_flip::Module<Test>;
+    type RandomnessSource = pallet_randomness_collective_flip::Pallet<Test>;
     type UnsignedFixedPoint = FixedU128;
     type WeightInfo = ();
 }

--- a/crates/refund/src/ext.rs
+++ b/crates/refund/src/ext.rs
@@ -54,8 +54,8 @@ pub(crate) mod security {
         <security::Pallet<T>>::get_secure_id(id)
     }
 
-    pub fn ensure_parachain_status_running<T: security::Config>() -> DispatchResult {
-        <security::Module<T>>::ensure_parachain_status_running()
+    pub fn ensure_parachain_status_not_shutdown<T: security::Config>() -> DispatchResult {
+        <security::Module<T>>::ensure_parachain_status_not_shutdown()
     }
 }
 

--- a/crates/refund/src/ext.rs
+++ b/crates/refund/src/ext.rs
@@ -47,10 +47,15 @@ pub(crate) mod btc_relay {
 
 #[cfg_attr(test, mockable)]
 pub(crate) mod security {
+    use frame_support::dispatch::DispatchResult;
     use primitive_types::H256;
 
     pub fn get_secure_id<T: security::Config>(id: &T::AccountId) -> H256 {
         <security::Pallet<T>>::get_secure_id(id)
+    }
+
+    pub fn ensure_parachain_status_running<T: security::Config>() -> DispatchResult {
+        <security::Module<T>>::ensure_parachain_status_running()
     }
 }
 

--- a/crates/refund/src/ext.rs
+++ b/crates/refund/src/ext.rs
@@ -55,7 +55,7 @@ pub(crate) mod security {
     }
 
     pub fn ensure_parachain_status_not_shutdown<T: security::Config>() -> DispatchResult {
-        <security::Module<T>>::ensure_parachain_status_not_shutdown()
+        <security::Pallet<T>>::ensure_parachain_status_not_shutdown()
     }
 }
 

--- a/crates/refund/src/lib.rs
+++ b/crates/refund/src/lib.rs
@@ -122,7 +122,7 @@ impl<T: Config> Module<T> {
         btc_address: BtcAddress,
         issue_id: H256,
     ) -> Result<Option<H256>, DispatchError> {
-        ext::security::ensure_parachain_status_running::<T>()?;
+        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
 
         let fee_polka_btc = ext::fee::get_refund_fee_from_total::<T>(total_amount_btc)?;
         let net_refund_amount_polka_btc = total_amount_btc
@@ -171,7 +171,7 @@ impl<T: Config> Module<T> {
     /// * `merkle_proof` - raw bytes of the proof
     /// * `raw_tx` - raw bytes of the transaction
     fn _execute_refund(refund_id: H256, merkle_proof: Vec<u8>, raw_tx: Vec<u8>) -> Result<(), DispatchError> {
-        ext::security::ensure_parachain_status_running::<T>()?;
+        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
 
         let request = Self::get_open_refund_request_from_id(&refund_id)?;
 

--- a/crates/refund/src/lib.rs
+++ b/crates/refund/src/lib.rs
@@ -122,6 +122,8 @@ impl<T: Config> Module<T> {
         btc_address: BtcAddress,
         issue_id: H256,
     ) -> Result<Option<H256>, DispatchError> {
+        ext::security::ensure_parachain_status_running::<T>()?;
+
         let fee_polka_btc = ext::fee::get_refund_fee_from_total::<T>(total_amount_btc)?;
         let net_refund_amount_polka_btc = total_amount_btc
             .checked_sub(&fee_polka_btc)
@@ -169,6 +171,8 @@ impl<T: Config> Module<T> {
     /// * `merkle_proof` - raw bytes of the proof
     /// * `raw_tx` - raw bytes of the transaction
     fn _execute_refund(refund_id: H256, merkle_proof: Vec<u8>, raw_tx: Vec<u8>) -> Result<(), DispatchError> {
+        ext::security::ensure_parachain_status_running::<T>()?;
+
         let request = Self::get_open_refund_request_from_id(&refund_id)?;
 
         // verify the payment

--- a/crates/refund/src/mock.rs
+++ b/crates/refund/src/mock.rs
@@ -152,7 +152,7 @@ impl security::Config for Test {
 
 impl vault_registry::Config for Test {
     type Event = TestEvent;
-    type RandomnessSource = pallet_randomness_collective_flip::Module<Test>;
+    type RandomnessSource = pallet_randomness_collective_flip::Pallet<Test>;
     type UnsignedFixedPoint = FixedU128;
     type WeightInfo = ();
 }

--- a/crates/replace/src/ext.rs
+++ b/crates/replace/src/ext.rs
@@ -172,8 +172,8 @@ pub(crate) mod security {
         <security::Pallet<T>>::get_secure_id(id)
     }
 
-    pub fn ensure_parachain_status_running<T: security::Config>() -> DispatchResult {
-        <security::Pallet<T>>::ensure_parachain_status_running()
+    pub fn ensure_parachain_status_not_shutdown<T: security::Config>() -> DispatchResult {
+        <security::Pallet<T>>::ensure_parachain_status_not_shutdown()
     }
 
     pub fn active_block_number<T: security::Config>() -> T::BlockNumber {

--- a/crates/replace/src/lib.rs
+++ b/crates/replace/src/lib.rs
@@ -186,6 +186,7 @@ decl_module! {
         fn request_replace(origin, amount: PolkaBTC<T>, griefing_collateral: DOT<T>)
             -> DispatchResult
         {
+            ext::security::ensure_parachain_status_not_shutdown::<T>()?;
             let old_vault = ensure_signed(origin)?;
             Self::_request_replace(old_vault, amount, griefing_collateral)?;
             Ok(())
@@ -201,6 +202,7 @@ decl_module! {
         fn withdraw_replace(origin, amount: PolkaBTC<T>)
             -> DispatchResult
         {
+            ext::security::ensure_parachain_status_not_shutdown::<T>()?;
             let old_vault = ensure_signed(origin)?;
             Self::_withdraw_replace_request(old_vault, amount)?;
             Ok(())
@@ -219,6 +221,7 @@ decl_module! {
         fn accept_replace(origin, old_vault: T::AccountId, amount_btc: PolkaBTC<T>, collateral: DOT<T>, btc_address: BtcAddress)
             -> DispatchResult
         {
+            ext::security::ensure_parachain_status_not_shutdown::<T>()?;
             let new_vault = ensure_signed(origin)?;
             Self::_accept_replace(old_vault, new_vault, amount_btc, collateral, btc_address)?;
             Ok(())
@@ -237,6 +240,7 @@ decl_module! {
         fn auction_replace(origin, old_vault: T::AccountId, btc_amount: PolkaBTC<T>, collateral: DOT<T>, btc_address: BtcAddress)
             -> DispatchResult
         {
+            ext::security::ensure_parachain_status_not_shutdown::<T>()?;
             let new_vault = ensure_signed(origin)?;
             Self::_auction_replace(old_vault, new_vault, btc_amount, collateral, btc_address)?;
             Ok(())
@@ -254,6 +258,7 @@ decl_module! {
         #[weight = <T as Config>::WeightInfo::execute_replace()]
         #[transactional]
         fn execute_replace(origin, replace_id: H256, merkle_proof: Vec<u8>, raw_tx: Vec<u8>) -> DispatchResult {
+            ext::security::ensure_parachain_status_not_shutdown::<T>()?;
             let _ = ensure_signed(origin)?;
             Self::_execute_replace(replace_id, merkle_proof, raw_tx)?;
             Ok(())
@@ -268,6 +273,7 @@ decl_module! {
         #[weight = <T as Config>::WeightInfo::cancel_replace()]
         #[transactional]
         fn cancel_replace(origin, replace_id: H256) -> DispatchResult {
+            ext::security::ensure_parachain_status_not_shutdown::<T>()?;
             let new_vault = ensure_signed(origin)?;
             Self::_cancel_replace(new_vault, replace_id)?;
             Ok(())
@@ -298,9 +304,6 @@ impl<T: Config> Module<T> {
         amount_btc: PolkaBTC<T>,
         griefing_collateral: DOT<T>,
     ) -> DispatchResult {
-        // Check that Parachain status is RUNNING
-        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
-
         // check vault is not banned
         ext::vault_registry::ensure_not_banned::<T>(&vault_id)?;
 
@@ -442,9 +445,6 @@ impl<T: Config> Module<T> {
     }
 
     fn _execute_replace(replace_id: H256, merkle_proof: Vec<u8>, raw_tx: Vec<u8>) -> Result<(), DispatchError> {
-        // Check that Parachain status is RUNNING
-        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
-
         // Retrieve the ReplaceRequest as per the replaceId parameter from Vaults in the VaultRegistry
         let replace = Self::get_open_replace_request(&replace_id)?;
 
@@ -496,9 +496,6 @@ impl<T: Config> Module<T> {
     }
 
     fn _cancel_replace(caller: T::AccountId, replace_id: H256) -> Result<(), DispatchError> {
-        // Check that Parachain status is RUNNING
-        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
-
         // Retrieve the ReplaceRequest as per the replaceId parameter from Vaults in the VaultRegistry
         let replace = Self::get_open_replace_request(&replace_id)?;
 
@@ -563,9 +560,6 @@ impl<T: Config> Module<T> {
         btc_address: BtcAddress,
         is_auction: bool,
     ) -> Result<(H256, ReplaceRequest<T::AccountId, T::BlockNumber, PolkaBTC<T>, DOT<T>>), DispatchError> {
-        // Check that Parachain status is RUNNING
-        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
-
         // don't allow vaults to replace themselves
         ensure!(old_vault_id != new_vault_id, Error::<T>::ReplaceSelfNotAllowed);
 

--- a/crates/replace/src/lib.rs
+++ b/crates/replace/src/lib.rs
@@ -299,7 +299,7 @@ impl<T: Config> Module<T> {
         griefing_collateral: DOT<T>,
     ) -> DispatchResult {
         // Check that Parachain status is RUNNING
-        ext::security::ensure_parachain_status_running::<T>()?;
+        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
 
         // check vault is not banned
         ext::vault_registry::ensure_not_banned::<T>(&vault_id)?;
@@ -443,7 +443,7 @@ impl<T: Config> Module<T> {
 
     fn _execute_replace(replace_id: H256, merkle_proof: Vec<u8>, raw_tx: Vec<u8>) -> Result<(), DispatchError> {
         // Check that Parachain status is RUNNING
-        ext::security::ensure_parachain_status_running::<T>()?;
+        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
 
         // Retrieve the ReplaceRequest as per the replaceId parameter from Vaults in the VaultRegistry
         let replace = Self::get_open_replace_request(&replace_id)?;
@@ -497,7 +497,7 @@ impl<T: Config> Module<T> {
 
     fn _cancel_replace(caller: T::AccountId, replace_id: H256) -> Result<(), DispatchError> {
         // Check that Parachain status is RUNNING
-        ext::security::ensure_parachain_status_running::<T>()?;
+        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
 
         // Retrieve the ReplaceRequest as per the replaceId parameter from Vaults in the VaultRegistry
         let replace = Self::get_open_replace_request(&replace_id)?;
@@ -564,7 +564,7 @@ impl<T: Config> Module<T> {
         is_auction: bool,
     ) -> Result<(H256, ReplaceRequest<T::AccountId, T::BlockNumber, PolkaBTC<T>, DOT<T>>), DispatchError> {
         // Check that Parachain status is RUNNING
-        ext::security::ensure_parachain_status_running::<T>()?;
+        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
 
         // don't allow vaults to replace themselves
         ensure!(old_vault_id != new_vault_id, Error::<T>::ReplaceSelfNotAllowed);

--- a/crates/replace/src/mock.rs
+++ b/crates/replace/src/mock.rs
@@ -115,7 +115,7 @@ impl pallet_balances::Config<pallet_balances::Instance2> for Test {
 impl vault_registry::Config for Test {
     type Event = TestEvent;
     type UnsignedFixedPoint = FixedU128;
-    type RandomnessSource = pallet_randomness_collective_flip::Module<Test>;
+    type RandomnessSource = pallet_randomness_collective_flip::Pallet<Test>;
     type WeightInfo = ();
 }
 

--- a/crates/security/src/lib.rs
+++ b/crates/security/src/lib.rs
@@ -46,7 +46,7 @@ pub trait Config: frame_system::Config {
 
 // This pallet's storage items.
 decl_storage! {
-    trait Store for Module<T: Config> as SecurityModule {
+    trait Store for Module<T: Config> as SecurityPallet {
         /// Integer/Enum defining the current state of the BTC-Parachain.
         ParachainStatus get(fn status): StatusCode;
 

--- a/crates/security/src/lib.rs
+++ b/crates/security/src/lib.rs
@@ -83,9 +83,11 @@ decl_module! {
         }
 
         fn on_initialize(_chain_height: T::BlockNumber) -> Weight {
-            <ActiveBlockCount<T>>::mutate(|n| {
-                *n = n.saturating_add(1u32.into());
-            });
+            if status() == StatusCode::Running {
+                <ActiveBlockCount<T>>::mutate(|n| {
+                    *n = n.saturating_add(1u32.into());
+                });
+            }
 
             0
         }

--- a/crates/security/src/lib.rs
+++ b/crates/security/src/lib.rs
@@ -83,11 +83,7 @@ decl_module! {
         }
 
         fn on_initialize(_chain_height: T::BlockNumber) -> Weight {
-            if Self::status() == StatusCode::Running {
-                <ActiveBlockCount<T>>::mutate(|n| {
-                    *n = n.saturating_add(1u32.into());
-                });
-            }
+            Self::increment_active_block();
 
             0
         }
@@ -253,6 +249,14 @@ impl<T: Config> Module<T> {
             *n = res;
             *n
         })
+    }
+
+    fn increment_active_block() {
+        if Self::status() == StatusCode::Running {
+            <ActiveBlockCount<T>>::mutate(|n| {
+                *n = n.saturating_add(1u32.into());
+            });
+        }
     }
 
     /// Generates a 256-bit unique hash from an `AccountId` and the

--- a/crates/security/src/lib.rs
+++ b/crates/security/src/lib.rs
@@ -140,15 +140,6 @@ decl_module! {
 // "Internal" functions, callable by code.
 #[cfg_attr(test, mockable)]
 impl<T: Config> Module<T> {
-    /// Ensures the Parachain is RUNNING
-    pub fn ensure_parachain_status_running() -> DispatchResult {
-        if <ParachainStatus>::get() == StatusCode::Running {
-            Ok(())
-        } else {
-            Err(Error::<T>::ParachainNotRunning.into())
-        }
-    }
-
     /// Ensures the Parachain is not SHUTDOWN
     pub fn ensure_parachain_status_not_shutdown() -> DispatchResult {
         if <ParachainStatus>::get() != StatusCode::Shutdown {

--- a/crates/security/src/lib.rs
+++ b/crates/security/src/lib.rs
@@ -35,7 +35,7 @@ use frame_system::ensure_root;
 use primitive_types::H256;
 use sha2::{Digest, Sha256};
 use sp_core::U256;
-use sp_std::{collections::btree_set::BTreeSet, iter::FromIterator, prelude::*};
+use sp_std::{collections::btree_set::BTreeSet, prelude::*};
 
 /// ## Configuration
 /// The pallet's configuration trait.
@@ -83,7 +83,7 @@ decl_module! {
         }
 
         fn on_initialize(_chain_height: T::BlockNumber) -> Weight {
-            if status() == StatusCode::Running {
+            if Self::status() == StatusCode::Running {
                 <ActiveBlockCount<T>>::mutate(|n| {
                     *n = n.saturating_add(1u32.into());
                 });

--- a/crates/security/src/lib.rs
+++ b/crates/security/src/lib.rs
@@ -142,55 +142,21 @@ decl_module! {
 // "Internal" functions, callable by code.
 #[cfg_attr(test, mockable)]
 impl<T: Config> Module<T> {
+    /// Ensures the Parachain is RUNNING
+    pub fn ensure_parachain_status_running() -> DispatchResult {
+        if <ParachainStatus>::get() == StatusCode::Running {
+            Ok(())
+        } else {
+            Err(Error::<T>::ParachainNotRunning.into())
+        }
+    }
+
     /// Ensures the Parachain is not SHUTDOWN
     pub fn ensure_parachain_status_not_shutdown() -> DispatchResult {
         if <ParachainStatus>::get() != StatusCode::Shutdown {
             Ok(())
         } else {
             Err(Error::<T>::ParachainShutdown.into())
-        }
-    }
-
-    /// Ensures that the parachain DOES NOT have the given errors
-    ///
-    /// # Arguments
-    ///
-    ///   * `error_codes` - list of `ErrorCode` to be checked
-    ///
-    /// Returns the first error that is encountered, or Ok(()) if none of the errors were found
-    pub fn ensure_parachain_does_not_have_errors(error_codes: Vec<ErrorCode>) -> DispatchResult {
-        if <ParachainStatus>::get() == StatusCode::Error {
-            for error_code in error_codes {
-                if <Errors>::get().contains(&error_code) {
-                    return Err(Error::<T>::from(error_code).into());
-                }
-            }
-        }
-        Ok(())
-    }
-
-    /// Ensures that the parachain is RUNNING or ONLY HAS specific errors
-    ///
-    /// # Arguments
-    ///
-    ///   * `error_codes` - list of `ErrorCode` to be checked
-    ///
-    /// Returns the first unexpected error that is encountered,
-    /// or Ok(()) if only expected errors / no errors at all were found
-    pub fn ensure_parachain_is_running_or_only_has_errors(error_codes: Vec<ErrorCode>) -> DispatchResult {
-        if <ParachainStatus>::get() == StatusCode::Running {
-            Ok(())
-        } else if <ParachainStatus>::get() == StatusCode::Error {
-            let error_set: BTreeSet<ErrorCode> = FromIterator::from_iter(error_codes);
-            for error_code in <Errors>::get().iter() {
-                // check if error is set
-                if !error_set.contains(&error_code) {
-                    return Err(Error::<T>::from(error_code.clone()).into());
-                }
-            }
-            Ok(())
-        } else {
-            Err(Error::<T>::ParachainNotRunning.into())
         }
     }
 

--- a/crates/security/src/tests.rs
+++ b/crates/security/src/tests.rs
@@ -166,3 +166,30 @@ fn testget_secure_ids_not_equal() {
         assert_ne!(left, right);
     })
 }
+
+#[test]
+fn testget_increment_active_block_succeeds() {
+    run_test(|| {
+        let initial_active_block = Security::active_block_number();
+        Security::set_status(StatusCode::Running);
+        Security::increment_active_block();
+        assert_eq!(Security::active_block_number(), initial_active_block + 1);
+    })
+}
+
+#[test]
+fn testget_active_block_not_incremented_if_not_running() {
+    run_test(|| {
+        let initial_active_block = Security::active_block_number();
+
+        // not updated if there is an error
+        Security::set_status(StatusCode::Error);
+        Security::increment_active_block();
+        assert_eq!(Security::active_block_number(), initial_active_block);
+
+        // not updated if there is shutdown
+        Security::set_status(StatusCode::Shutdown);
+        Security::increment_active_block();
+        assert_eq!(Security::active_block_number(), initial_active_block);
+    })
+}

--- a/crates/security/src/tests.rs
+++ b/crates/security/src/tests.rs
@@ -33,7 +33,7 @@ fn test_get_and_set_status() {
 fn test_is_ensure_parachain_running_succeeds() {
     run_test(|| {
         Security::set_status(StatusCode::Running);
-        assert_ok!(Security::ensure_parachain_status_not_shutdown());
+        assert_ok!(Security::ensure_parachain_status_running());
     })
 }
 
@@ -42,13 +42,13 @@ fn test_is_ensure_parachain_running_fails() {
     run_test(|| {
         Security::set_status(StatusCode::Error);
         assert_noop!(
-            Security::ensure_parachain_status_not_shutdown(),
+            Security::ensure_parachain_status_running(),
             TestError::ParachainNotRunning
         );
 
         Security::set_status(StatusCode::Shutdown);
         assert_noop!(
-            Security::ensure_parachain_status_not_shutdown(),
+            Security::ensure_parachain_status_running(),
             TestError::ParachainNotRunning
         );
     })
@@ -73,58 +73,6 @@ fn test_is_ensure_parachain_not_shutdown_fails() {
             Security::ensure_parachain_status_not_shutdown(),
             TestError::ParachainShutdown
         );
-    })
-}
-
-#[test]
-fn test_ensure_parachain_does_not_have_errors() {
-    run_test(|| {
-        Security::set_status(StatusCode::Running);
-        assert_ok!(Security::ensure_parachain_does_not_have_errors(vec![
-            ErrorCode::InvalidBTCRelay
-        ],));
-
-        Security::set_status(StatusCode::Error);
-        assert_ok!(Security::ensure_parachain_does_not_have_errors(vec![
-            ErrorCode::InvalidBTCRelay
-        ],));
-
-        Security::insert_error(ErrorCode::InvalidBTCRelay);
-        assert_noop!(
-            Security::ensure_parachain_does_not_have_errors(vec![ErrorCode::InvalidBTCRelay]),
-            TestError::InvalidBTCRelay
-        );
-
-        assert_ok!(Security::ensure_parachain_does_not_have_errors(vec![]));
-    })
-}
-
-#[test]
-fn test_ensure_parachain_is_running_or_only_has_errors() {
-    run_test(|| {
-        Security::set_status(StatusCode::Running);
-        assert_ok!(Security::ensure_parachain_is_running_or_only_has_errors(vec![]));
-
-        Security::set_status(StatusCode::Error);
-        assert_ok!(Security::ensure_parachain_is_running_or_only_has_errors(vec![
-            ErrorCode::InvalidBTCRelay
-        ]));
-
-        Security::insert_error(ErrorCode::InvalidBTCRelay);
-        assert_ok!(Security::ensure_parachain_is_running_or_only_has_errors(vec![
-            ErrorCode::InvalidBTCRelay
-        ]));
-
-        Security::insert_error(ErrorCode::NoDataBTCRelay);
-        assert_noop!(
-            Security::ensure_parachain_is_running_or_only_has_errors(vec![ErrorCode::InvalidBTCRelay]),
-            TestError::NoDataBTCRelay
-        );
-
-        assert_ok!(Security::ensure_parachain_is_running_or_only_has_errors(vec![
-            ErrorCode::InvalidBTCRelay,
-            ErrorCode::NoDataBTCRelay
-        ]));
     })
 }
 

--- a/crates/security/src/tests.rs
+++ b/crates/security/src/tests.rs
@@ -33,7 +33,7 @@ fn test_get_and_set_status() {
 fn test_is_ensure_parachain_running_succeeds() {
     run_test(|| {
         Security::set_status(StatusCode::Running);
-        assert_ok!(Security::ensure_parachain_status_running());
+        assert_ok!(Security::ensure_parachain_status_not_shutdown());
     })
 }
 
@@ -42,13 +42,13 @@ fn test_is_ensure_parachain_running_fails() {
     run_test(|| {
         Security::set_status(StatusCode::Error);
         assert_noop!(
-            Security::ensure_parachain_status_running(),
+            Security::ensure_parachain_status_not_shutdown(),
             TestError::ParachainNotRunning
         );
 
         Security::set_status(StatusCode::Shutdown);
         assert_noop!(
-            Security::ensure_parachain_status_running(),
+            Security::ensure_parachain_status_not_shutdown(),
             TestError::ParachainNotRunning
         );
     })

--- a/crates/staked-relayers/src/ext.rs
+++ b/crates/staked-relayers/src/ext.rs
@@ -48,6 +48,7 @@ pub(crate) mod vault_registry {
 
 #[cfg_attr(test, mockable)]
 pub(crate) mod security {
+    use frame_support::dispatch::DispatchResult;
     use security::types::{ErrorCode, StatusCode};
     use sp_std::collections::btree_set::BTreeSet;
 
@@ -74,6 +75,10 @@ pub(crate) mod security {
 
     pub fn active_block_number<T: security::Config>() -> T::BlockNumber {
         <security::Pallet<T>>::active_block_number()
+    }
+
+    pub fn ensure_parachain_status_running<T: security::Config>() -> DispatchResult {
+        <security::Module<T>>::ensure_parachain_status_running()
     }
 }
 

--- a/crates/staked-relayers/src/ext.rs
+++ b/crates/staked-relayers/src/ext.rs
@@ -77,8 +77,8 @@ pub(crate) mod security {
         <security::Pallet<T>>::active_block_number()
     }
 
-    pub fn ensure_parachain_status_running<T: security::Config>() -> DispatchResult {
-        <security::Module<T>>::ensure_parachain_status_running()
+    pub fn ensure_parachain_status_not_shutdown<T: security::Config>() -> DispatchResult {
+        <security::Module<T>>::ensure_parachain_status_not_shutdown()
     }
 }
 

--- a/crates/staked-relayers/src/ext.rs
+++ b/crates/staked-relayers/src/ext.rs
@@ -78,7 +78,7 @@ pub(crate) mod security {
     }
 
     pub fn ensure_parachain_status_not_shutdown<T: security::Config>() -> DispatchResult {
-        <security::Module<T>>::ensure_parachain_status_not_shutdown()
+        <security::Pallet<T>>::ensure_parachain_status_not_shutdown()
     }
 }
 

--- a/crates/staked-relayers/src/lib.rs
+++ b/crates/staked-relayers/src/lib.rs
@@ -165,7 +165,7 @@ decl_module! {
             block_height: u32)
             -> DispatchResult
         {
-            ext::security::ensure_parachain_status_running::<T>()?;
+            ext::security::ensure_parachain_status_not_shutdown::<T>()?;
             let relayer = ensure_signed(origin)?;
             Self::ensure_relayer_is_registered(&relayer)?;
             ext::btc_relay::initialize::<T>(relayer, raw_block_header, block_height)
@@ -180,7 +180,7 @@ decl_module! {
         #[weight = <T as Config>::WeightInfo::register_staked_relayer()]
         #[transactional]
         fn register_staked_relayer(origin, stake: DOT<T>) -> DispatchResult {
-            ext::security::ensure_parachain_status_running::<T>()?;
+            ext::security::ensure_parachain_status_not_shutdown::<T>()?;
             let signer = ensure_signed(origin)?;
 
             ensure!(
@@ -215,7 +215,7 @@ decl_module! {
         #[weight = <T as Config>::WeightInfo::deregister_staked_relayer()]
         #[transactional]
         fn deregister_staked_relayer(origin) -> DispatchResult {
-            ext::security::ensure_parachain_status_running::<T>()?;
+            ext::security::ensure_parachain_status_not_shutdown::<T>()?;
             let signer = ensure_signed(origin)?;
             let staked_relayer = Self::get_active_staked_relayer(&signer)?;
             Self::ensure_staked_relayer_is_not_voting(&signer)?;
@@ -264,7 +264,7 @@ decl_module! {
         fn store_block_header(
             origin, raw_block_header: RawBlockHeader
         ) -> DispatchResult {
-            ext::security::ensure_parachain_status_running::<T>()?;
+            ext::security::ensure_parachain_status_not_shutdown::<T>()?;
             let relayer = ensure_signed(origin)?;
 
             Self::ensure_relayer_is_registered(&relayer)?;
@@ -470,7 +470,7 @@ decl_module! {
         #[weight = <T as Config>::WeightInfo::report_vault_theft()]
         #[transactional]
         fn report_vault_theft(origin, vault_id: T::AccountId, merkle_proof: Vec<u8>, raw_tx: Vec<u8>) -> DispatchResult {
-            ext::security::ensure_parachain_status_running::<T>()?;
+            ext::security::ensure_parachain_status_not_shutdown::<T>()?;
             let signer = ensure_signed(origin)?;
 
             let tx_id = sha256d_le(&raw_tx);

--- a/crates/staked-relayers/src/lib.rs
+++ b/crates/staked-relayers/src/lib.rs
@@ -165,6 +165,7 @@ decl_module! {
             block_height: u32)
             -> DispatchResult
         {
+            ext::security::ensure_parachain_status_running::<T>()?;
             let relayer = ensure_signed(origin)?;
             Self::ensure_relayer_is_registered(&relayer)?;
             ext::btc_relay::initialize::<T>(relayer, raw_block_header, block_height)
@@ -179,6 +180,7 @@ decl_module! {
         #[weight = <T as Config>::WeightInfo::register_staked_relayer()]
         #[transactional]
         fn register_staked_relayer(origin, stake: DOT<T>) -> DispatchResult {
+            ext::security::ensure_parachain_status_running::<T>()?;
             let signer = ensure_signed(origin)?;
 
             ensure!(
@@ -213,6 +215,7 @@ decl_module! {
         #[weight = <T as Config>::WeightInfo::deregister_staked_relayer()]
         #[transactional]
         fn deregister_staked_relayer(origin) -> DispatchResult {
+            ext::security::ensure_parachain_status_running::<T>()?;
             let signer = ensure_signed(origin)?;
             let staked_relayer = Self::get_active_staked_relayer(&signer)?;
             Self::ensure_staked_relayer_is_not_voting(&signer)?;
@@ -261,6 +264,7 @@ decl_module! {
         fn store_block_header(
             origin, raw_block_header: RawBlockHeader
         ) -> DispatchResult {
+            ext::security::ensure_parachain_status_running::<T>()?;
             let relayer = ensure_signed(origin)?;
 
             Self::ensure_relayer_is_registered(&relayer)?;
@@ -466,7 +470,7 @@ decl_module! {
         #[weight = <T as Config>::WeightInfo::report_vault_theft()]
         #[transactional]
         fn report_vault_theft(origin, vault_id: T::AccountId, merkle_proof: Vec<u8>, raw_tx: Vec<u8>) -> DispatchResult {
-            let signer = ensure_signed(origin)?;
+            ext::security::ensure_parachain_status_running::<T>()?;
 
             let tx_id = sha256d_le(&raw_tx);
 

--- a/crates/staked-relayers/src/lib.rs
+++ b/crates/staked-relayers/src/lib.rs
@@ -471,6 +471,7 @@ decl_module! {
         #[transactional]
         fn report_vault_theft(origin, vault_id: T::AccountId, merkle_proof: Vec<u8>, raw_tx: Vec<u8>) -> DispatchResult {
             ext::security::ensure_parachain_status_running::<T>()?;
+            let signer = ensure_signed(origin)?;
 
             let tx_id = sha256d_le(&raw_tx);
 

--- a/crates/vault-registry/src/ext.rs
+++ b/crates/vault-registry/src/ext.rs
@@ -67,10 +67,6 @@ pub(crate) mod security {
         <security::Pallet<T>>::ensure_parachain_status_not_shutdown()
     }
 
-    pub fn ensure_parachain_does_not_have_errors<T: security::Config>(error_codes: Vec<ErrorCode>) -> DispatchResult {
-        <security::Pallet<T>>::ensure_parachain_does_not_have_errors(error_codes)
-    }
-
     pub fn active_block_number<T: security::Config>() -> T::BlockNumber {
         <security::Pallet<T>>::active_block_number()
     }

--- a/crates/vault-registry/src/ext.rs
+++ b/crates/vault-registry/src/ext.rs
@@ -63,10 +63,6 @@ pub(crate) mod security {
     use security::ErrorCode;
     use sp_std::vec::Vec;
 
-    pub fn ensure_parachain_status_running<T: security::Config>() -> DispatchResult {
-        <security::Pallet<T>>::ensure_parachain_status_running()
-    }
-
     pub fn ensure_parachain_status_not_shutdown<T: security::Config>() -> DispatchResult {
         <security::Pallet<T>>::ensure_parachain_status_not_shutdown()
     }

--- a/crates/vault-registry/src/ext.rs
+++ b/crates/vault-registry/src/ext.rs
@@ -60,8 +60,6 @@ pub(crate) mod oracle {
 #[cfg_attr(test, mockable)]
 pub(crate) mod security {
     use frame_support::dispatch::DispatchResult;
-    use security::ErrorCode;
-    use sp_std::vec::Vec;
 
     pub fn ensure_parachain_status_not_shutdown<T: security::Config>() -> DispatchResult {
         <security::Pallet<T>>::ensure_parachain_status_not_shutdown()

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -484,7 +484,6 @@ impl<T: Config> Module<T> {
     /// * `vault_id` - the id of the vault from which to increase to-be-issued tokens
     /// * `tokens` - the amount of tokens to be reserved
     pub fn try_increase_to_be_issued_tokens(vault_id: &T::AccountId, tokens: PolkaBTC<T>) -> Result<(), DispatchError> {
-        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
         let mut vault = Self::get_active_rich_vault_from_id(&vault_id)?;
 
         let issuable_tokens = vault.issuable_tokens()?;
@@ -527,7 +526,6 @@ impl<T: Config> Module<T> {
         tokens: PolkaBTC<T>,
         griefing_collateral: DOT<T>,
     ) -> Result<(PolkaBTC<T>, DOT<T>), DispatchError> {
-        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
         let mut vault = Self::get_active_rich_vault_from_id(&vault_id)?;
 
         let new_to_be_replaced = vault
@@ -561,7 +559,6 @@ impl<T: Config> Module<T> {
         vault_id: &T::AccountId,
         tokens: PolkaBTC<T>,
     ) -> Result<(PolkaBTC<T>, DOT<T>), DispatchError> {
-        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
         let mut vault = Self::get_rich_vault_from_id(&vault_id)?;
 
         let initial_to_be_replaced = vault.data.to_be_replaced_tokens;
@@ -594,10 +591,6 @@ impl<T: Config> Module<T> {
     /// * `vault_id` - the id of the vault from which to decrease to-be-issued tokens
     /// * `tokens` - the amount of tokens to be unreserved
     pub fn decrease_to_be_issued_tokens(vault_id: &T::AccountId, tokens: PolkaBTC<T>) -> DispatchResult {
-        Self::check_parachain_not_shutdown_and_not_errors(
-            [ErrorCode::InvalidBTCRelay, ErrorCode::OracleOffline].to_vec(),
-        )?;
-
         let mut vault = Self::get_rich_vault_from_id(vault_id)?;
         vault.decrease_to_be_issued(tokens)?;
 
@@ -617,9 +610,6 @@ impl<T: Config> Module<T> {
     /// * `VaultNotFound` - if no vault exists for the given `vault_id`
     /// * `InsufficientTokensCommitted` - if the amount of tokens reserved is too low
     pub fn issue_tokens(vault_id: &T::AccountId, tokens: PolkaBTC<T>) -> DispatchResult {
-        Self::check_parachain_not_shutdown_and_not_errors(
-            [ErrorCode::InvalidBTCRelay, ErrorCode::OracleOffline].to_vec(),
-        )?;
         let mut vault = Self::get_rich_vault_from_id(&vault_id)?;
         vault.issue_tokens(tokens)?;
         Self::deposit_event(Event::<T>::IssueTokens(vault.id(), tokens));
@@ -641,9 +631,6 @@ impl<T: Config> Module<T> {
     /// * `VaultNotFound` - if no vault exists for the given `vault_id`
     /// * `InsufficientTokensCommitted` - if the amount of redeemable tokens is too low
     pub fn try_increase_to_be_redeemed_tokens(vault_id: &T::AccountId, tokens: PolkaBTC<T>) -> DispatchResult {
-        Self::check_parachain_not_shutdown_and_not_errors(
-            [ErrorCode::InvalidBTCRelay, ErrorCode::OracleOffline].to_vec(),
-        )?;
         let mut vault = Self::get_active_rich_vault_from_id(&vault_id)?;
         let redeemable = vault
             .data
@@ -668,10 +655,6 @@ impl<T: Config> Module<T> {
     /// * `VaultNotFound` - if no vault exists for the given `vault_id`
     /// * `InsufficientTokensCommitted` - if the amount of to-be-redeemed tokens is too low
     pub fn decrease_to_be_redeemed_tokens(vault_id: &T::AccountId, tokens: PolkaBTC<T>) -> DispatchResult {
-        Self::check_parachain_not_shutdown_and_not_errors(
-            [ErrorCode::InvalidBTCRelay, ErrorCode::OracleOffline].to_vec(),
-        )?;
-
         let mut vault = Self::get_rich_vault_from_id(&vault_id)?;
         vault.decrease_to_be_redeemed(tokens)?;
 
@@ -689,9 +672,6 @@ impl<T: Config> Module<T> {
     /// * `tokens` - the amount of tokens to be decreased
     /// * `user_id` - the id of the user making the redeem request
     pub fn decrease_tokens(vault_id: &T::AccountId, user_id: &T::AccountId, tokens: PolkaBTC<T>) -> DispatchResult {
-        Self::check_parachain_not_shutdown_and_not_errors(
-            [ErrorCode::InvalidBTCRelay, ErrorCode::OracleOffline].to_vec(),
-        )?;
         // decrease to-be-redeemed and issued
         let mut vault = Self::get_rich_vault_from_id(&vault_id)?;
         vault.decrease_tokens(tokens)?;
@@ -713,10 +693,6 @@ impl<T: Config> Module<T> {
         premium: DOT<T>,
         redeemer_id: &T::AccountId,
     ) -> DispatchResult {
-        Self::check_parachain_not_shutdown_and_not_errors(
-            [ErrorCode::InvalidBTCRelay, ErrorCode::OracleOffline].to_vec(),
-        )?;
-
         let mut vault = Self::get_rich_vault_from_id(&vault_id)?;
 
         // need to read before we decrease it
@@ -773,10 +749,6 @@ impl<T: Config> Module<T> {
     /// * `InsufficientTokensCommitted` - if the amount of tokens issued by the liquidation vault is too low
     /// * `InsufficientFunds` - if the liquidation vault does not have enough collateral to transfer
     pub fn redeem_tokens_liquidation(redeemer_id: &T::AccountId, amount_btc: PolkaBTC<T>) -> DispatchResult {
-        Self::check_parachain_not_shutdown_and_not_errors(
-            [ErrorCode::InvalidBTCRelay, ErrorCode::OracleOffline].to_vec(),
-        )?;
-
         let mut liquidation_vault = Self::get_rich_liquidation_vault();
 
         ensure!(
@@ -827,10 +799,6 @@ impl<T: Config> Module<T> {
         tokens: PolkaBTC<T>,
         collateral: DOT<T>,
     ) -> DispatchResult {
-        Self::check_parachain_not_shutdown_and_not_errors(
-            [ErrorCode::InvalidBTCRelay, ErrorCode::OracleOffline].to_vec(),
-        )?;
-
         let mut old_vault = Self::get_rich_vault_from_id(&old_vault_id)?;
         let mut new_vault = Self::get_rich_vault_from_id(&new_vault_id)?;
 
@@ -868,10 +836,6 @@ impl<T: Config> Module<T> {
         new_vault_id: &T::AccountId,
         tokens: PolkaBTC<T>,
     ) -> DispatchResult {
-        Self::check_parachain_not_shutdown_and_not_errors(
-            [ErrorCode::InvalidBTCRelay, ErrorCode::OracleOffline].to_vec(),
-        )?;
-
         let mut old_vault = Self::get_rich_vault_from_id(&old_vault_id)?;
         let mut new_vault = Self::get_rich_vault_from_id(&new_vault_id)?;
 
@@ -927,9 +891,6 @@ impl<T: Config> Module<T> {
     /// # Errors
     /// * `VaultNotFound` - if the vault to liquidate does not exist
     pub fn liquidate_vault_with_status(vault_id: &T::AccountId, status: VaultStatus) -> DispatchResult {
-        // Parachain must not be shutdown
-        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
-
         let mut vault = Self::get_active_rich_vault_from_id(&vault_id)?;
         let vault_orig = vault.data.clone();
         let mut liquidation_vault = Self::get_rich_liquidation_vault();
@@ -1290,8 +1251,6 @@ impl<T: Config> Module<T> {
     /// # Arguments
     /// * `amount_btc` - the amount of polkabtc
     pub fn get_required_collateral_for_polkabtc(amount_btc: PolkaBTC<T>) -> Result<DOT<T>, DispatchError> {
-        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
-
         let threshold = <SecureCollateralThreshold<T>>::get();
         let collateral = Self::get_required_collateral_for_polkabtc_with_threshold(amount_btc, threshold)?;
         Ok(collateral)
@@ -1300,8 +1259,6 @@ impl<T: Config> Module<T> {
     /// Get the amount of collateral required for the given vault to be at the
     /// current SecureCollateralThreshold with the current exchange rate
     pub fn get_required_collateral_for_vault(vault_id: T::AccountId) -> Result<DOT<T>, DispatchError> {
-        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
-
         let vault = Self::get_active_rich_vault_from_id(&vault_id)?;
         let issued_tokens = vault.data.issued_tokens + vault.data.to_be_issued_tokens;
 
@@ -1352,18 +1309,6 @@ impl<T: Config> Module<T> {
 
         let ret = rand_hash.to_low_u64_le() % (limit as u64);
         ret as usize
-    }
-
-    /// Ensure that the parachain is NOT shutdown and DOES NOT have the given errors
-    ///
-    /// # Arguments
-    ///
-    ///   * `error_codes` - list of `ErrorCode` to be checked
-    fn check_parachain_not_shutdown_and_not_errors(error_codes: Vec<ErrorCode>) -> DispatchResult {
-        // Parachain must not be shutdown
-        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
-        // Ensure error state does not contain InvalidBTCRelay or OracleOffline
-        ext::security::ensure_parachain_does_not_have_errors::<T>(error_codes)
     }
 
     /// calculate the collateralization as a ratio of the issued tokens to the

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -215,7 +215,7 @@ decl_module! {
         fn lock_additional_collateral(origin, amount: DOT<T>) -> DispatchResult {
             let sender = ensure_signed(origin)?;
 
-            ext::security::ensure_parachain_status_running::<T>()?;
+            ext::security::ensure_parachain_status_not_shutdown::<T>()?;
 
             Self::try_lock_additional_collateral(&sender, amount)?;
 
@@ -248,7 +248,7 @@ decl_module! {
         #[transactional]
         fn withdraw_collateral(origin, amount: DOT<T>) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            ext::security::ensure_parachain_status_running::<T>()?;
+            ext::security::ensure_parachain_status_not_shutdown::<T>()?;
 
             Self::try_withdraw_collateral(&sender, amount)?;
 
@@ -270,7 +270,7 @@ decl_module! {
         #[transactional]
         fn update_public_key(origin, public_key: BtcPublicKey) -> DispatchResult {
             let account_id = ensure_signed(origin)?;
-            ext::security::ensure_parachain_status_running::<T>()?;
+            ext::security::ensure_parachain_status_not_shutdown::<T>()?;
             let mut vault = Self::get_active_rich_vault_from_id(&account_id)?;
             vault.update_public_key(public_key.clone());
             Self::deposit_event(Event::<T>::UpdatePublicKey(account_id, public_key));
@@ -281,7 +281,7 @@ decl_module! {
         #[transactional]
         fn register_address(origin, btc_address: BtcAddress) -> DispatchResult {
             let account_id = ensure_signed(origin)?;
-            ext::security::ensure_parachain_status_running::<T>()?;
+            ext::security::ensure_parachain_status_not_shutdown::<T>()?;
             Self::insert_vault_deposit_address(&account_id, btc_address)?;
             Self::deposit_event(Event::<T>::RegisterAddress(account_id, btc_address));
             Ok(())
@@ -298,7 +298,7 @@ decl_module! {
         #[weight = <T as Config>::WeightInfo::accept_new_issues()]
         #[transactional]
         fn accept_new_issues(origin, accept_new_issues: bool) -> DispatchResult  {
-            ext::security::ensure_parachain_status_running::<T>()?;
+            ext::security::ensure_parachain_status_not_shutdown::<T>()?;
             let vault_id = ensure_signed(origin)?;
             let mut vault = Self::get_active_rich_vault_from_id(&vault_id)?;
             vault.set_accept_new_issues(accept_new_issues)
@@ -326,7 +326,7 @@ impl<T: Config> Module<T> {
     /// Public functions
 
     pub fn _register_vault(vault_id: &T::AccountId, collateral: DOT<T>, public_key: BtcPublicKey) -> DispatchResult {
-        ext::security::ensure_parachain_status_running::<T>()?;
+        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
 
         ensure!(
             collateral >= Self::get_minimum_collateral_vault(),
@@ -476,7 +476,7 @@ impl<T: Config> Module<T> {
     /// * `vault_id` - the id of the vault from which to increase to-be-issued tokens
     /// * `tokens` - the amount of tokens to be reserved
     pub fn try_increase_to_be_issued_tokens(vault_id: &T::AccountId, tokens: PolkaBTC<T>) -> Result<(), DispatchError> {
-        ext::security::ensure_parachain_status_running::<T>()?;
+        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
         let mut vault = Self::get_active_rich_vault_from_id(&vault_id)?;
 
         let issuable_tokens = vault.issuable_tokens()?;
@@ -519,7 +519,7 @@ impl<T: Config> Module<T> {
         tokens: PolkaBTC<T>,
         griefing_collateral: DOT<T>,
     ) -> Result<(PolkaBTC<T>, DOT<T>), DispatchError> {
-        ext::security::ensure_parachain_status_running::<T>()?;
+        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
         let mut vault = Self::get_active_rich_vault_from_id(&vault_id)?;
 
         let new_to_be_replaced = vault
@@ -553,7 +553,7 @@ impl<T: Config> Module<T> {
         vault_id: &T::AccountId,
         tokens: PolkaBTC<T>,
     ) -> Result<(PolkaBTC<T>, DOT<T>), DispatchError> {
-        ext::security::ensure_parachain_status_running::<T>()?;
+        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
         let mut vault = Self::get_rich_vault_from_id(&vault_id)?;
 
         let initial_to_be_replaced = vault.data.to_be_replaced_tokens;
@@ -1282,7 +1282,7 @@ impl<T: Config> Module<T> {
     /// # Arguments
     /// * `amount_btc` - the amount of polkabtc
     pub fn get_required_collateral_for_polkabtc(amount_btc: PolkaBTC<T>) -> Result<DOT<T>, DispatchError> {
-        ext::security::ensure_parachain_status_running::<T>()?;
+        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
 
         let threshold = <SecureCollateralThreshold<T>>::get();
         let collateral = Self::get_required_collateral_for_polkabtc_with_threshold(amount_btc, threshold)?;
@@ -1292,7 +1292,7 @@ impl<T: Config> Module<T> {
     /// Get the amount of collateral required for the given vault to be at the
     /// current SecureCollateralThreshold with the current exchange rate
     pub fn get_required_collateral_for_vault(vault_id: T::AccountId) -> Result<DOT<T>, DispatchError> {
-        ext::security::ensure_parachain_status_running::<T>()?;
+        ext::security::ensure_parachain_status_not_shutdown::<T>()?;
 
         let vault = Self::get_active_rich_vault_from_id(&vault_id)?;
         let issued_tokens = vault.data.issued_tokens + vault.data.to_be_issued_tokens;

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -38,7 +38,6 @@ use frame_support::{
 };
 use frame_system::ensure_signed;
 use primitive_types::U256;
-use security::ErrorCode;
 use sp_arithmetic::{traits::*, FixedPointNumber};
 use sp_core::H256;
 use sp_std::{convert::TryInto, vec::Vec};

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -215,7 +215,7 @@ decl_module! {
         fn lock_additional_collateral(origin, amount: DOT<T>) -> DispatchResult {
             let sender = ensure_signed(origin)?;
 
-            Self::check_parachain_not_shutdown_and_not_errors([ErrorCode::OracleOffline].to_vec())?;
+            ext::security::ensure_parachain_status_running::<T>()?;
 
             Self::try_lock_additional_collateral(&sender, amount)?;
 
@@ -298,6 +298,7 @@ decl_module! {
         #[weight = <T as Config>::WeightInfo::accept_new_issues()]
         #[transactional]
         fn accept_new_issues(origin, accept_new_issues: bool) -> DispatchResult  {
+            ext::security::ensure_parachain_status_running::<T>()?;
             let vault_id = ensure_signed(origin)?;
             let mut vault = Self::get_active_rich_vault_from_id(&vault_id)?;
             vault.set_accept_new_issues(accept_new_issues)

--- a/crates/vault-registry/src/mock.rs
+++ b/crates/vault-registry/src/mock.rs
@@ -137,7 +137,7 @@ impl exchange_rate_oracle::Config for Test {
 
 impl Config for Test {
     type Event = TestEvent;
-    type RandomnessSource = pallet_randomness_collective_flip::Module<Test>;
+    type RandomnessSource = pallet_randomness_collective_flip::Pallet<Test>;
     type UnsignedFixedPoint = FixedU128;
     type WeightInfo = ();
 }

--- a/crates/vault-registry/src/tests.rs
+++ b/crates/vault-registry/src/tests.rs
@@ -1450,7 +1450,7 @@ fn wallet_has_btc_address_succeeds() {
 
 fn setup_block(i: u64, parent_hash: H256) -> H256 {
     System::initialize(&i, &parent_hash, &Default::default(), frame_system::InitKind::Full);
-    <pallet_randomness_collective_flip::Module<Test>>::on_initialize(i);
+    <pallet_randomness_collective_flip::Pallet<Test>>::on_initialize(i);
 
     let header = System::finalize();
     Security::<Test>::set_active_block_number(*header.number());

--- a/crates/vault-registry/src/tests.rs
+++ b/crates/vault-registry/src/tests.rs
@@ -1041,7 +1041,7 @@ fn _is_vault_below_auction_threshold_false_succeeds() {
 #[test]
 fn register_vault_parachain_not_running_fails() {
     run_test(|| {
-        ext::security::ensure_parachain_status_running::<Test>
+        ext::security::ensure_parachain_status_not_shutdown::<Test>
             .mock_safe(|| MockResult::Return(Err(SecurityError::ParachainNotRunning.into())));
 
         assert_noop!(

--- a/parachain/runtime/src/lib.rs
+++ b/parachain/runtime/src/lib.rs
@@ -283,7 +283,6 @@ parameter_types! {
 }
 
 impl pallet_transaction_payment::Config for Runtime {
-    // type Currency = pallet_balances::Module<Runtime, pallet_balances::Instance1>;
     type OnChargeTransaction = pallet_transaction_payment::CurrencyAdapter<DOT, ()>;
     type TransactionByteFee = TransactionByteFee;
     type WeightToFee = IdentityFee<Balance>;
@@ -754,7 +753,6 @@ impl_runtime_apis! {
         ) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, sp_runtime::RuntimeString> {
             use frame_benchmarking::{Benchmarking, BenchmarkBatch, add_benchmark, TrackedStorageKey};
 
-            // use frame_system_benchmarking::Module as SystemBench;
             impl frame_system_benchmarking::Config for Runtime {}
 
             let whitelist: Vec<TrackedStorageKey> = vec![

--- a/parachain/runtime/tests/mock/issue_testing_utils.rs
+++ b/parachain/runtime/tests/mock/issue_testing_utils.rs
@@ -102,7 +102,7 @@ impl ExecuteIssueBuilder {
             .with_relayer(self.relayer)
             .mine();
 
-        SecurityModule::set_active_block_number(SecurityModule::active_block_number() + CONFIRMATIONS);
+        SecurityPallet::set_active_block_number(SecurityPallet::active_block_number() + CONFIRMATIONS);
 
         if self.register_submitter_as_vault {
             try_register_vault(DEFAULT_COLLATERAL, self.submitter);
@@ -167,7 +167,7 @@ pub fn execute_refund(vault_id: [u8; 32]) -> (H256, RefundRequest<AccountId, u12
     let (_tx_id, _height, proof, raw_tx) =
         generate_transaction_and_mine(refund_address, refund.amount_polka_btc, Some(refund_id));
 
-    SecurityModule::set_active_block_number((1 + CONFIRMATIONS) * 2);
+    SecurityPallet::set_active_block_number((1 + CONFIRMATIONS) * 2);
 
     assert_ok!(
         Call::Refund(RefundCall::execute_refund(refund_id, proof, raw_tx)).dispatch(origin_of(account_of(vault_id)))
@@ -178,7 +178,7 @@ pub fn execute_refund(vault_id: [u8; 32]) -> (H256, RefundRequest<AccountId, u12
 
 pub fn cancel_issue(issue_id: H256, vault: [u8; 32]) {
     // expire request without transferring btc
-    SecurityModule::set_active_block_number(IssuePallet::issue_period() + 1 + 1);
+    SecurityPallet::set_active_block_number(IssuePallet::issue_period() + 1 + 1);
 
     // cancel issue request
     assert_ok!(Call::Issue(IssueCall::cancel_issue(issue_id)).dispatch(origin_of(account_of(vault))));

--- a/parachain/runtime/tests/mock/mod.rs
+++ b/parachain/runtime/tests/mock/mod.rs
@@ -68,10 +68,10 @@ pub type BTCRelayError = btc_relay::Error<Runtime>;
 pub type BTCRelayEvent = btc_relay::Event<Runtime>;
 
 pub type CollateralError = collateral::Error<Runtime>;
-pub type CollateralPallet = collateral::Module<Runtime>;
+pub type CollateralPallet = collateral::Pallet<Runtime>;
 
 pub type ExchangeRateOracleCall = exchange_rate_oracle::Call<Runtime>;
-pub type ExchangeRateOraclePallet = exchange_rate_oracle::Module<Runtime>;
+pub type ExchangeRateOraclePallet = exchange_rate_oracle::Pallet<Runtime>;
 
 pub type FeeCall = fee::Call<Runtime>;
 pub type FeeError = fee::Error<Runtime>;

--- a/parachain/runtime/tests/mock/mod.rs
+++ b/parachain/runtime/tests/mock/mod.rs
@@ -68,6 +68,14 @@ pub type BTCRelayError = btc_relay::Error<Runtime>;
 pub type BTCRelayEvent = btc_relay::Event<Runtime>;
 
 pub type CollateralError = collateral::Error<Runtime>;
+pub type CollateralModule = collateral::Module<Runtime>;
+
+pub type ExchangeRateOracleCall = exchange_rate_oracle::Call<Runtime>;
+pub type ExchangeRateOracleModule = exchange_rate_oracle::Module<Runtime>;
+
+pub type FeeCall = fee::Call<Runtime>;
+pub type FeeError = fee::Error<Runtime>;
+pub type FeeModule = fee::Module<Runtime>;
 
 pub type IssueCall = issue::Call<Runtime>;
 pub type IssuePallet = issue::Pallet<Runtime>;
@@ -81,7 +89,6 @@ pub type RefundEvent = refund::Event<Runtime>;
 pub type RedeemCall = redeem::Call<Runtime>;
 pub type RedeemPallet = redeem::Pallet<Runtime>;
 pub type RedeemEvent = redeem::Event<Runtime>;
-pub type RedeemError = redeem::Error<Runtime>;
 
 pub type ReplaceCall = replace::Call<Runtime>;
 pub type ReplaceEvent = replace::Event<Runtime>;
@@ -89,6 +96,22 @@ pub type ReplacePallet = replace::Pallet<Runtime>;
 
 pub type StakedRelayersCall = staked_relayers::Call<Runtime>;
 pub type StakedRelayersPallet = staked_relayers::Pallet<Runtime>;
+
+pub type SecurityError = security::Error<Runtime>;
+pub type SecurityPallet = security::Pallet<Runtime>;
+
+pub type SlaPallet = sla::Pallet<Runtime>;
+
+pub type StakedRelayersCall = staked_relayers::Call<Runtime>;
+pub type StakedRelayersPallet = staked_relayers::Pallet<Runtime>;
+
+pub type SystemModule = frame_system::Pallet<Runtime>;
+
+pub type TreasuryModule = treasury::Module<Runtime>;
+
+pub type VaultRegistryCall = vault_registry::Call<Runtime>;
+pub type VaultRegistryError = vault_registry::Error<Runtime>;
+pub type VaultRegistryPallet = vault_registry::Pallet<Runtime>;
 
 pub fn default_user_state() -> UserData {
     UserData {
@@ -696,42 +719,6 @@ pub fn generate_transaction_and_mine(
         .mine();
     (tx_id, height, proof, raw_tx)
 }
-
-#[allow(dead_code)]
-pub type SystemModule = frame_system::Pallet<Runtime>;
-
-#[allow(dead_code)]
-pub type SecurityModule = security::Pallet<Runtime>;
-#[allow(dead_code)]
-pub type SecurityError = security::Error<Runtime>;
-
-#[allow(dead_code)]
-pub type VaultRegistryCall = vault_registry::Call<Runtime>;
-#[allow(dead_code)]
-pub type VaultRegistryPallet = vault_registry::Pallet<Runtime>;
-#[allow(dead_code)]
-pub type VaultRegistryError = vault_registry::Error<Runtime>;
-
-#[allow(dead_code)]
-pub type ExchangeRateOracleCall = exchange_rate_oracle::Call<Runtime>;
-#[allow(dead_code)]
-pub type ExchangeRateOracleModule = exchange_rate_oracle::Pallet<Runtime>;
-
-#[allow(dead_code)]
-pub type SlaPallet = sla::Pallet<Runtime>;
-
-#[allow(dead_code)]
-pub type FeePallet = fee::Pallet<Runtime>;
-#[allow(dead_code)]
-pub type FeeCall = fee::Call<Runtime>;
-#[allow(dead_code)]
-pub type FeeError = fee::Error<Runtime>;
-
-#[allow(dead_code)]
-pub type CollateralModule = collateral::Pallet<Runtime>;
-
-#[allow(dead_code)]
-pub type TreasuryModule = treasury::Pallet<Runtime>;
 
 pub struct ExtBuilder {
     test_externalities: sp_io::TestExternalities,

--- a/parachain/runtime/tests/mock/mod.rs
+++ b/parachain/runtime/tests/mock/mod.rs
@@ -68,14 +68,14 @@ pub type BTCRelayError = btc_relay::Error<Runtime>;
 pub type BTCRelayEvent = btc_relay::Event<Runtime>;
 
 pub type CollateralError = collateral::Error<Runtime>;
-pub type CollateralModule = collateral::Module<Runtime>;
+pub type CollateralPallet = collateral::Module<Runtime>;
 
 pub type ExchangeRateOracleCall = exchange_rate_oracle::Call<Runtime>;
-pub type ExchangeRateOracleModule = exchange_rate_oracle::Module<Runtime>;
+pub type ExchangeRateOraclePallet = exchange_rate_oracle::Module<Runtime>;
 
 pub type FeeCall = fee::Call<Runtime>;
 pub type FeeError = fee::Error<Runtime>;
-pub type FeeModule = fee::Module<Runtime>;
+pub type FeePallet = fee::Pallet<Runtime>;
 
 pub type IssueCall = issue::Call<Runtime>;
 pub type IssuePallet = issue::Pallet<Runtime>;
@@ -88,14 +88,12 @@ pub type RefundEvent = refund::Event<Runtime>;
 
 pub type RedeemCall = redeem::Call<Runtime>;
 pub type RedeemPallet = redeem::Pallet<Runtime>;
+pub type RedeemError = redeem::Error<Runtime>;
 pub type RedeemEvent = redeem::Event<Runtime>;
 
 pub type ReplaceCall = replace::Call<Runtime>;
 pub type ReplaceEvent = replace::Event<Runtime>;
 pub type ReplacePallet = replace::Pallet<Runtime>;
-
-pub type StakedRelayersCall = staked_relayers::Call<Runtime>;
-pub type StakedRelayersPallet = staked_relayers::Pallet<Runtime>;
 
 pub type SecurityError = security::Error<Runtime>;
 pub type SecurityPallet = security::Pallet<Runtime>;
@@ -107,7 +105,7 @@ pub type StakedRelayersPallet = staked_relayers::Pallet<Runtime>;
 
 pub type SystemModule = frame_system::Pallet<Runtime>;
 
-pub type TreasuryModule = treasury::Module<Runtime>;
+pub type TreasuryPallet = treasury::Pallet<Runtime>;
 
 pub type VaultRegistryCall = vault_registry::Call<Runtime>;
 pub type VaultRegistryError = vault_registry::Error<Runtime>;
@@ -161,10 +159,10 @@ impl UserData {
     pub fn get(id: [u8; 32]) -> Self {
         let account_id = account_of(id);
         Self {
-            free_balance: CollateralModule::get_balance_from_account(&account_id),
-            locked_balance: CollateralModule::get_collateral_from_account(&account_id),
-            locked_tokens: TreasuryModule::get_locked_balance_from_account(account_id.clone()),
-            free_tokens: TreasuryModule::get_balance_from_account(account_id.clone()),
+            free_balance: CollateralPallet::get_balance_from_account(&account_id),
+            locked_balance: CollateralPallet::get_collateral_from_account(&account_id),
+            locked_tokens: TreasuryPallet::get_locked_balance_from_account(account_id.clone()),
+            free_tokens: TreasuryPallet::get_balance_from_account(account_id.clone()),
         }
     }
     #[allow(dead_code)]
@@ -173,24 +171,24 @@ impl UserData {
         let account_id = account_of(id);
 
         // set tokens to 0
-        TreasuryModule::lock(account_id.clone(), old.free_tokens).unwrap();
-        TreasuryModule::burn(account_id.clone(), old.free_tokens + old.locked_tokens).unwrap();
+        TreasuryPallet::lock(account_id.clone(), old.free_tokens).unwrap();
+        TreasuryPallet::burn(account_id.clone(), old.free_tokens + old.locked_tokens).unwrap();
 
         // set free balance:
-        CollateralModule::transfer(account_id.clone(), account_of(FAUCET), old.free_balance).unwrap();
-        CollateralModule::transfer(account_of(FAUCET), account_id.clone(), new.free_balance).unwrap();
+        CollateralPallet::transfer(account_id.clone(), account_of(FAUCET), old.free_balance).unwrap();
+        CollateralPallet::transfer(account_of(FAUCET), account_id.clone(), new.free_balance).unwrap();
 
         // set locked balance:
-        CollateralModule::slash_collateral(account_id.clone(), account_of(FAUCET), old.locked_balance).unwrap();
-        CollateralModule::transfer(account_of(FAUCET), account_id.clone(), new.locked_balance).unwrap();
-        CollateralModule::lock_collateral(&account_id, new.locked_balance).unwrap();
+        CollateralPallet::slash_collateral(account_id.clone(), account_of(FAUCET), old.locked_balance).unwrap();
+        CollateralPallet::transfer(account_of(FAUCET), account_id.clone(), new.locked_balance).unwrap();
+        CollateralPallet::lock_collateral(&account_id, new.locked_balance).unwrap();
 
         // set free_tokens
-        TreasuryModule::mint(account_id.clone(), new.free_tokens);
+        TreasuryPallet::mint(account_id.clone(), new.free_tokens);
 
         // set locked_tokens
-        TreasuryModule::mint(account_id.clone(), new.locked_tokens);
-        TreasuryModule::lock(account_id, new.locked_tokens).unwrap();
+        TreasuryPallet::mint(account_id.clone(), new.locked_tokens);
+        TreasuryPallet::lock(account_id, new.locked_tokens).unwrap();
 
         // sanity check:
         assert_eq!(Self::get(id), new);
@@ -242,8 +240,8 @@ impl CoreVaultData {
             griefing_collateral: CurrencySource::<Runtime>::Griefing(account_id.clone())
                 .current_balance()
                 .unwrap(),
-            free_balance: CollateralModule::get_balance_from_account(&account_id),
-            free_tokens: TreasuryModule::get_balance_from_account(account_id.clone()),
+            free_balance: CollateralPallet::get_balance_from_account(&account_id),
+            free_tokens: TreasuryPallet::get_balance_from_account(account_id.clone()),
             to_be_replaced: vault.to_be_replaced_tokens,
             replace_collateral: vault.replace_collateral,
         }
@@ -258,8 +256,8 @@ impl CoreVaultData {
             to_be_redeemed: vault.to_be_redeemed_tokens,
             backing_collateral: CurrencySource::<Runtime>::LiquidationVault.current_balance().unwrap(),
             griefing_collateral: 0,
-            free_balance: CollateralModule::get_balance_from_account(&account_id),
-            free_tokens: TreasuryModule::get_balance_from_account(account_id.clone()),
+            free_balance: CollateralPallet::get_balance_from_account(&account_id),
+            free_tokens: TreasuryPallet::get_balance_from_account(account_id.clone()),
             to_be_replaced: 0,
             replace_collateral: 0,
         }
@@ -278,7 +276,7 @@ impl CoreVaultData {
         VaultRegistryPallet::slash_collateral(
             CurrencySource::FreeBalance(account_of(FAUCET)),
             CurrencySource::Backing(account_of(vault)),
-            CollateralModule::get_balance_from_account(&account_of(FAUCET)),
+            CollateralPallet::get_balance_from_account(&account_of(FAUCET)),
         )
         .unwrap();
 
@@ -306,8 +304,8 @@ impl CoreVaultData {
             &account_of(vault),
             current.to_be_replaced,
         ));
-        assert_ok!(TreasuryModule::lock(account_of(vault), current.free_tokens));
-        assert_ok!(TreasuryModule::burn(account_of(vault), current.free_tokens));
+        assert_ok!(TreasuryPallet::lock(account_of(vault), current.free_tokens));
+        assert_ok!(TreasuryPallet::burn(account_of(vault), current.free_tokens));
 
         // set to-be-issued
         assert_ok!(VaultRegistryPallet::try_increase_to_be_issued_tokens(
@@ -333,7 +331,7 @@ impl CoreVaultData {
         ));
 
         // set free tokens:
-        TreasuryModule::mint(account_of(vault), state.free_tokens);
+        TreasuryPallet::mint(account_of(vault), state.free_tokens);
 
         // clear all balances
         VaultRegistryPallet::slash_collateral(
@@ -471,7 +469,7 @@ impl ParachainTwoVaultState {
 }
 #[allow(dead_code)]
 pub fn drop_exchange_rate_and_liquidate(vault: [u8; 32]) {
-    assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(
+    assert_ok!(ExchangeRateOraclePallet::_set_exchange_rate(
         FixedU128::checked_from_integer(10_000_000_000).unwrap()
     ));
     assert_ok!(VaultRegistryPallet::liquidate_vault(&account_of(vault)));
@@ -860,9 +858,9 @@ impl ExtBuilder {
     pub fn execute_without_relay_init<R>(mut self, execute: impl FnOnce() -> R) -> R {
         self.test_externalities.execute_with(|| {
             SystemModule::set_block_number(1); // required to be able to dispatch functions
-            SecurityModule::set_active_block_number(1);
+            SecurityPallet::set_active_block_number(1);
 
-            assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
+            assert_ok!(ExchangeRateOraclePallet::_set_exchange_rate(FixedU128::one()));
             set_default_thresholds();
 
             execute()

--- a/parachain/runtime/tests/mock/redeem_testing_utils.rs
+++ b/parachain/runtime/tests/mock/redeem_testing_utils.rs
@@ -42,7 +42,7 @@ impl ExecuteRedeemBuilder {
             .with_op_return(Some(self.redeem_id))
             .mine();
 
-        SecurityModule::set_active_block_number(SecurityModule::active_block_number() + CONFIRMATIONS);
+        SecurityPallet::set_active_block_number(SecurityPallet::active_block_number() + CONFIRMATIONS);
 
         // alice executes the redeemrequest by confirming the btc transaction
         Call::Redeem(RedeemCall::execute_redeem(self.redeem_id, proof, raw_tx))
@@ -58,7 +58,7 @@ pub fn setup_cancelable_redeem(user: [u8; 32], vault: [u8; 32], collateral: u128
     let redeem_id = setup_redeem(polka_btc, user, vault, collateral);
 
     // expire request without transferring btc
-    SecurityModule::set_active_block_number(RedeemPallet::redeem_period() + 1 + 1);
+    SecurityPallet::set_active_block_number(RedeemPallet::redeem_period() + 1 + 1);
 
     // bob cannot execute past expiry
     assert_noop!(

--- a/parachain/runtime/tests/test_btc_relay.rs
+++ b/parachain/runtime/tests/test_btc_relay.rs
@@ -60,3 +60,43 @@ fn integration_test_submit_block_headers_and_verify_transaction_inclusion() {
         }
     })
 }
+
+#[test]
+fn integration_test_btc_relay_with_parachain_shutdown_fails() {
+    ExtBuilder::build().execute_with(|| {
+        SecurityModule::set_status(StatusCode::Shutdown);
+
+        assert_noop!(
+            Call::BTCRelay(BTCRelayCall::verify_and_validate_transaction(
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default()
+            ))
+            .dispatch(origin_of(account_of(ALICE))),
+            SecurityError::ParachainNotRunning
+        );
+        assert_noop!(
+            Call::BTCRelay(BTCRelayCall::verify_transaction_inclusion(
+                Default::default(),
+                Default::default(),
+                Default::default()
+            ))
+            .dispatch(origin_of(account_of(ALICE))),
+            SecurityError::ParachainNotRunning
+        );
+        assert_noop!(
+            Call::BTCRelay(BTCRelayCall::validate_transaction(
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default()
+            ))
+            .dispatch(origin_of(account_of(ALICE))),
+            SecurityError::ParachainNotRunning
+        );
+    })
+}

--- a/parachain/runtime/tests/test_btc_relay.rs
+++ b/parachain/runtime/tests/test_btc_relay.rs
@@ -12,7 +12,7 @@ fn integration_test_submit_block_headers_and_verify_transaction_inclusion() {
         // load blocks with transactions
         let test_data = get_bitcoin_testdata();
 
-        SecurityModule::set_active_block_number(1);
+        SecurityPallet::set_active_block_number(1);
 
         // store all block headers. parachain_genesis is the first block
         // known in the parachain. Any block before will be rejected
@@ -34,7 +34,7 @@ fn integration_test_submit_block_headers_and_verify_transaction_inclusion() {
 
             assert_store_main_chain_header_event(block.height, block.get_block_hash(), account_of(ALICE));
         }
-        SecurityModule::set_active_block_number(1 + CONFIRMATIONS);
+        SecurityPallet::set_active_block_number(1 + CONFIRMATIONS);
         // verify all transaction
         let current_height = btc_relay::Pallet::<Runtime>::get_best_block_height();
         for block in test_data.iter() {
@@ -64,7 +64,7 @@ fn integration_test_submit_block_headers_and_verify_transaction_inclusion() {
 #[test]
 fn integration_test_btc_relay_with_parachain_shutdown_fails() {
     ExtBuilder::build().execute_with(|| {
-        SecurityModule::set_status(StatusCode::Shutdown);
+        SecurityPallet::set_status(StatusCode::Shutdown);
 
         assert_noop!(
             Call::BTCRelay(BTCRelayCall::verify_and_validate_transaction(

--- a/parachain/runtime/tests/test_btc_relay.rs
+++ b/parachain/runtime/tests/test_btc_relay.rs
@@ -77,7 +77,7 @@ fn integration_test_btc_relay_with_parachain_shutdown_fails() {
                 Default::default()
             ))
             .dispatch(origin_of(account_of(ALICE))),
-            SecurityError::ParachainNotRunning
+            SecurityError::ParachainShutdown
         );
         assert_noop!(
             Call::BTCRelay(BTCRelayCall::verify_transaction_inclusion(
@@ -86,7 +86,7 @@ fn integration_test_btc_relay_with_parachain_shutdown_fails() {
                 Default::default()
             ))
             .dispatch(origin_of(account_of(ALICE))),
-            SecurityError::ParachainNotRunning
+            SecurityError::ParachainShutdown
         );
         assert_noop!(
             Call::BTCRelay(BTCRelayCall::validate_transaction(
@@ -96,7 +96,7 @@ fn integration_test_btc_relay_with_parachain_shutdown_fails() {
                 Default::default()
             ))
             .dispatch(origin_of(account_of(ALICE))),
-            SecurityError::ParachainNotRunning
+            SecurityError::ParachainShutdown
         );
     })
 }

--- a/parachain/runtime/tests/test_fee_pool.rs
+++ b/parachain/runtime/tests/test_fee_pool.rs
@@ -13,14 +13,14 @@ const RELAYER_2: [u8; 32] = GRACE;
 
 fn test_with(execute: impl Fn(Currency)) {
     ExtBuilder::build().execute_with(|| {
-        SecurityModule::set_active_block_number(1);
-        assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
+        SecurityPallet::set_active_block_number(1);
+        assert_ok!(ExchangeRateOraclePallet::_set_exchange_rate(FixedU128::one()));
         setup_dot_reward();
         execute(Currency::DOT);
     });
     ExtBuilder::build().execute_with(|| {
-        SecurityModule::set_active_block_number(1);
-        assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
+        SecurityPallet::set_active_block_number(1);
+        assert_ok!(ExchangeRateOraclePallet::_set_exchange_rate(FixedU128::one()));
         execute(Currency::PolkaBTC);
     });
 }
@@ -111,7 +111,7 @@ fn setup_dot_reward() {
 }
 
 fn set_issued_and_backing(vault: [u8; 32], amount_issued: u128, backing: u128) {
-    SecurityModule::set_active_block_number(1);
+    SecurityPallet::set_active_block_number(1);
 
     // we want issued to be 100 times amount_issued, _including fees_
     let request_amount = 100 * amount_issued;
@@ -257,7 +257,7 @@ fn test_maintainer_fee_pool_withdrawal() {
 #[test]
 fn integration_test_fee_with_parachain_shutdown_fails() {
     ExtBuilder::build().execute_with(|| {
-        SecurityModule::set_status(StatusCode::Shutdown);
+        SecurityPallet::set_status(StatusCode::Shutdown);
 
         assert_noop!(
             Call::Fee(FeeCall::withdraw_polka_btc(0)).dispatch(origin_of(account_of(ALICE))),

--- a/parachain/runtime/tests/test_fee_pool.rs
+++ b/parachain/runtime/tests/test_fee_pool.rs
@@ -253,3 +253,19 @@ fn test_maintainer_fee_pool_withdrawal() {
         assert_eq_modulo_rounding!(get_rewards(currency, MAINTAINER), maintainer_rewards);
     })
 }
+
+#[test]
+fn integration_test_fee_with_parachain_shutdown_fails() {
+    ExtBuilder::build().execute_with(|| {
+        SecurityModule::set_status(StatusCode::Shutdown);
+
+        assert_noop!(
+            Call::Fee(FeeCall::withdraw_polka_btc(0)).dispatch(origin_of(account_of(ALICE))),
+            SecurityError::ParachainNotRunning
+        );
+        assert_noop!(
+            Call::Fee(FeeCall::withdraw_dot(0)).dispatch(origin_of(account_of(ALICE))),
+            SecurityError::ParachainNotRunning
+        );
+    })
+}

--- a/parachain/runtime/tests/test_fee_pool.rs
+++ b/parachain/runtime/tests/test_fee_pool.rs
@@ -261,11 +261,11 @@ fn integration_test_fee_with_parachain_shutdown_fails() {
 
         assert_noop!(
             Call::Fee(FeeCall::withdraw_polka_btc(0)).dispatch(origin_of(account_of(ALICE))),
-            SecurityError::ParachainNotRunning
+            SecurityError::ParachainShutdown
         );
         assert_noop!(
             Call::Fee(FeeCall::withdraw_dot(0)).dispatch(origin_of(account_of(ALICE))),
-            SecurityError::ParachainNotRunning
+            SecurityError::ParachainShutdown
         );
     })
 }

--- a/parachain/runtime/tests/test_issue.rs
+++ b/parachain/runtime/tests/test_issue.rs
@@ -5,8 +5,8 @@ use mock::{issue_testing_utils::*, *};
 
 fn test_with<R>(execute: impl FnOnce() -> R) -> R {
     ExtBuilder::build().execute_with(|| {
-        SecurityModule::set_active_block_number(1);
-        assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
+        SecurityPallet::set_active_block_number(1);
+        assert_ok!(ExchangeRateOraclePallet::_set_exchange_rate(FixedU128::one()));
         UserData::force_to(USER, default_user_state());
         execute()
     })
@@ -39,7 +39,7 @@ mod expiry_test {
         test_with(|| {
             set_issue_period(100);
             let (issue_id, _) = request_issue(4_000);
-            SecurityModule::set_active_block_number(75);
+            SecurityPallet::set_active_block_number(75);
 
             assert_noop!(cancel_issue(issue_id), IssueError::TimeNotExpired);
             assert_ok!(execute_issue(issue_id));
@@ -51,7 +51,7 @@ mod expiry_test {
         test_with(|| {
             set_issue_period(100);
             let (issue_id, _) = request_issue(4_000);
-            SecurityModule::set_active_block_number(110);
+            SecurityPallet::set_active_block_number(110);
 
             assert_noop!(execute_issue(issue_id), IssueError::CommitPeriodExpired);
             assert_ok!(cancel_issue(issue_id));
@@ -63,7 +63,7 @@ mod expiry_test {
         test_with(|| {
             set_issue_period(200);
             let (issue_id, _) = request_issue(4_000);
-            SecurityModule::set_active_block_number(110);
+            SecurityPallet::set_active_block_number(110);
             set_issue_period(100);
 
             // request still uses period = 200, so cancel fails and execute succeeds
@@ -77,7 +77,7 @@ mod expiry_test {
         test_with(|| {
             set_issue_period(100);
             let (issue_id, _) = request_issue(4_000);
-            SecurityModule::set_active_block_number(110);
+            SecurityPallet::set_active_block_number(110);
             set_issue_period(200);
 
             // request uses period = 200, so execute succeeds and cancel fails
@@ -90,7 +90,7 @@ mod expiry_test {
 #[test]
 fn integration_test_issue_with_parachain_shutdown_fails() {
     test_with(|| {
-        SecurityModule::set_status(StatusCode::Shutdown);
+        SecurityPallet::set_status(StatusCode::Shutdown);
 
         assert_noop!(
             Call::Issue(IssueCall::request_issue(0, account_of(BOB), 0)).dispatch(origin_of(account_of(ALICE))),
@@ -156,7 +156,7 @@ mod request_issue_tests {
     fn integration_test_request_with_griefing_collateral_at_minimum_succeeds() {
         test_with_initialized_vault(|| {
             let amount = 10_000;
-            let amount_in_dot = ExchangeRateOracleModule::btc_to_dots(amount).unwrap();
+            let amount_in_dot = ExchangeRateOraclePallet::btc_to_dots(amount).unwrap();
             let griefing_collateral = FeePallet::get_issue_griefing_collateral(amount_in_dot).unwrap();
             assert_ok!(
                 Call::Issue(IssueCall::request_issue(amount, account_of(VAULT), griefing_collateral))
@@ -187,7 +187,7 @@ mod request_issue_tests {
     fn integration_test_request_not_accepting_new_issues_fails() {
         test_with_initialized_vault(|| {
             let amount = 10_000;
-            let amount_in_dot = ExchangeRateOracleModule::btc_to_dots(amount).unwrap();
+            let amount_in_dot = ExchangeRateOraclePallet::btc_to_dots(amount).unwrap();
             let griefing_collateral = FeePallet::get_issue_griefing_collateral(amount_in_dot).unwrap() - 1;
             assert_noop!(
                 Call::Issue(IssueCall::request_issue(amount, account_of(VAULT), griefing_collateral))
@@ -252,7 +252,7 @@ fn integration_test_issue_polka_btc_execute_succeeds() {
         // send the btc from the user to the vault
         let (_tx_id, _height, proof, raw_tx) = generate_transaction_and_mine(vault_btc_address, total_amount_btc, None);
 
-        SecurityModule::set_active_block_number(1 + CONFIRMATIONS);
+        SecurityPallet::set_active_block_number(1 + CONFIRMATIONS);
 
         // alice executes the issue by confirming the btc transaction
         assert_ok!(Call::Issue(IssueCall::execute_issue(issue_id, proof, raw_tx))
@@ -453,7 +453,7 @@ fn integration_test_issue_polka_btc_cancel() {
         // random non-zero starting state
         let (issue_id, issue) = RequestIssueBuilder::new(10_000).request();
 
-        SecurityModule::set_active_block_number(IssuePallet::issue_period() + 1 + 1);
+        SecurityPallet::set_active_block_number(IssuePallet::issue_period() + 1 + 1);
 
         // alice cannot execute past expiry
         assert_noop!(
@@ -479,7 +479,7 @@ fn integration_test_issue_polka_btc_cancel_liquidated() {
     test_with_initialized_vault(|| {
         let (issue_id, issue) = RequestIssueBuilder::new(10_000).request();
 
-        SecurityModule::set_active_block_number(IssuePallet::issue_period() + 1 + 1);
+        SecurityPallet::set_active_block_number(IssuePallet::issue_period() + 1 + 1);
 
         // alice cannot execute past expiry
         assert_noop!(
@@ -542,7 +542,7 @@ fn integration_test_issue_with_unrelated_rawtx_and_txid_fails() {
             .with_op_return(None)
             .mine();
 
-        SecurityModule::set_active_block_number(SecurityModule::active_block_number() + CONFIRMATIONS);
+        SecurityPallet::set_active_block_number(SecurityPallet::active_block_number() + CONFIRMATIONS);
 
         // fail due to insufficient amount
         assert_noop!(

--- a/parachain/runtime/tests/test_issue.rs
+++ b/parachain/runtime/tests/test_issue.rs
@@ -94,12 +94,12 @@ fn integration_test_issue_with_parachain_shutdown_fails() {
 
         assert_noop!(
             Call::Issue(IssueCall::request_issue(0, account_of(BOB), 0)).dispatch(origin_of(account_of(ALICE))),
-            SecurityError::ParachainNotRunning,
+            SecurityError::ParachainShutdown,
         );
 
         assert_noop!(
             Call::Issue(IssueCall::cancel_issue(H256([0; 32]),)).dispatch(origin_of(account_of(ALICE))),
-            SecurityError::ParachainNotRunning,
+            SecurityError::ParachainShutdown,
         );
 
         assert_noop!(
@@ -109,7 +109,7 @@ fn integration_test_issue_with_parachain_shutdown_fails() {
                 Default::default()
             ))
             .dispatch(origin_of(account_of(ALICE))),
-            SecurityError::ParachainNotRunning,
+            SecurityError::ParachainShutdown,
         );
 
         assert_noop!(
@@ -119,7 +119,7 @@ fn integration_test_issue_with_parachain_shutdown_fails() {
                 Default::default()
             ))
             .dispatch(origin_of(account_of(ALICE))),
-            SecurityError::ParachainNotRunning,
+            SecurityError::ParachainShutdown,
         );
     });
 }

--- a/parachain/runtime/tests/test_issue.rs
+++ b/parachain/runtime/tests/test_issue.rs
@@ -88,7 +88,7 @@ mod expiry_test {
 }
 
 #[test]
-fn integration_test_issue_should_fail_if_not_running() {
+fn integration_test_issue_with_parachain_shutdown_fails() {
     test_with(|| {
         SecurityModule::set_status(StatusCode::Shutdown);
 
@@ -98,8 +98,27 @@ fn integration_test_issue_should_fail_if_not_running() {
         );
 
         assert_noop!(
-            Call::Issue(IssueCall::execute_issue(H256([0; 32]), vec![0u8; 32], vec![0u8; 32]))
-                .dispatch(origin_of(account_of(ALICE))),
+            Call::Issue(IssueCall::cancel_issue(H256([0; 32]),)).dispatch(origin_of(account_of(ALICE))),
+            SecurityError::ParachainNotRunning,
+        );
+
+        assert_noop!(
+            Call::Issue(IssueCall::execute_issue(
+                Default::default(),
+                Default::default(),
+                Default::default()
+            ))
+            .dispatch(origin_of(account_of(ALICE))),
+            SecurityError::ParachainNotRunning,
+        );
+
+        assert_noop!(
+            Call::Refund(RefundCall::execute_refund(
+                Default::default(),
+                Default::default(),
+                Default::default()
+            ))
+            .dispatch(origin_of(account_of(ALICE))),
             SecurityError::ParachainNotRunning,
         );
     });

--- a/parachain/runtime/tests/test_redeem.rs
+++ b/parachain/runtime/tests/test_redeem.rs
@@ -37,7 +37,7 @@ fn integration_test_redeem_with_parachain_shutdown_fails() {
                 account_of(BOB),
             ))
             .dispatch(origin_of(account_of(ALICE))),
-            SecurityError::ParachainNotRunning,
+            SecurityError::ParachainShutdown,
         );
 
         assert_noop!(
@@ -48,27 +48,27 @@ fn integration_test_redeem_with_parachain_shutdown_fails() {
                 Default::default()
             ))
             .dispatch(origin_of(account_of(ALICE))),
-            SecurityError::ParachainNotRunning,
+            SecurityError::ParachainShutdown,
         );
 
         assert_noop!(
             Call::Redeem(RedeemCall::cancel_redeem(Default::default(), false)).dispatch(origin_of(account_of(ALICE))),
-            SecurityError::ParachainNotRunning,
+            SecurityError::ParachainShutdown,
         );
         assert_noop!(
             Call::Redeem(RedeemCall::cancel_redeem(Default::default(), true)).dispatch(origin_of(account_of(ALICE))),
-            SecurityError::ParachainNotRunning,
+            SecurityError::ParachainShutdown,
         );
 
         assert_noop!(
             Call::Redeem(RedeemCall::liquidation_redeem(1000)).dispatch(origin_of(account_of(ALICE))),
-            SecurityError::ParachainNotRunning,
+            SecurityError::ParachainShutdown,
         );
 
         assert_noop!(
             Call::Redeem(RedeemCall::mint_tokens_for_reimbursed_redeem(Default::default()))
                 .dispatch(origin_of(account_of(ALICE))),
-            SecurityError::ParachainNotRunning,
+            SecurityError::ParachainShutdown,
         );
     });
 }
@@ -226,12 +226,12 @@ fn integration_test_redeem_parachain_status_shutdown_fails() {
 
         assert_noop!(
             Call::Issue(IssueCall::request_issue(0, account_of(BOB), 0)).dispatch(origin_of(account_of(ALICE))),
-            SecurityError::ParachainNotRunning,
+            SecurityError::ParachainShutdown,
         );
 
         assert_noop!(
             Call::Issue(IssueCall::cancel_issue(H256([0; 32]),)).dispatch(origin_of(account_of(ALICE))),
-            SecurityError::ParachainNotRunning,
+            SecurityError::ParachainShutdown,
         );
 
         assert_noop!(
@@ -242,7 +242,7 @@ fn integration_test_redeem_parachain_status_shutdown_fails() {
                 vec![0u8; 32]
             ))
             .dispatch(origin_of(account_of(ALICE))),
-            SecurityError::ParachainNotRunning,
+            SecurityError::ParachainShutdown,
         );
     });
 }

--- a/parachain/runtime/tests/test_redeem.rs
+++ b/parachain/runtime/tests/test_redeem.rs
@@ -4,8 +4,8 @@ use mock::{redeem_testing_utils::*, *};
 
 fn test_with<R>(execute: impl FnOnce() -> R) -> R {
     ExtBuilder::build().execute_with(|| {
-        SecurityModule::set_active_block_number(1);
-        assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
+        SecurityPallet::set_active_block_number(1);
+        assert_ok!(ExchangeRateOraclePallet::_set_exchange_rate(FixedU128::one()));
         set_default_thresholds();
         UserData::force_to(USER, default_user_state());
         CoreVaultData::force_to(VAULT, default_vault_state());
@@ -28,7 +28,7 @@ fn consume_to_be_replaced(vault: &mut CoreVaultData, amount_btc: u128) {
 #[test]
 fn integration_test_redeem_with_parachain_shutdown_fails() {
     test_with(|| {
-        SecurityModule::set_status(StatusCode::Shutdown);
+        SecurityPallet::set_status(StatusCode::Shutdown);
 
         assert_noop!(
             Call::Redeem(RedeemCall::request_redeem(
@@ -42,7 +42,6 @@ fn integration_test_redeem_with_parachain_shutdown_fails() {
 
         assert_noop!(
             Call::Redeem(RedeemCall::execute_redeem(
-                Default::default(),
                 Default::default(),
                 Default::default(),
                 Default::default()
@@ -171,7 +170,7 @@ mod expiry_test {
         test_with(|| {
             set_redeem_period(100);
             let redeem_id = request_redeem();
-            SecurityModule::set_active_block_number(75);
+            SecurityPallet::set_active_block_number(75);
 
             assert_noop!(cancel_redeem(redeem_id), RedeemError::TimeNotExpired);
             assert_ok!(execute_redeem(redeem_id));
@@ -183,7 +182,7 @@ mod expiry_test {
         test_with(|| {
             set_redeem_period(100);
             let redeem_id = request_redeem();
-            SecurityModule::set_active_block_number(110);
+            SecurityPallet::set_active_block_number(110);
 
             assert_noop!(execute_redeem(redeem_id), RedeemError::CommitPeriodExpired);
             assert_ok!(cancel_redeem(redeem_id));
@@ -195,7 +194,7 @@ mod expiry_test {
         test_with(|| {
             set_redeem_period(200);
             let redeem_id = request_redeem();
-            SecurityModule::set_active_block_number(110);
+            SecurityPallet::set_active_block_number(110);
             set_redeem_period(100);
 
             // request still uses period = 200, so cancel fails and execute succeeds
@@ -209,7 +208,7 @@ mod expiry_test {
         test_with(|| {
             set_redeem_period(100);
             let redeem_id = request_redeem();
-            SecurityModule::set_active_block_number(110);
+            SecurityPallet::set_active_block_number(110);
             set_redeem_period(200);
 
             // request uses period = 200, so execute succeeds and cancel fails
@@ -222,7 +221,7 @@ mod expiry_test {
 #[test]
 fn integration_test_redeem_parachain_status_shutdown_fails() {
     test_with(|| {
-        SecurityModule::set_status(StatusCode::Shutdown);
+        SecurityPallet::set_status(StatusCode::Shutdown);
 
         assert_noop!(
             Call::Issue(IssueCall::request_issue(0, account_of(BOB), 0)).dispatch(origin_of(account_of(ALICE))),
@@ -235,13 +234,8 @@ fn integration_test_redeem_parachain_status_shutdown_fails() {
         );
 
         assert_noop!(
-            Call::Issue(IssueCall::execute_issue(
-                H256([0; 32]),
-                H256Le::zero(),
-                vec![0u8; 32],
-                vec![0u8; 32]
-            ))
-            .dispatch(origin_of(account_of(ALICE))),
+            Call::Issue(IssueCall::execute_issue(H256([0; 32]), vec![0u8; 32], vec![0u8; 32]))
+                .dispatch(origin_of(account_of(ALICE))),
             SecurityError::ParachainShutdown,
         );
     });
@@ -279,7 +273,7 @@ fn integration_test_premium_redeem_polka_btc_execute() {
 
         // make vault undercollateralized. Note that we place it under the liquidation threshold
         // as well, but as long as we don't call liquidate that's ok
-        assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::from(100)));
+        assert_ok!(ExchangeRateOraclePallet::_set_exchange_rate(FixedU128::from(100)));
 
         // alice requests to redeem polka_btc from Bob
         assert_ok!(Call::Redeem(RedeemCall::request_redeem(
@@ -297,7 +291,7 @@ fn integration_test_premium_redeem_polka_btc_execute() {
         let (_tx_id, _tx_block_height, merkle_proof, raw_tx) =
             generate_transaction_and_mine(user_btc_address, polka_btc, Some(redeem_id));
 
-        SecurityModule::set_active_block_number(1 + CONFIRMATIONS);
+        SecurityPallet::set_active_block_number(1 + CONFIRMATIONS);
 
         assert_ok!(
             Call::Redeem(RedeemCall::execute_redeem(redeem_id, merkle_proof, raw_tx))
@@ -380,7 +374,7 @@ fn integration_test_redeem_polka_btc_cancel_reimburse_sufficient_collateral_for_
 
         let redeem_id = setup_cancelable_redeem(USER, VAULT, 100000000, amount_btc);
         let redeem = RedeemPallet::get_open_redeem_request_from_id(&redeem_id).unwrap();
-        let amount_without_fee_dot = ExchangeRateOracleModule::btc_to_dots(redeem.amount_btc).unwrap();
+        let amount_without_fee_dot = ExchangeRateOraclePallet::btc_to_dots(redeem.amount_btc).unwrap();
 
         let punishment_fee = FeePallet::get_punishment_fee(amount_without_fee_dot).unwrap();
         assert!(punishment_fee > 0);
@@ -429,7 +423,7 @@ fn integration_test_redeem_polka_btc_cancel_reimburse_insufficient_collateral_fo
 
         let redeem_id = setup_cancelable_redeem(USER, VAULT, 100000000, amount_btc);
         let redeem = RedeemPallet::get_open_redeem_request_from_id(&redeem_id).unwrap();
-        let amount_without_fee_dot = ExchangeRateOracleModule::btc_to_dots(redeem.amount_btc).unwrap();
+        let amount_without_fee_dot = ExchangeRateOraclePallet::btc_to_dots(redeem.amount_btc).unwrap();
 
         let punishment_fee = FeePallet::get_punishment_fee(amount_without_fee_dot).unwrap();
         assert!(punishment_fee > 0);
@@ -457,7 +451,7 @@ fn integration_test_redeem_polka_btc_cancel_reimburse_insufficient_collateral_fo
             })
         );
 
-        SecurityModule::set_active_block_number(100000000);
+        SecurityPallet::set_active_block_number(100000000);
         CoreVaultData::force_to(
             VAULT,
             CoreVaultData {
@@ -486,7 +480,7 @@ fn integration_test_redeem_polka_btc_cancel_no_reimburse() {
 
         let redeem_id = setup_cancelable_redeem(USER, VAULT, 100000000, amount_btc);
         let redeem = RedeemPallet::get_open_redeem_request_from_id(&redeem_id).unwrap();
-        let amount_without_fee_dot = ExchangeRateOracleModule::btc_to_dots(redeem.amount_btc).unwrap();
+        let amount_without_fee_dot = ExchangeRateOraclePallet::btc_to_dots(redeem.amount_btc).unwrap();
 
         let punishment_fee = FeePallet::get_punishment_fee(amount_without_fee_dot).unwrap();
         assert!(punishment_fee > 0);
@@ -759,7 +753,7 @@ fn integration_test_redeem_banning() {
         );
 
         // check that the ban is not permanent
-        SecurityModule::set_active_block_number(100000000);
+        SecurityPallet::set_active_block_number(100000000);
         assert_ok!(
             Call::Issue(IssueCall::request_issue(50, account_of(VAULT), 50)).dispatch(origin_of(account_of(USER)))
         );

--- a/parachain/runtime/tests/test_replace.rs
+++ b/parachain/runtime/tests/test_replace.rs
@@ -798,6 +798,61 @@ fn integration_test_replace_auction_replace() {
 }
 
 #[test]
+fn integration_test_replace_with_parachain_shutdown_fails() {
+    test_with(|| {
+        SecurityModule::set_status(StatusCode::Shutdown);
+        // make vault auctionable
+        VaultRegistryModule::set_auction_collateral_threshold(FixedU128::from(10_000));
+
+        assert_noop!(
+            Call::Replace(ReplaceCall::request_replace(0, 0)).dispatch(origin_of(account_of(OLD_VAULT))),
+            SecurityError::ParachainNotRunning,
+        );
+        assert_noop!(
+            Call::Replace(ReplaceCall::withdraw_replace(0,)).dispatch(origin_of(account_of(OLD_VAULT))),
+            SecurityError::ParachainNotRunning
+        );
+        assert_noop!(
+            Call::Replace(ReplaceCall::accept_replace(
+                Default::default(),
+                0,
+                0,
+                Default::default()
+            ))
+            .dispatch(origin_of(account_of(OLD_VAULT))),
+            SecurityError::ParachainNotRunning
+        );
+
+        assert_noop!(
+            Call::Replace(ReplaceCall::auction_replace(
+                account_of(OLD_VAULT),
+                0,
+                0,
+                Default::default()
+            ))
+            .dispatch(origin_of(account_of(OLD_VAULT))),
+            SecurityError::ParachainNotRunning
+        );
+
+        assert_noop!(
+            Call::Replace(ReplaceCall::execute_replace(
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default()
+            ))
+            .dispatch(origin_of(account_of(OLD_VAULT))),
+            SecurityError::ParachainNotRunning
+        );
+
+        assert_noop!(
+            Call::Replace(ReplaceCall::cancel_replace(Default::default())).dispatch(origin_of(account_of(OLD_VAULT))),
+            SecurityError::ParachainNotRunning
+        );
+    })
+}
+
+#[test]
 fn integration_test_replace_execute_replace() {
     ExtBuilder::build().execute_with(|| {
         assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));

--- a/parachain/runtime/tests/test_replace.rs
+++ b/parachain/runtime/tests/test_replace.rs
@@ -421,7 +421,7 @@ mod request_replace_tests {
 
             assert_noop!(
                 Call::Replace(ReplaceCall::request_replace(0, 0)).dispatch(origin_of(account_of(OLD_VAULT))),
-                SecurityError::ParachainNotRunning,
+                SecurityError::ParachainShutdown,
             );
         });
     }
@@ -806,11 +806,11 @@ fn integration_test_replace_with_parachain_shutdown_fails() {
 
         assert_noop!(
             Call::Replace(ReplaceCall::request_replace(0, 0)).dispatch(origin_of(account_of(OLD_VAULT))),
-            SecurityError::ParachainNotRunning,
+            SecurityError::ParachainShutdown,
         );
         assert_noop!(
             Call::Replace(ReplaceCall::withdraw_replace(0,)).dispatch(origin_of(account_of(OLD_VAULT))),
-            SecurityError::ParachainNotRunning
+            SecurityError::ParachainShutdown
         );
         assert_noop!(
             Call::Replace(ReplaceCall::accept_replace(
@@ -820,7 +820,7 @@ fn integration_test_replace_with_parachain_shutdown_fails() {
                 Default::default()
             ))
             .dispatch(origin_of(account_of(OLD_VAULT))),
-            SecurityError::ParachainNotRunning
+            SecurityError::ParachainShutdown
         );
 
         assert_noop!(
@@ -831,7 +831,7 @@ fn integration_test_replace_with_parachain_shutdown_fails() {
                 Default::default()
             ))
             .dispatch(origin_of(account_of(OLD_VAULT))),
-            SecurityError::ParachainNotRunning
+            SecurityError::ParachainShutdown
         );
 
         assert_noop!(
@@ -842,12 +842,12 @@ fn integration_test_replace_with_parachain_shutdown_fails() {
                 Default::default()
             ))
             .dispatch(origin_of(account_of(OLD_VAULT))),
-            SecurityError::ParachainNotRunning
+            SecurityError::ParachainShutdown
         );
 
         assert_noop!(
             Call::Replace(ReplaceCall::cancel_replace(Default::default())).dispatch(origin_of(account_of(OLD_VAULT))),
-            SecurityError::ParachainNotRunning
+            SecurityError::ParachainShutdown
         );
     })
 }

--- a/parachain/runtime/tests/test_staked_relayers.rs
+++ b/parachain/runtime/tests/test_staked_relayers.rs
@@ -90,3 +90,40 @@ fn integration_test_report_vault_theft_by_relayer() {
 fn integration_test_report_vault_theft_by_non_relayer() {
     test_vault_theft(false);
 }
+
+#[test]
+fn test_staked_relayer_parachain_status_check_fails() {
+    ExtBuilder::build().execute_with(|| {
+        SecurityModule::set_status(StatusCode::Shutdown);
+
+        assert_noop!(
+            Call::StakedRelayers(StakedRelayersCall::initialize(Default::default(), 0))
+                .dispatch(origin_of(account_of(ALICE))),
+            SecurityError::ParachainNotRunning
+        );
+        assert_noop!(
+            Call::StakedRelayers(StakedRelayersCall::register_staked_relayer(0)).dispatch(origin_of(account_of(ALICE))),
+            SecurityError::ParachainNotRunning
+        );
+        assert_noop!(
+            Call::StakedRelayers(StakedRelayersCall::deregister_staked_relayer())
+                .dispatch(origin_of(account_of(ALICE))),
+            SecurityError::ParachainNotRunning
+        );
+        assert_noop!(
+            Call::StakedRelayers(StakedRelayersCall::store_block_header(Default::default()))
+                .dispatch(origin_of(account_of(ALICE))),
+            SecurityError::ParachainNotRunning
+        );
+        assert_noop!(
+            Call::StakedRelayers(StakedRelayersCall::report_vault_theft(
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default()
+            ))
+            .dispatch(origin_of(account_of(ALICE))),
+            SecurityError::ParachainNotRunning
+        );
+    })
+}

--- a/parachain/runtime/tests/test_staked_relayers.rs
+++ b/parachain/runtime/tests/test_staked_relayers.rs
@@ -99,21 +99,21 @@ fn test_staked_relayer_parachain_status_check_fails() {
         assert_noop!(
             Call::StakedRelayers(StakedRelayersCall::initialize(Default::default(), 0))
                 .dispatch(origin_of(account_of(ALICE))),
-            SecurityError::ParachainNotRunning
+            SecurityError::ParachainShutdown
         );
         assert_noop!(
             Call::StakedRelayers(StakedRelayersCall::register_staked_relayer(0)).dispatch(origin_of(account_of(ALICE))),
-            SecurityError::ParachainNotRunning
+            SecurityError::ParachainShutdown
         );
         assert_noop!(
             Call::StakedRelayers(StakedRelayersCall::deregister_staked_relayer())
                 .dispatch(origin_of(account_of(ALICE))),
-            SecurityError::ParachainNotRunning
+            SecurityError::ParachainShutdown
         );
         assert_noop!(
             Call::StakedRelayers(StakedRelayersCall::store_block_header(Default::default()))
                 .dispatch(origin_of(account_of(ALICE))),
-            SecurityError::ParachainNotRunning
+            SecurityError::ParachainShutdown
         );
         assert_noop!(
             Call::StakedRelayers(StakedRelayersCall::report_vault_theft(
@@ -123,7 +123,7 @@ fn test_staked_relayer_parachain_status_check_fails() {
                 Default::default()
             ))
             .dispatch(origin_of(account_of(ALICE))),
-            SecurityError::ParachainNotRunning
+            SecurityError::ParachainShutdown
         );
     })
 }

--- a/parachain/runtime/tests/test_staked_relayers.rs
+++ b/parachain/runtime/tests/test_staked_relayers.rs
@@ -20,11 +20,11 @@ fn test_vault_theft(submit_by_relayer: bool) {
         ]));
         let other_btc_address = BtcAddress::P2SH(H160([1; 20]));
 
-        SecurityModule::set_active_block_number(1);
+        SecurityPallet::set_active_block_number(1);
 
-        assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
+        assert_ok!(ExchangeRateOraclePallet::_set_exchange_rate(FixedU128::one()));
         VaultRegistryPallet::insert_vault(&account_of(LIQUIDATION_VAULT), Vault::default());
-        // assert_ok!(CollateralModule::lock_collateral(&account_of(vault), collateral_vault));
+        // assert_ok!(CollateralPallet::lock_collateral(&account_of(vault), collateral_vault));
         assert_ok!(
             Call::VaultRegistry(VaultRegistryCall::register_vault(collateral_vault, dummy_public_key()))
                 .dispatch(origin_of(account_of(vault)))
@@ -38,7 +38,7 @@ fn test_vault_theft(submit_by_relayer: bool) {
         assert_ok!(Call::StakedRelayers(StakedRelayersCall::register_staked_relayer(100))
             .dispatch(origin_of(account_of(user))));
 
-        SecurityModule::set_active_block_number(StakedRelayersPallet::get_maturity_period() + 100);
+        SecurityPallet::set_active_block_number(StakedRelayersPallet::get_maturity_period() + 100);
 
         // manually activate
         assert_ok!(StakedRelayersPallet::activate_staked_relayer(&account_of(user)));
@@ -61,7 +61,7 @@ fn test_vault_theft(submit_by_relayer: bool) {
                 .unwrap();
         assert_eq!(SlaPallet::relayer_sla(account_of(ALICE)), expected_sla);
 
-        SecurityModule::set_active_block_number(1000);
+        SecurityPallet::set_active_block_number(1000);
 
         if submit_by_relayer {
             assert_ok!(
@@ -94,7 +94,7 @@ fn integration_test_report_vault_theft_by_non_relayer() {
 #[test]
 fn test_staked_relayer_parachain_status_check_fails() {
     ExtBuilder::build().execute_with(|| {
-        SecurityModule::set_status(StatusCode::Shutdown);
+        SecurityPallet::set_status(StatusCode::Shutdown);
 
         assert_noop!(
             Call::StakedRelayers(StakedRelayersCall::initialize(Default::default(), 0))
@@ -117,7 +117,6 @@ fn test_staked_relayer_parachain_status_check_fails() {
         );
         assert_noop!(
             Call::StakedRelayers(StakedRelayersCall::report_vault_theft(
-                Default::default(),
                 Default::default(),
                 Default::default(),
                 Default::default()

--- a/parachain/runtime/tests/test_vault_registry.rs
+++ b/parachain/runtime/tests/test_vault_registry.rs
@@ -125,3 +125,39 @@ mod withdraw_collateral_test {
         });
     }
 }
+
+#[test]
+fn integration_test_vault_registry_with_parachain_shutdown_fails() {
+    test_with(|| {
+        SecurityModule::set_status(StatusCode::Shutdown);
+
+        assert_noop!(
+            Call::VaultRegistry(VaultRegistryCall::register_vault(0, Default::default()))
+                .dispatch(origin_of(account_of(VAULT))),
+            SecurityError::ParachainNotRunning
+        );
+        assert_noop!(
+            Call::VaultRegistry(VaultRegistryCall::lock_additional_collateral(0))
+                .dispatch(origin_of(account_of(VAULT))),
+            SecurityError::ParachainNotRunning
+        );
+        assert_noop!(
+            Call::VaultRegistry(VaultRegistryCall::withdraw_collateral(0)).dispatch(origin_of(account_of(VAULT))),
+            SecurityError::ParachainNotRunning
+        );
+        assert_noop!(
+            Call::VaultRegistry(VaultRegistryCall::update_public_key(Default::default()))
+                .dispatch(origin_of(account_of(VAULT))),
+            SecurityError::ParachainNotRunning
+        );
+        assert_noop!(
+            Call::VaultRegistry(VaultRegistryCall::register_address(Default::default()))
+                .dispatch(origin_of(account_of(VAULT))),
+            SecurityError::ParachainNotRunning
+        );
+        assert_noop!(
+            Call::VaultRegistry(VaultRegistryCall::accept_new_issues(false)).dispatch(origin_of(account_of(VAULT))),
+            SecurityError::ParachainNotRunning
+        );
+    });
+}

--- a/parachain/runtime/tests/test_vault_registry.rs
+++ b/parachain/runtime/tests/test_vault_registry.rs
@@ -129,7 +129,7 @@ mod withdraw_collateral_test {
 #[test]
 fn integration_test_vault_registry_with_parachain_shutdown_fails() {
     test_with(|| {
-        SecurityModule::set_status(StatusCode::Shutdown);
+        SecurityPallet::set_status(StatusCode::Shutdown);
 
         assert_noop!(
             Call::VaultRegistry(VaultRegistryCall::register_vault(0, Default::default()))
@@ -159,6 +159,6 @@ fn integration_test_vault_registry_with_parachain_shutdown_fails() {
             Call::VaultRegistry(VaultRegistryCall::accept_new_issues(false)).dispatch(origin_of(account_of(VAULT))),
             SecurityError::ParachainShutdown
         );
-        assert_noop!(VaultRegistryModule::_on_initialize(), SecurityError::ParachainShutdown);
+        assert_noop!(VaultRegistryPallet::_on_initialize(), SecurityError::ParachainShutdown);
     });
 }

--- a/parachain/runtime/tests/test_vault_registry.rs
+++ b/parachain/runtime/tests/test_vault_registry.rs
@@ -134,30 +134,30 @@ fn integration_test_vault_registry_with_parachain_shutdown_fails() {
         assert_noop!(
             Call::VaultRegistry(VaultRegistryCall::register_vault(0, Default::default()))
                 .dispatch(origin_of(account_of(VAULT))),
-            SecurityError::ParachainNotRunning
+            SecurityError::ParachainShutdown
         );
         assert_noop!(
             Call::VaultRegistry(VaultRegistryCall::lock_additional_collateral(0))
                 .dispatch(origin_of(account_of(VAULT))),
-            SecurityError::ParachainNotRunning
+            SecurityError::ParachainShutdown
         );
         assert_noop!(
             Call::VaultRegistry(VaultRegistryCall::withdraw_collateral(0)).dispatch(origin_of(account_of(VAULT))),
-            SecurityError::ParachainNotRunning
+            SecurityError::ParachainShutdown
         );
         assert_noop!(
             Call::VaultRegistry(VaultRegistryCall::update_public_key(Default::default()))
                 .dispatch(origin_of(account_of(VAULT))),
-            SecurityError::ParachainNotRunning
+            SecurityError::ParachainShutdown
         );
         assert_noop!(
             Call::VaultRegistry(VaultRegistryCall::register_address(Default::default()))
                 .dispatch(origin_of(account_of(VAULT))),
-            SecurityError::ParachainNotRunning
+            SecurityError::ParachainShutdown
         );
         assert_noop!(
             Call::VaultRegistry(VaultRegistryCall::accept_new_issues(false)).dispatch(origin_of(account_of(VAULT))),
-            SecurityError::ParachainNotRunning
+            SecurityError::ParachainShutdown
         );
     });
 }

--- a/parachain/runtime/tests/test_vault_registry.rs
+++ b/parachain/runtime/tests/test_vault_registry.rs
@@ -159,5 +159,6 @@ fn integration_test_vault_registry_with_parachain_shutdown_fails() {
             Call::VaultRegistry(VaultRegistryCall::accept_new_issues(false)).dispatch(origin_of(account_of(VAULT))),
             SecurityError::ParachainShutdown
         );
+        assert_noop!(VaultRegistryModule::_on_initialize(), SecurityError::ParachainShutdown);
     });
 }

--- a/parachain/runtime/tests/test_vault_sla.rs
+++ b/parachain/runtime/tests/test_vault_sla.rs
@@ -16,8 +16,8 @@ fn initial_sla() -> FixedI128 {
 
 fn test_with<R>(execute: impl FnOnce() -> R) -> R {
     ExtBuilder::build().execute_with(|| {
-        SecurityModule::set_active_block_number(1);
-        assert_ok!(ExchangeRateOracleModule::_set_exchange_rate(FixedU128::one()));
+        SecurityPallet::set_active_block_number(1);
+        assert_ok!(ExchangeRateOraclePallet::_set_exchange_rate(FixedU128::one()));
         set_default_thresholds();
 
         SlaPallet::set_vault_sla(&account_of(VAULT), initial_sla());


### PR DESCRIPTION
- now we're checking `ensure_parachain_status_not_shutdown` at the beginning of every dispatchable function, except the ones that meant to be called with sudo. 
- vault_registry::on_initialize now checks parachain status
- internal (i.e. non-entry-point) vault registry functions are no longer checking parachain status
- oracle offline check is done in the oracle `btc_to_dot` and `dot_to_btc` functions. Every function that calls it will propagate the error
- fixed a bug where `active_block_count` was updated regardless of parachain status.