### PR TITLE
[BREAKING] Fix: tx_id validation

### DIFF
--- a/crates/issue/src/benchmarking.rs
+++ b/crates/issue/src/benchmarking.rs
@@ -118,7 +118,7 @@ benchmarks! {
         VaultRegistry::<T>::try_increase_to_be_issued_tokens(&vault_id, value.into()).unwrap();
         let secure_id = Security::<T>::get_secure_id(&vault_id);
         VaultRegistry::<T>::register_deposit_address(&vault_id, secure_id).unwrap();
-    }: _(RawOrigin::Signed(origin), issue_id, tx_id, proof, raw_tx)
+    }: _(RawOrigin::Signed(origin), issue_id, proof, raw_tx)
 
     cancel_issue {
         let origin: T::AccountId = account("Origin", 0, 0);

--- a/crates/issue/src/lib.rs
+++ b/crates/issue/src/lib.rs
@@ -30,7 +30,7 @@ pub mod types;
 pub use crate::types::{IssueRequest, IssueRequestStatus};
 
 use crate::types::{IssueRequestV2, PolkaBTC, Version, DOT};
-use bitcoin::{types::H256Le, utils::sha256d_le};
+use bitcoin::utils::sha256d_le;
 use btc_relay::{BtcAddress, BtcPublicKey};
 use frame_support::{
     decl_error, decl_event, decl_module, decl_storage,
@@ -176,17 +176,16 @@ decl_module! {
         ///
         /// * `origin` - sender of the transaction
         /// * `issue_id` - identifier of issue request as output from request_issue
-        /// * `tx_id` - transaction hash
         /// * `tx_block_height` - block number of backing chain
         /// * `merkle_proof` - raw bytes
         /// * `raw_tx` - raw bytes
         #[weight = <T as Config>::WeightInfo::execute_issue()]
         #[transactional]
-        fn execute_issue(origin, issue_id: H256, tx_id: H256Le, merkle_proof: Vec<u8>, raw_tx: Vec<u8>)
+        fn execute_issue(origin, issue_id: H256, merkle_proof: Vec<u8>, raw_tx: Vec<u8>)
             -> DispatchResult
         {
             let executor = ensure_signed(origin)?;
-            Self::_execute_issue(executor, issue_id, tx_id, merkle_proof, raw_tx)?;
+            Self::_execute_issue(executor, issue_id, merkle_proof, raw_tx)?;
             Ok(())
         }
 
@@ -300,7 +299,6 @@ impl<T: Config> Module<T> {
     fn _execute_issue(
         executor: T::AccountId,
         issue_id: H256,
-        _: H256Le,
         merkle_proof: Vec<u8>,
         raw_tx: Vec<u8>,
     ) -> Result<(), DispatchError> {

--- a/crates/issue/src/lib.rs
+++ b/crates/issue/src/lib.rs
@@ -30,7 +30,7 @@ pub mod types;
 pub use crate::types::{IssueRequest, IssueRequestStatus};
 
 use crate::types::{IssueRequestV2, PolkaBTC, Version, DOT};
-use bitcoin::types::H256Le;
+use bitcoin::{types::H256Le, utils::sha256d_le};
 use btc_relay::{BtcAddress, BtcPublicKey};
 use frame_support::{
     decl_error, decl_event, decl_module, decl_storage,
@@ -300,7 +300,7 @@ impl<T: Config> Module<T> {
     fn _execute_issue(
         executor: T::AccountId,
         issue_id: H256,
-        tx_id: H256Le,
+        _: H256Le,
         merkle_proof: Vec<u8>,
         raw_tx: Vec<u8>,
     ) -> Result<(), DispatchError> {
@@ -318,6 +318,7 @@ impl<T: Config> Module<T> {
             Error::<T>::CommitPeriodExpired
         );
 
+        let tx_id = sha256d_le(&raw_tx);
         ext::btc_relay::verify_transaction_inclusion::<T>(tx_id, merkle_proof)?;
         let (refund_address, amount_transferred) =
             ext::btc_relay::validate_transaction::<T>(raw_tx, None, issue.btc_address, None)?;

--- a/crates/issue/src/tests.rs
+++ b/crates/issue/src/tests.rs
@@ -1,5 +1,5 @@
 use crate::{ext, mock::*, Config, PolkaBTC, RawEvent, DOT};
-use bitcoin::types::H256Le;
+
 use btc_relay::{BtcAddress, BtcPublicKey};
 use frame_support::{assert_noop, assert_ok, dispatch::DispatchError};
 use mocktopus::mocking::*;
@@ -45,7 +45,7 @@ fn request_issue_ok(origin: AccountId, amount: Balance, vault: AccountId, collat
 fn execute_issue(origin: AccountId, issue_id: &H256) -> Result<(), DispatchError> {
     ext::security::ensure_parachain_status_running::<Test>.mock_safe(|| MockResult::Return(Ok(())));
 
-    Issue::_execute_issue(origin, *issue_id, H256Le::zero(), vec![0u8; 100], vec![0u8; 100])
+    Issue::_execute_issue(origin, *issue_id, vec![0u8; 100], vec![0u8; 100])
 }
 
 fn cancel_issue(origin: AccountId, issue_id: &H256) -> Result<(), DispatchError> {
@@ -327,7 +327,7 @@ fn test_execute_issue_parachain_not_running_fails() {
             .mock_safe(|| MockResult::Return(Err(SecurityError::ParachainNotRunning.into())));
 
         assert_noop!(
-            Issue::_execute_issue(origin, H256::zero(), H256Le::zero(), vec![0u8; 100], vec![0u8; 100],),
+            Issue::_execute_issue(origin, H256::zero(), vec![0u8; 100], vec![0u8; 100],),
             SecurityError::ParachainNotRunning
         );
     })

--- a/crates/redeem/src/benchmarking.rs
+++ b/crates/redeem/src/benchmarking.rs
@@ -118,7 +118,7 @@ benchmarks! {
         BtcRelay::<T>::store_block_header(&relayer_id, block_header).unwrap();
         Security::<T>::set_active_block_number(Security::<T>::active_block_number() + BtcRelay::<T>::parachain_confirmations() + 1u32.into());
 
-    }: _(RawOrigin::Signed(vault_id), redeem_id, tx_id, proof, raw_tx)
+    }: _(RawOrigin::Signed(vault_id), redeem_id, proof, raw_tx)
 
     cancel_redeem_reimburse {
         let origin: T::AccountId = account("Origin", 0, 0);

--- a/crates/redeem/src/lib.rs
+++ b/crates/redeem/src/lib.rs
@@ -30,7 +30,7 @@ pub mod types;
 pub use crate::types::{RedeemRequest, RedeemRequestStatus};
 
 use crate::types::{PolkaBTC, RedeemRequestV2, Version, DOT};
-use bitcoin::types::H256Le;
+use bitcoin::{types::H256Le, utils::sha256d_le};
 use btc_relay::BtcAddress;
 use frame_support::{
     decl_error, decl_event, decl_module, decl_storage,
@@ -375,7 +375,7 @@ impl<T: Config> Module<T> {
 
     fn _execute_redeem(
         redeem_id: H256,
-        tx_id: H256Le,
+        _: H256Le,
         merkle_proof: Vec<u8>,
         raw_tx: Vec<u8>,
     ) -> Result<(), DispatchError> {
@@ -390,6 +390,7 @@ impl<T: Config> Module<T> {
         );
 
         let amount: usize = redeem.amount_btc.try_into().map_err(|_e| Error::<T>::TryIntoIntError)?;
+        let tx_id = sha256d_le(&raw_tx);
         ext::btc_relay::verify_transaction_inclusion::<T>(tx_id, merkle_proof)?;
         // NOTE: vault client must register change addresses before
         // sending the bitcoin transaction

--- a/crates/redeem/src/lib.rs
+++ b/crates/redeem/src/lib.rs
@@ -30,7 +30,7 @@ pub mod types;
 pub use crate::types::{RedeemRequest, RedeemRequestStatus};
 
 use crate::types::{PolkaBTC, RedeemRequestV2, Version, DOT};
-use bitcoin::{types::H256Le, utils::sha256d_le};
+use bitcoin::utils::sha256d_le;
 use btc_relay::BtcAddress;
 use frame_support::{
     decl_error, decl_event, decl_module, decl_storage,
@@ -199,11 +199,11 @@ decl_module! {
         /// * `raw_tx` - raw bytes
         #[weight = <T as Config>::WeightInfo::execute_redeem()]
         #[transactional]
-        fn execute_redeem(origin, redeem_id: H256, tx_id: H256Le, merkle_proof: Vec<u8>, raw_tx: Vec<u8>)
+        fn execute_redeem(origin, redeem_id: H256, merkle_proof: Vec<u8>, raw_tx: Vec<u8>)
             -> DispatchResult
         {
             let _ = ensure_signed(origin)?;
-            Self::_execute_redeem(redeem_id, tx_id, merkle_proof, raw_tx)?;
+            Self::_execute_redeem(redeem_id, merkle_proof, raw_tx)?;
             Ok(())
         }
 
@@ -373,12 +373,7 @@ impl<T: Config> Module<T> {
         Ok(())
     }
 
-    fn _execute_redeem(
-        redeem_id: H256,
-        _: H256Le,
-        merkle_proof: Vec<u8>,
-        raw_tx: Vec<u8>,
-    ) -> Result<(), DispatchError> {
+    fn _execute_redeem(redeem_id: H256, merkle_proof: Vec<u8>, raw_tx: Vec<u8>) -> Result<(), DispatchError> {
         ext::security::ensure_parachain_status_running::<T>()?;
 
         let redeem = Self::get_open_redeem_request_from_id(&redeem_id)?;

--- a/crates/redeem/src/tests.rs
+++ b/crates/redeem/src/tests.rs
@@ -1,7 +1,6 @@
 use crate::{ext, mock::*};
 
 use crate::types::{PolkaBTC, RedeemRequest, RedeemRequestStatus, DOT};
-use bitcoin::types::H256Le;
 use btc_relay::{BtcAddress, BtcPublicKey};
 use frame_support::{assert_err, assert_noop, assert_ok, dispatch::DispatchError};
 use mocktopus::mocking::*;
@@ -241,13 +240,7 @@ fn test_execute_redeem_fails_with_redeem_id_not_found() {
     run_test(|| {
         ext::oracle::btc_to_dots::<Test>.mock_safe(|x| MockResult::Return(btcdot_parity(x)));
         assert_err!(
-            Redeem::execute_redeem(
-                Origin::signed(BOB),
-                H256([0u8; 32]),
-                H256Le::zero(),
-                Vec::default(),
-                Vec::default()
-            ),
+            Redeem::execute_redeem(Origin::signed(BOB), H256([0u8; 32]), Vec::default(), Vec::default()),
             TestError::RedeemIdNotFound
         );
     })
@@ -311,7 +304,6 @@ fn test_execute_redeem_succeeds_with_another_account() {
         assert_ok!(Redeem::execute_redeem(
             Origin::signed(ALICE),
             H256([0u8; 32]),
-            H256Le::zero(),
             Vec::default(),
             Vec::default()
         ));
@@ -344,13 +336,7 @@ fn test_execute_redeem_fails_with_commit_period_expired() {
         });
 
         assert_err!(
-            Redeem::execute_redeem(
-                Origin::signed(BOB),
-                H256([0u8; 32]),
-                H256Le::zero(),
-                Vec::default(),
-                Vec::default()
-            ),
+            Redeem::execute_redeem(Origin::signed(BOB), H256([0u8; 32]), Vec::default(), Vec::default()),
             TestError::CommitPeriodExpired
         );
     })
@@ -414,7 +400,6 @@ fn test_execute_redeem_succeeds() {
         assert_ok!(Redeem::execute_redeem(
             Origin::signed(BOB),
             H256([0u8; 32]),
-            H256Le::zero(),
             Vec::default(),
             Vec::default()
         ));

--- a/crates/refund/src/lib.rs
+++ b/crates/refund/src/lib.rs
@@ -22,7 +22,7 @@ pub use default_weights::WeightInfo;
 mod ext;
 pub mod types;
 
-use bitcoin::{types::H256Le, utils::sha256d_le};
+use bitcoin::utils::sha256d_le;
 use btc_relay::BtcAddress;
 use frame_support::{
     decl_error, decl_event, decl_module, decl_storage, dispatch::DispatchError, ensure, transactional,
@@ -92,12 +92,11 @@ decl_module! {
         fn execute_refund(
             origin,
             refund_id: H256,
-            tx_id: H256Le,
             merkle_proof: Vec<u8>,
             raw_tx: Vec<u8>,
         ) -> Result<(), DispatchError> {
             ensure_signed(origin)?;
-            Self::_execute_refund(refund_id, tx_id, merkle_proof, raw_tx)
+            Self::_execute_refund(refund_id, merkle_proof, raw_tx)
         }
     }
 }
@@ -167,15 +166,9 @@ impl<T: Config> Module<T> {
     ///
     /// * `refund_id` - identifier of a refund request. This ID can be obtained by listening to the RequestRefund event,
     ///   or by querying the open refunds.
-    /// * `tx_id` - transaction hash
     /// * `merkle_proof` - raw bytes of the proof
     /// * `raw_tx` - raw bytes of the transaction
-    fn _execute_refund(
-        refund_id: H256,
-        _: H256Le,
-        merkle_proof: Vec<u8>,
-        raw_tx: Vec<u8>,
-    ) -> Result<(), DispatchError> {
+    fn _execute_refund(refund_id: H256, merkle_proof: Vec<u8>, raw_tx: Vec<u8>) -> Result<(), DispatchError> {
         let request = Self::get_open_refund_request_from_id(&refund_id)?;
 
         // verify the payment

--- a/crates/refund/src/lib.rs
+++ b/crates/refund/src/lib.rs
@@ -22,7 +22,7 @@ pub use default_weights::WeightInfo;
 mod ext;
 pub mod types;
 
-use bitcoin::types::H256Le;
+use bitcoin::{types::H256Le, utils::sha256d_le};
 use btc_relay::BtcAddress;
 use frame_support::{
     decl_error, decl_event, decl_module, decl_storage, dispatch::DispatchError, ensure, transactional,
@@ -172,7 +172,7 @@ impl<T: Config> Module<T> {
     /// * `raw_tx` - raw bytes of the transaction
     fn _execute_refund(
         refund_id: H256,
-        tx_id: H256Le,
+        _: H256Le,
         merkle_proof: Vec<u8>,
         raw_tx: Vec<u8>,
     ) -> Result<(), DispatchError> {
@@ -183,6 +183,7 @@ impl<T: Config> Module<T> {
             .amount_polka_btc
             .try_into()
             .map_err(|_e| Error::<T>::TryIntoIntError)?;
+        let tx_id = sha256d_le(&raw_tx);
         ext::btc_relay::verify_transaction_inclusion::<T>(tx_id, merkle_proof)?;
         ext::btc_relay::validate_transaction::<T>(
             raw_tx,

--- a/crates/refund/src/tests.rs
+++ b/crates/refund/src/tests.rs
@@ -1,5 +1,4 @@
 use crate::{ext, mock::*, RawEvent};
-use bitcoin::types::H256Le;
 use btc_relay::BtcAddress;
 use frame_support::assert_ok;
 use mocktopus::mocking::*;
@@ -43,11 +42,6 @@ fn test_refund_succeeds() {
         }
         .unwrap();
 
-        assert_ok!(Refund::_execute_refund(
-            refund_id,
-            H256Le::zero(),
-            vec![0u8; 100],
-            vec![0u8; 100],
-        ));
+        assert_ok!(Refund::_execute_refund(refund_id, vec![0u8; 100], vec![0u8; 100],));
     })
 }

--- a/crates/replace/src/benchmarking.rs
+++ b/crates/replace/src/benchmarking.rs
@@ -199,7 +199,7 @@ benchmarks! {
         BtcRelay::<T>::store_block_header(&relayer_id, block_header).unwrap();
         Security::<T>::set_active_block_number(Security::<T>::active_block_number() + BtcRelay::<T>::parachain_confirmations() + 1u32.into());
 
-    }: _(RawOrigin::Signed(old_vault_id), replace_id, tx_id, proof, raw_tx)
+    }: _(RawOrigin::Signed(old_vault_id), replace_id, proof, raw_tx)
 
     cancel_replace {
         let new_vault_id: T::AccountId = account("Origin", 0, 0);

--- a/crates/replace/src/lib.rs
+++ b/crates/replace/src/lib.rs
@@ -27,7 +27,7 @@ use primitive_types::H256;
 use sp_runtime::{traits::Zero, ModuleId};
 use sp_std::{convert::TryInto, vec::Vec};
 
-use bitcoin::types::H256Le;
+use bitcoin::{types::H256Le, utils::sha256d_le};
 use btc_relay::BtcAddress;
 
 #[doc(inline)]
@@ -439,7 +439,7 @@ impl<T: Config> Module<T> {
 
     fn _execute_replace(
         replace_id: H256,
-        tx_id: H256Le,
+        _: H256Le,
         merkle_proof: Vec<u8>,
         raw_tx: Vec<u8>,
     ) -> Result<(), DispatchError> {
@@ -461,6 +461,7 @@ impl<T: Config> Module<T> {
 
         // Call verifyTransactionInclusion in BTC-Relay, providing txid, txBlockHeight, txIndex, and merkleProof as
         // parameters
+        let tx_id = sha256d_le(&raw_tx);
         ext::btc_relay::verify_transaction_inclusion::<T>(tx_id, merkle_proof)?;
 
         // Call validateTransaction in BTC-Relay

--- a/crates/replace/src/lib.rs
+++ b/crates/replace/src/lib.rs
@@ -27,7 +27,7 @@ use primitive_types::H256;
 use sp_runtime::{traits::Zero, ModuleId};
 use sp_std::{convert::TryInto, vec::Vec};
 
-use bitcoin::{types::H256Le, utils::sha256d_le};
+use bitcoin::utils::sha256d_le;
 use btc_relay::BtcAddress;
 
 #[doc(inline)]
@@ -243,15 +243,14 @@ decl_module! {
         ///
         /// * `origin` - sender of the transaction: the new vault
         /// * `replace_id` - the ID of the replacement request
-        /// * `tx_id` - the backing chain transaction id
         /// * `tx_block_height` - the blocked height of the backing transaction
         /// * 'merkle_proof' - the merkle root of the block
         /// * `raw_tx` - the transaction id in bytes
         #[weight = <T as Config>::WeightInfo::execute_replace()]
         #[transactional]
-        fn execute_replace(origin, replace_id: H256, tx_id: H256Le, merkle_proof: Vec<u8>, raw_tx: Vec<u8>) -> DispatchResult {
+        fn execute_replace(origin, replace_id: H256, merkle_proof: Vec<u8>, raw_tx: Vec<u8>) -> DispatchResult {
             let _ = ensure_signed(origin)?;
-            Self::_execute_replace(replace_id, tx_id, merkle_proof, raw_tx)?;
+            Self::_execute_replace(replace_id, merkle_proof, raw_tx)?;
             Ok(())
         }
 
@@ -437,12 +436,7 @@ impl<T: Config> Module<T> {
         Ok(())
     }
 
-    fn _execute_replace(
-        replace_id: H256,
-        _: H256Le,
-        merkle_proof: Vec<u8>,
-        raw_tx: Vec<u8>,
-    ) -> Result<(), DispatchError> {
+    fn _execute_replace(replace_id: H256, merkle_proof: Vec<u8>, raw_tx: Vec<u8>) -> Result<(), DispatchError> {
         // Check that Parachain status is RUNNING
         ext::security::ensure_parachain_status_running::<T>()?;
 

--- a/crates/replace/src/tests.rs
+++ b/crates/replace/src/tests.rs
@@ -1,5 +1,5 @@
 use crate::{ext, mock::*, ReplaceRequest, ReplaceRequestStatus};
-use bitcoin::types::H256Le;
+
 use btc_relay::BtcAddress;
 use frame_support::{assert_err, assert_ok};
 use mocktopus::mocking::*;
@@ -275,12 +275,7 @@ mod execute_replace_test {
     fn test_execute_replace_succeeds() {
         run_test(|| {
             setup_mocks();
-            assert_ok!(Replace::_execute_replace(
-                H256::zero(),
-                H256Le::zero(),
-                Vec::new(),
-                Vec::new()
-            ));
+            assert_ok!(Replace::_execute_replace(H256::zero(), Vec::new(), Vec::new()));
             assert_event_matches!(Event::ExecuteReplace(_, OLD_VAULT, NEW_VAULT));
         })
     }
@@ -292,7 +287,7 @@ mod execute_replace_test {
             ext::security::has_expired::<Test>.mock_safe(|_, _| MockResult::Return(Ok(true)));
 
             assert_err!(
-                Replace::_execute_replace(H256::zero(), H256Le::zero(), Vec::new(), Vec::new()),
+                Replace::_execute_replace(H256::zero(), Vec::new(), Vec::new()),
                 TestError::ReplacePeriodExpired
             );
         })

--- a/crates/staked-relayers/src/benchmarking.rs
+++ b/crates/staked-relayers/src/benchmarking.rs
@@ -177,7 +177,7 @@ benchmarks! {
         BtcRelay::<T>::store_block_header(&relayer_id, block_header).unwrap();
         Security::<T>::set_active_block_number(Security::<T>::active_block_number() + BtcRelay::<T>::parachain_confirmations() + 1u32.into());
 
-    }: _(RawOrigin::Signed(origin), vault_id, tx_id, proof, raw_tx)
+    }: _(RawOrigin::Signed(origin), vault_id, proof, raw_tx)
 }
 
 impl_benchmark_test_suite!(

--- a/crates/staked-relayers/src/lib.rs
+++ b/crates/staked-relayers/src/lib.rs
@@ -29,7 +29,8 @@ use mocktopus::macros::mockable;
 pub use security;
 
 use crate::types::{PolkaBTC, ProposalStatus, StakedRelayer, StatusUpdate, StatusUpdateId, Tally, Votes, DOT};
-use bitcoin::{parser::parse_transaction, types::*};
+use bitcoin::{parser::parse_transaction, types::*, utils::sha256d_le};
+
 use btc_relay::{BtcAddress, Error as BtcRelayError};
 use frame_support::{
     decl_error, decl_event, decl_module, decl_storage,
@@ -464,8 +465,10 @@ decl_module! {
         /// * `raw_tx`: The raw Bitcoin transaction.
         #[weight = <T as Config>::WeightInfo::report_vault_theft()]
         #[transactional]
-        fn report_vault_theft(origin, vault_id: T::AccountId, tx_id: H256Le, merkle_proof: Vec<u8>, raw_tx: Vec<u8>) -> DispatchResult {
+        fn report_vault_theft(origin, vault_id: T::AccountId, _tx_id: H256Le, merkle_proof: Vec<u8>, raw_tx: Vec<u8>) -> DispatchResult {
             let signer = ensure_signed(origin)?;
+
+            let tx_id = sha256d_le(&raw_tx);
 
             // liquidated vaults are removed, so no need for check here
 

--- a/crates/staked-relayers/src/lib.rs
+++ b/crates/staked-relayers/src/lib.rs
@@ -465,7 +465,7 @@ decl_module! {
         /// * `raw_tx`: The raw Bitcoin transaction.
         #[weight = <T as Config>::WeightInfo::report_vault_theft()]
         #[transactional]
-        fn report_vault_theft(origin, vault_id: T::AccountId, _tx_id: H256Le, merkle_proof: Vec<u8>, raw_tx: Vec<u8>) -> DispatchResult {
+        fn report_vault_theft(origin, vault_id: T::AccountId, merkle_proof: Vec<u8>, raw_tx: Vec<u8>) -> DispatchResult {
             let signer = ensure_signed(origin)?;
 
             let tx_id = sha256d_le(&raw_tx);

--- a/crates/staked-relayers/src/tests.rs
+++ b/crates/staked-relayers/src/tests.rs
@@ -785,7 +785,6 @@ fn test_report_vault_passes_with_vault_transaction() {
         assert_ok!(StakedRelayers::report_vault_theft(
             Origin::signed(ALICE),
             CAROL,
-            H256Le::zero(),
             vec![0u8; 32],
             hex::decode(&raw_tx).unwrap()
         ),);
@@ -813,7 +812,6 @@ fn test_report_vault_fails_with_non_vault_transaction() {
             StakedRelayers::report_vault_theft(
                 Origin::signed(ALICE),
                 CAROL,
-                H256Le::zero(),
                 vec![0u8; 32],
                 hex::decode(&raw_tx).unwrap()
             ),
@@ -842,7 +840,6 @@ fn test_report_vault_succeeds_with_segwit_transaction() {
         assert_ok!(StakedRelayers::report_vault_theft(
             Origin::signed(ALICE),
             CAROL,
-            H256Le::zero(),
             vec![0u8; 32],
             hex::decode(&raw_tx).unwrap()
         ));
@@ -863,11 +860,13 @@ fn test_report_vault_theft_succeeds() {
         assert_ok!(StakedRelayers::report_vault_theft(
             relayer,
             BOB,
-            H256Le::zero(),
             vec![0u8; 32],
             vec![0u8; 32],
         ));
-        assert_emitted!(Event::VaultTheft(BOB, H256Le::zero()));
+        // check that the event has been emitted
+        assert!(System::events()
+            .iter()
+            .any(|a| matches!(a.event, TestEvent::staked_relayers(Event::VaultTheft(id, _)) if id == BOB)));
     })
 }
 

--- a/parachain/runtime/tests/mock/issue_testing_utils.rs
+++ b/parachain/runtime/tests/mock/issue_testing_utils.rs
@@ -95,7 +95,7 @@ impl ExecuteIssueBuilder {
     #[transactional]
     pub fn execute(&self) -> DispatchResultWithPostInfo {
         // send the btc from the user to the vault
-        let (tx_id, _height, proof, raw_tx) = TransactionGenerator::new()
+        let (tx_id, _height, proof, raw_tx, _) = TransactionGenerator::new()
             .with_address(self.issue.btc_address)
             .with_amount(self.amount)
             .with_op_return(None)

--- a/parachain/runtime/tests/mock/mod.rs
+++ b/parachain/runtime/tests/mock/mod.rs
@@ -575,7 +575,7 @@ impl TransactionGenerator {
         self.relayer = relayer;
         self
     }
-    pub fn mine(&self) -> (H256Le, u32, Vec<u8>, Vec<u8>) {
+    pub fn mine(&self) -> (H256Le, u32, Vec<u8>, Vec<u8>, Transaction) {
         let mut height = 1;
         let extra_confirmations = self.confirmations - 1;
 
@@ -662,7 +662,7 @@ impl TransactionGenerator {
             prev_block_hash = conf_block.header.hash().unwrap();
         }
 
-        (tx_id, tx_block_height, bytes_proof, raw_tx)
+        (tx_id, tx_block_height, bytes_proof, raw_tx, transaction)
     }
 
     fn relay(&self, height: u32, block: &Block, raw_block_header: RawBlockHeader) {
@@ -689,11 +689,12 @@ pub fn generate_transaction_and_mine(
     amount: u128,
     return_data: Option<H256>,
 ) -> (H256Le, u32, Vec<u8>, Vec<u8>) {
-    TransactionGenerator::new()
+    let (tx_id, height, proof, raw_tx, _) = TransactionGenerator::new()
         .with_address(address)
         .with_amount(amount)
         .with_op_return(return_data)
-        .mine()
+        .mine();
+    (tx_id, height, proof, raw_tx)
 }
 
 #[allow(dead_code)]

--- a/parachain/runtime/tests/mock/redeem_testing_utils.rs
+++ b/parachain/runtime/tests/mock/redeem_testing_utils.rs
@@ -36,7 +36,7 @@ impl ExecuteRedeemBuilder {
     #[transactional]
     pub fn execute(&self) -> DispatchResultWithPostInfo {
         // send the btc from the user to the vault
-        let (tx_id, _height, proof, raw_tx, _) = TransactionGenerator::new()
+        let (_tx_id, _height, proof, raw_tx, _) = TransactionGenerator::new()
             .with_address(self.redeem.btc_address)
             .with_amount(self.amount)
             .with_op_return(Some(self.redeem_id))
@@ -45,7 +45,7 @@ impl ExecuteRedeemBuilder {
         SecurityModule::set_active_block_number(SecurityModule::active_block_number() + CONFIRMATIONS);
 
         // alice executes the redeemrequest by confirming the btc transaction
-        Call::Redeem(RedeemCall::execute_redeem(self.redeem_id, tx_id, proof, raw_tx))
+        Call::Redeem(RedeemCall::execute_redeem(self.redeem_id, proof, raw_tx))
             .dispatch(origin_of(self.submitter.clone()))
     }
 
@@ -62,13 +62,7 @@ pub fn setup_cancelable_redeem(user: [u8; 32], vault: [u8; 32], collateral: u128
 
     // bob cannot execute past expiry
     assert_noop!(
-        Call::Redeem(RedeemCall::execute_redeem(
-            redeem_id,
-            H256Le::from_bytes_le(&[0; 32]),
-            vec![],
-            vec![],
-        ))
-        .dispatch(origin_of(account_of(vault))),
+        Call::Redeem(RedeemCall::execute_redeem(redeem_id, vec![], vec![],)).dispatch(origin_of(account_of(vault))),
         RedeemError::CommitPeriodExpired,
     );
 

--- a/parachain/runtime/tests/mock/redeem_testing_utils.rs
+++ b/parachain/runtime/tests/mock/redeem_testing_utils.rs
@@ -36,7 +36,7 @@ impl ExecuteRedeemBuilder {
     #[transactional]
     pub fn execute(&self) -> DispatchResultWithPostInfo {
         // send the btc from the user to the vault
-        let (tx_id, _height, proof, raw_tx) = TransactionGenerator::new()
+        let (tx_id, _height, proof, raw_tx, _) = TransactionGenerator::new()
             .with_address(self.redeem.btc_address)
             .with_amount(self.amount)
             .with_op_return(Some(self.redeem_id))

--- a/parachain/runtime/tests/test_issue.rs
+++ b/parachain/runtime/tests/test_issue.rs
@@ -98,13 +98,8 @@ fn integration_test_issue_should_fail_if_not_running() {
         );
 
         assert_noop!(
-            Call::Issue(IssueCall::execute_issue(
-                H256([0; 32]),
-                H256Le::zero(),
-                vec![0u8; 32],
-                vec![0u8; 32]
-            ))
-            .dispatch(origin_of(account_of(ALICE))),
+            Call::Issue(IssueCall::execute_issue(H256([0; 32]), vec![0u8; 32], vec![0u8; 32]))
+                .dispatch(origin_of(account_of(ALICE))),
             SecurityError::ParachainNotRunning,
         );
     });
@@ -217,12 +212,12 @@ fn integration_test_issue_polka_btc_execute_succeeds() {
         let total_amount_btc = amount_btc + fee_amount_btc;
 
         // send the btc from the user to the vault
-        let (tx_id, _height, proof, raw_tx) = generate_transaction_and_mine(vault_btc_address, total_amount_btc, None);
+        let (_tx_id, _height, proof, raw_tx) = generate_transaction_and_mine(vault_btc_address, total_amount_btc, None);
 
         SecurityModule::set_active_block_number(1 + CONFIRMATIONS);
 
         // alice executes the issue by confirming the btc transaction
-        assert_ok!(Call::Issue(IssueCall::execute_issue(issue_id, tx_id, proof, raw_tx))
+        assert_ok!(Call::Issue(IssueCall::execute_issue(issue_id, proof, raw_tx))
             .dispatch(origin_of(account_of(vault_proof_submitter))));
     });
 }
@@ -424,13 +419,7 @@ fn integration_test_issue_polka_btc_cancel() {
 
         // alice cannot execute past expiry
         assert_noop!(
-            Call::Issue(IssueCall::execute_issue(
-                issue_id,
-                H256Le::from_bytes_le(&[0; 32]),
-                vec![],
-                vec![]
-            ))
-            .dispatch(origin_of(account_of(VAULT))),
+            Call::Issue(IssueCall::execute_issue(issue_id, vec![], vec![])).dispatch(origin_of(account_of(VAULT))),
             IssueError::CommitPeriodExpired
         );
 
@@ -456,13 +445,7 @@ fn integration_test_issue_polka_btc_cancel_liquidated() {
 
         // alice cannot execute past expiry
         assert_noop!(
-            Call::Issue(IssueCall::execute_issue(
-                issue_id,
-                H256Le::from_bytes_le(&[0; 32]),
-                vec![],
-                vec![]
-            ))
-            .dispatch(origin_of(account_of(VAULT))),
+            Call::Issue(IssueCall::execute_issue(issue_id, vec![], vec![])).dispatch(origin_of(account_of(VAULT))),
             IssueError::CommitPeriodExpired
         );
 
@@ -515,7 +498,7 @@ fn integration_test_issue_polka_btc_execute_liquidated() {
 fn integration_test_issue_with_unrelated_rawtx_and_txid_fails() {
     test_with_initialized_vault(|| {
         let (issue_id, issue) = request_issue(1000);
-        let (tx_id, _height, proof, raw_tx, mut transaction) = TransactionGenerator::new()
+        let (_tx_id, _height, proof, raw_tx, mut transaction) = TransactionGenerator::new()
             .with_address(issue.btc_address)
             .with_amount(1)
             .with_op_return(None)
@@ -525,7 +508,7 @@ fn integration_test_issue_with_unrelated_rawtx_and_txid_fails() {
 
         // fail due to insufficient amount
         assert_noop!(
-            Call::Issue(IssueCall::execute_issue(issue_id, tx_id, proof.clone(), raw_tx))
+            Call::Issue(IssueCall::execute_issue(issue_id, proof.clone(), raw_tx))
                 .dispatch(origin_of(account_of(CAROL))),
             IssueError::InvalidExecutor
         );
@@ -533,13 +516,8 @@ fn integration_test_issue_with_unrelated_rawtx_and_txid_fails() {
         // increase the amount in the raw_tx, but not in the blockchain. This should definitely fail
         transaction.outputs[0].value = 1000;
         assert_noop!(
-            Call::Issue(IssueCall::execute_issue(
-                issue_id,
-                tx_id,
-                proof,
-                transaction.format_with(true)
-            ))
-            .dispatch(origin_of(account_of(CAROL))),
+            Call::Issue(IssueCall::execute_issue(issue_id, proof, transaction.format_with(true)))
+                .dispatch(origin_of(account_of(CAROL))),
             BTCRelayError::InvalidTxid
         );
     })

--- a/parachain/runtime/tests/test_issue.rs
+++ b/parachain/runtime/tests/test_issue.rs
@@ -532,13 +532,15 @@ fn integration_test_issue_with_unrelated_rawtx_and_txid_fails() {
 
         // increase the amount in the raw_tx, but not in the blockchain. This should definitely fail
         transaction.outputs[0].value = 1000;
-        assert!(Call::Issue(IssueCall::execute_issue(
-            issue_id,
-            tx_id,
-            proof,
-            transaction.format_with(true)
-        ))
-        .dispatch(origin_of(account_of(CAROL)))
-        .is_err());
+        assert_noop!(
+            Call::Issue(IssueCall::execute_issue(
+                issue_id,
+                tx_id,
+                proof,
+                transaction.format_with(true)
+            ))
+            .dispatch(origin_of(account_of(CAROL))),
+            BTCRelayError::InvalidTxid
+        );
     })
 }

--- a/parachain/runtime/tests/test_redeem.rs
+++ b/parachain/runtime/tests/test_redeem.rs
@@ -235,13 +235,13 @@ fn integration_test_premium_redeem_polka_btc_execute() {
         let redeem = RedeemModule::get_open_redeem_request_from_id(&redeem_id).unwrap();
 
         // send the btc from the vault to the user
-        let (tx_id, _tx_block_height, merkle_proof, raw_tx) =
+        let (_tx_id, _tx_block_height, merkle_proof, raw_tx) =
             generate_transaction_and_mine(user_btc_address, polka_btc, Some(redeem_id));
 
         SecurityModule::set_active_block_number(1 + CONFIRMATIONS);
 
         assert_ok!(
-            Call::Redeem(RedeemCall::execute_redeem(redeem_id, tx_id, merkle_proof, raw_tx))
+            Call::Redeem(RedeemCall::execute_redeem(redeem_id, merkle_proof, raw_tx))
                 .dispatch(origin_of(account_of(VAULT)))
         );
 

--- a/parachain/runtime/tests/test_replace.rs
+++ b/parachain/runtime/tests/test_replace.rs
@@ -842,11 +842,11 @@ fn integration_test_replace_execute_replace() {
         let replace_id = assert_accept_event();
 
         // send the btc from the old_vault to the new_vault
-        let (tx_id, _tx_block_height, merkle_proof, raw_tx) =
+        let (_tx_id, _tx_block_height, merkle_proof, raw_tx) =
             generate_transaction_and_mine(new_vault_btc_address, polkabtc, Some(replace_id));
 
         SecurityModule::set_active_block_number(1 + CONFIRMATIONS);
-        let r = Call::Replace(ReplaceCall::execute_replace(replace_id, tx_id, merkle_proof, raw_tx))
+        let r = Call::Replace(ReplaceCall::execute_replace(replace_id, merkle_proof, raw_tx))
             .dispatch(origin_of(account_of(old_vault)));
         assert_ok!(r);
     });
@@ -1111,12 +1111,12 @@ fn execute_replace(replace_id: H256) -> DispatchResultWithPostInfo {
     let replace = ReplaceModule::get_open_replace_request(&replace_id).unwrap();
 
     // send the btc from the old_vault to the new_vault
-    let (tx_id, _tx_block_height, merkle_proof, raw_tx) =
+    let (_tx_id, _tx_block_height, merkle_proof, raw_tx) =
         generate_transaction_and_mine(replace.btc_address, replace.amount, Some(replace_id));
 
     SecurityModule::set_active_block_number(SecurityModule::active_block_number() + CONFIRMATIONS);
 
-    Call::Replace(ReplaceCall::execute_replace(replace_id, tx_id, merkle_proof, raw_tx))
+    Call::Replace(ReplaceCall::execute_replace(replace_id, merkle_proof, raw_tx))
         .dispatch(origin_of(account_of(OLD_VAULT)))
 }
 

--- a/parachain/runtime/tests/test_staked_relayers.rs
+++ b/parachain/runtime/tests/test_staked_relayers.rs
@@ -45,7 +45,7 @@ fn test_vault_theft(submit_by_relayer: bool) {
 
         let initial_sla = SlaModule::relayer_sla(account_of(ALICE));
 
-        let (tx_id, _height, proof, raw_tx, _) = TransactionGenerator::new()
+        let (_tx_id, _height, proof, raw_tx, _) = TransactionGenerator::new()
             .with_address(other_btc_address)
             .with_amount(amount)
             .with_confirmations(7)
@@ -64,25 +64,19 @@ fn test_vault_theft(submit_by_relayer: bool) {
         SecurityModule::set_active_block_number(1000);
 
         if submit_by_relayer {
-            assert_ok!(Call::StakedRelayers(StakedRelayersCall::report_vault_theft(
-                account_of(vault),
-                tx_id,
-                proof,
-                raw_tx
-            ))
-            .dispatch(origin_of(account_of(user))));
+            assert_ok!(
+                Call::StakedRelayers(StakedRelayersCall::report_vault_theft(account_of(vault), proof, raw_tx))
+                    .dispatch(origin_of(account_of(user)))
+            );
 
             // check sla increase for the theft report
             expected_sla = expected_sla + SlaModule::relayer_correct_theft_report();
             assert_eq!(SlaModule::relayer_sla(account_of(ALICE)), expected_sla);
         } else {
-            assert_ok!(Call::StakedRelayers(StakedRelayersCall::report_vault_theft(
-                account_of(vault),
-                tx_id,
-                proof,
-                raw_tx
-            ))
-            .dispatch(origin_of(account_of(CAROL))));
+            assert_ok!(
+                Call::StakedRelayers(StakedRelayersCall::report_vault_theft(account_of(vault), proof, raw_tx))
+                    .dispatch(origin_of(account_of(CAROL)))
+            );
         }
     });
 }

--- a/parachain/runtime/tests/test_staked_relayers.rs
+++ b/parachain/runtime/tests/test_staked_relayers.rs
@@ -45,7 +45,7 @@ fn test_vault_theft(submit_by_relayer: bool) {
 
         let initial_sla = SlaModule::relayer_sla(account_of(ALICE));
 
-        let (tx_id, _height, proof, raw_tx) = TransactionGenerator::new()
+        let (tx_id, _height, proof, raw_tx, _) = TransactionGenerator::new()
             .with_address(other_btc_address)
             .with_amount(amount)
             .with_confirmations(7)


### PR DESCRIPTION
~~This fixes the issue, but I want to remove the tx_id argument altogether~~

Breaking changes:
- removed `tx_id` argument from execute issue/redeem/replace/refund & report_vault_theft