### PR TITLE
[BREAKING] Refactor: remove voting

### DIFF
--- a/crates/redeem/src/mock.rs
+++ b/crates/redeem/src/mock.rs
@@ -248,12 +248,7 @@ impl ExtBuilder {
             relayer_target_sla: FixedI128::from(100),
             relayer_block_submission: FixedI128::from(1),
             relayer_duplicate_block_submission: FixedI128::from(1),
-            relayer_correct_no_data_vote_or_report: FixedI128::from(1),
-            relayer_correct_invalid_vote_or_report: FixedI128::from(10),
             relayer_correct_theft_report: FixedI128::from(1),
-            relayer_false_no_data_vote_or_report: FixedI128::from(-10),
-            relayer_false_invalid_vote_or_report: FixedI128::from(-100),
-            relayer_ignored_vote: FixedI128::from(-10),
         }
         .assimilate_storage(&mut storage)
         .unwrap();

--- a/crates/sla/src/lib.rs
+++ b/crates/sla/src/lib.rs
@@ -76,12 +76,7 @@ decl_storage! {
         VaultRefunded get(fn vault_refunded) config(): T::SignedFixedPoint;
         RelayerBlockSubmission get(fn relayer_block_submission) config(): T::SignedFixedPoint;
         RelayerDuplicateBlockSubmission get(fn relayer_duplicate_block_submission) config(): T::SignedFixedPoint;
-        RelayerCorrectNoDataVoteOrReport get(fn relayer_correct_no_data_vote_or_report) config(): T::SignedFixedPoint;
-        RelayerCorrectInvalidVoteOrReport get(fn relayer_correct_invalid_vote_or_report) config(): T::SignedFixedPoint;
         RelayerCorrectTheftReport get(fn relayer_correct_theft_report) config(): T::SignedFixedPoint;
-        RelayerFalseNoDataVoteOrReport get(fn relayer_false_no_data_vote_or_report) config(): T::SignedFixedPoint;
-        RelayerFalseInvalidVoteOrReport get(fn relayer_false_invalid_vote_or_report) config(): T::SignedFixedPoint;
-        RelayerIgnoredVote get(fn relayer_ignored_vote) config(): T::SignedFixedPoint;
     }
 }
 
@@ -468,12 +463,7 @@ impl<T: Config> Module<T> {
         match event {
             RelayerEvent::BlockSubmission => <RelayerBlockSubmission<T>>::get(),
             RelayerEvent::DuplicateBlockSubmission => <RelayerDuplicateBlockSubmission<T>>::get(),
-            RelayerEvent::CorrectNoDataVoteOrReport => <RelayerCorrectNoDataVoteOrReport<T>>::get(),
-            RelayerEvent::CorrectInvalidVoteOrReport => <RelayerCorrectInvalidVoteOrReport<T>>::get(),
             RelayerEvent::CorrectTheftReport => <RelayerCorrectTheftReport<T>>::get(),
-            RelayerEvent::FalseNoDataVoteOrReport => <RelayerFalseNoDataVoteOrReport<T>>::get(),
-            RelayerEvent::FalseInvalidVoteOrReport => <RelayerFalseInvalidVoteOrReport<T>>::get(),
-            RelayerEvent::IgnoredVote => <RelayerIgnoredVote<T>>::get(),
         }
     }
 
@@ -482,12 +472,7 @@ impl<T: Config> Module<T> {
         match event {
             RelayerEvent::BlockSubmission => <RelayerBlockSubmission<T>>::set(value),
             RelayerEvent::DuplicateBlockSubmission => <RelayerDuplicateBlockSubmission<T>>::set(value),
-            RelayerEvent::CorrectNoDataVoteOrReport => <RelayerCorrectNoDataVoteOrReport<T>>::set(value),
-            RelayerEvent::CorrectInvalidVoteOrReport => <RelayerCorrectInvalidVoteOrReport<T>>::set(value),
             RelayerEvent::CorrectTheftReport => <RelayerCorrectTheftReport<T>>::set(value),
-            RelayerEvent::FalseNoDataVoteOrReport => <RelayerFalseNoDataVoteOrReport<T>>::set(value),
-            RelayerEvent::FalseInvalidVoteOrReport => <RelayerFalseInvalidVoteOrReport<T>>::set(value),
-            RelayerEvent::IgnoredVote => <RelayerIgnoredVote<T>>::set(value),
         }
     }
 

--- a/crates/sla/src/mock.rs
+++ b/crates/sla/src/mock.rs
@@ -178,12 +178,7 @@ impl ExtBuilder {
             relayer_target_sla: FixedI128::from(100),
             relayer_block_submission: FixedI128::from(1),
             relayer_duplicate_block_submission: FixedI128::from(1),
-            relayer_correct_no_data_vote_or_report: FixedI128::from(1),
-            relayer_correct_invalid_vote_or_report: FixedI128::from(10),
             relayer_correct_theft_report: FixedI128::from(1),
-            relayer_false_no_data_vote_or_report: FixedI128::from(-10),
-            relayer_false_invalid_vote_or_report: FixedI128::from(-100),
-            relayer_ignored_vote: FixedI128::from(-10),
         }
         .assimilate_storage(&mut storage)
         .unwrap();

--- a/crates/sla/src/types.rs
+++ b/crates/sla/src/types.rs
@@ -13,12 +13,7 @@ pub enum VaultEvent<PolkaBTC> {
 pub enum RelayerEvent {
     BlockSubmission,
     DuplicateBlockSubmission,
-    CorrectNoDataVoteOrReport,
-    CorrectInvalidVoteOrReport,
     CorrectTheftReport,
-    FalseNoDataVoteOrReport,
-    FalseInvalidVoteOrReport,
-    IgnoredVote,
 }
 
 pub(crate) type Inner<T> = <<T as Config>::SignedFixedPoint as FixedPointNumber>::Inner;

--- a/crates/staked-relayers/src/benchmarking.rs
+++ b/crates/staked-relayers/src/benchmarking.rs
@@ -36,7 +36,7 @@ benchmarks! {
             .with_timestamp(1588813835)
             .mine(U256::from(2).pow(254.into())).unwrap();
         let block_header = RawBlockHeader::from_bytes(&block.header.try_format().unwrap()).unwrap();
-        <ActiveStakedRelayers<T>>::insert(&origin, StakedRelayer { stake: stake.into(), height: Security::<T>::active_block_number() });
+        <Stakes<T>>::insert(&origin, Into::<DOT<T>>::into(stake));
     }: _(RawOrigin::Signed(origin), block_header, height)
 
     store_block_header {
@@ -56,7 +56,7 @@ benchmarks! {
         let raw_block_header = RawBlockHeader::from_bytes(&init_block.header.try_format().unwrap())
             .expect("could not serialize block header");
 
-            <ActiveStakedRelayers<T>>::insert(&origin, StakedRelayer { stake: stake.into(), height: Security::<T>::active_block_number() });
+        <Stakes<T>>::insert(&origin, Into::<DOT<T>>::into(stake));
 
         BtcRelay::<T>::initialize(origin.clone(), raw_block_header, height).unwrap();
 
@@ -78,14 +78,14 @@ benchmarks! {
         let u in 100 .. 1000;
     }: _(RawOrigin::Signed(origin.clone()), u.into())
     verify {
-        assert_eq!(<InactiveStakedRelayers<T>>::get(origin).stake, u.into());
+        assert_eq!(<Stakes<T>>::get(origin), Into::<DOT<T>>::into(u));
     }
 
     deregister_staked_relayer {
         let origin: T::AccountId = account("Origin", 0, 0);
         let _ = T::DOT::make_free_balance_be(&origin, (1u32 << 31).into());
         let stake: u32 = 100;
-        <ActiveStakedRelayers<T>>::insert(&origin, StakedRelayer { stake: stake.into(), height: Security::<T>::active_block_number() });
+        <Stakes<T>>::insert(&origin, Into::<DOT<T>>::into(stake));
         Collateral::<T>::lock_collateral(&origin, stake.into()).unwrap();
     }: _(RawOrigin::Signed(origin))
 
@@ -94,7 +94,7 @@ benchmarks! {
         let _ = T::DOT::make_free_balance_be(&staked_relayer, (1u32 << 31).into());
 
         let stake: u32 = 100;
-        StakedRelayers::<T>::insert_active_staked_relayer(&staked_relayer, stake.into(), Security::<T>::active_block_number());
+        <Stakes<T>>::insert(&staked_relayer, Into::<DOT<T>>::into(stake));
         Collateral::<T>::lock_collateral(&staked_relayer, stake.into()).unwrap();
 
     }: _(RawOrigin::Root, staked_relayer)
@@ -104,7 +104,7 @@ benchmarks! {
         let relayer_id: T::AccountId = account("Relayer", 0, 0);
 
         let stake: u32 = 100;
-        StakedRelayers::<T>::insert_active_staked_relayer(&origin, stake.into(), Security::<T>::active_block_number());
+        <Stakes<T>>::insert(&origin, Into::<DOT<T>>::into(stake));
 
         let vault_address = BtcAddress::P2PKH(H160::from_slice(&[
             126, 125, 148, 208, 221, 194, 29, 131, 191, 188, 252, 119, 152, 228, 84, 126, 223, 8,

--- a/crates/staked-relayers/src/default_weights.rs
+++ b/crates/staked-relayers/src/default_weights.rs
@@ -9,15 +9,8 @@ pub trait WeightInfo {
     fn initialize() -> Weight;
     fn register_staked_relayer() -> Weight;
     fn deregister_staked_relayer() -> Weight;
-    fn suggest_status_update() -> Weight;
-    fn vote_on_status_update() -> Weight;
-    fn force_status_update() -> Weight;
-    fn slash_staked_relayer() -> Weight;
     fn report_vault_theft() -> Weight;
-    fn remove_active_status_update() -> Weight;
-    fn remove_inactive_status_update() -> Weight;
-    fn set_maturity_period() -> Weight;
-    fn evaluate_status_update() -> Weight;
+    fn slash_staked_relayer() -> Weight;
     fn store_block_header() -> Weight;
 }
 
@@ -38,21 +31,6 @@ impl crate::WeightInfo for () {
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
-    fn suggest_status_update() -> Weight {
-        (86_591_000 as Weight)
-            .saturating_add(DbWeight::get().reads(5 as Weight))
-            .saturating_add(DbWeight::get().writes(4 as Weight))
-    }
-    fn vote_on_status_update() -> Weight {
-        (45_633_000 as Weight)
-            .saturating_add(DbWeight::get().reads(2 as Weight))
-            .saturating_add(DbWeight::get().writes(1 as Weight))
-    }
-    fn force_status_update() -> Weight {
-        (30_442_000 as Weight)
-            .saturating_add(DbWeight::get().reads(2 as Weight))
-            .saturating_add(DbWeight::get().writes(2 as Weight))
-    }
     fn slash_staked_relayer() -> Weight {
         (109_555_000 as Weight)
             .saturating_add(DbWeight::get().reads(6 as Weight))
@@ -62,18 +40,6 @@ impl crate::WeightInfo for () {
         (251_206_000 as Weight)
             .saturating_add(DbWeight::get().reads(16 as Weight))
             .saturating_add(DbWeight::get().writes(5 as Weight))
-    }
-    fn remove_active_status_update() -> Weight {
-        (5_585_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
-    }
-    fn remove_inactive_status_update() -> Weight {
-        (5_571_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
-    }
-    fn set_maturity_period() -> Weight {
-        (5_571_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
-    }
-    fn evaluate_status_update() -> Weight {
-        (5_571_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn store_block_header() -> Weight {
         (123_623_000 as Weight)

--- a/crates/staked-relayers/src/ext.rs
+++ b/crates/staked-relayers/src/ext.rs
@@ -50,32 +50,12 @@ pub(crate) mod vault_registry {
 #[cfg_attr(test, mockable)]
 pub(crate) mod security {
     use frame_support::dispatch::DispatchResult;
-    use security::types::{ErrorCode, StatusCode};
+    use security::types::ErrorCode;
     use sp_std::collections::btree_set::BTreeSet;
-
-    pub(crate) fn get_parachain_status<T: security::Config>() -> StatusCode {
-        <security::Pallet<T>>::get_parachain_status()
-    }
-
-    pub(crate) fn set_status<T: security::Config>(status_code: StatusCode) {
-        <security::Pallet<T>>::set_status(status_code)
-    }
-
-    pub(crate) fn insert_error<T: security::Config>(error_code: ErrorCode) {
-        <security::Pallet<T>>::insert_error(error_code)
-    }
-
-    pub(crate) fn remove_error<T: security::Config>(error_code: ErrorCode) {
-        <security::Pallet<T>>::remove_error(error_code)
-    }
 
     #[allow(dead_code)]
     pub(crate) fn get_errors<T: security::Config>() -> BTreeSet<ErrorCode> {
         <security::Pallet<T>>::get_errors()
-    }
-
-    pub fn active_block_number<T: security::Config>() -> T::BlockNumber {
-        <security::Pallet<T>>::active_block_number()
     }
 
     pub fn ensure_parachain_status_not_shutdown<T: security::Config>() -> DispatchResult {
@@ -95,7 +75,6 @@ pub(crate) mod btc_relay {
     use bitcoin::types::{H256Le, RawBlockHeader, Transaction};
     use btc_relay::BtcAddress;
     use frame_support::dispatch::DispatchResult;
-    use security::types::ErrorCode;
     use sp_std::prelude::*;
 
     pub fn initialize<T: btc_relay::Config>(
@@ -112,23 +91,12 @@ pub(crate) mod btc_relay {
     ) -> DispatchResult {
         <btc_relay::Pallet<T>>::store_block_header(relayer, raw_block_header)
     }
-    pub(crate) fn flag_block_error<T: btc_relay::Config>(block_hash: H256Le, error: ErrorCode) -> DispatchResult {
-        <btc_relay::Pallet<T>>::flag_block_error(block_hash, error)
-    }
-
-    pub(crate) fn clear_block_error<T: btc_relay::Config>(block_hash: H256Le, error: ErrorCode) -> DispatchResult {
-        <btc_relay::Pallet<T>>::clear_block_error(block_hash, error)
-    }
 
     pub(crate) fn verify_transaction_inclusion<T: btc_relay::Config>(
         tx_id: H256Le,
         raw_merkle_proof: Vec<u8>,
     ) -> DispatchResult {
         <btc_relay::Pallet<T>>::_verify_transaction_inclusion(tx_id, raw_merkle_proof, None)
-    }
-
-    pub(crate) fn block_header_exists<T: btc_relay::Config>(block_hash: H256Le) -> bool {
-        <btc_relay::Pallet<T>>::block_header_exists(block_hash)
     }
 
     pub(crate) fn extract_outputs<T: btc_relay::Config>(

--- a/crates/staked-relayers/src/mock.rs
+++ b/crates/staked-relayers/src/mock.rs
@@ -33,7 +33,7 @@ frame_support::construct_runtime!(
         // Operational
         BTCRelay: btc_relay::{Pallet, Call, Config<T>, Storage, Event<T>},
         Security: security::{Pallet, Call, Storage, Event<T>},
-        StakedRelayers: staked_relayers::{Pallet, Call, Config<T>, Storage, Event<T>},
+        StakedRelayers: staked_relayers::{Pallet, Call, Storage, Event<T>},
         VaultRegistry: vault_registry::{Pallet, Call, Config<T>, Storage, Event<T>},
         ExchangeRateOracle: exchange_rate_oracle::{Pallet, Call, Config<T>, Storage, Event<T>},
         Redeem: redeem::{Pallet, Call, Config<T>, Storage, Event<T>},
@@ -280,13 +280,6 @@ impl ExtBuilder {
                     (DAVE, DAVE_BALANCE),
                     (EVE, EVE_BALANCE),
                 ],
-            }
-            .assimilate_storage(storage)
-            .unwrap();
-
-            staked_relayers::GenesisConfig::<Test> {
-                gov_id: CAROL,
-                maturity_period: 10,
             }
             .assimilate_storage(storage)
             .unwrap();

--- a/crates/staked-relayers/src/types.rs
+++ b/crates/staked-relayers/src/types.rs
@@ -1,118 +1,11 @@
-use bitcoin::types::*;
 use codec::{Decode, Encode};
 use frame_support::traits::Currency;
-use security::types::{ErrorCode, StatusCode};
-use sp_arithmetic::traits::Saturating;
-use sp_std::{cmp::Ord, collections::btree_set::BTreeSet, fmt::Debug, prelude::Vec};
+use sp_std::fmt::Debug;
 
 pub(crate) type DOT<T> = <<T as collateral::Config>::DOT as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 
 pub(crate) type PolkaBTC<T> =
     <<T as treasury::Config>::PolkaBTC as Currency<<T as frame_system::Config>::AccountId>>::Balance;
-
-pub type StatusUpdateId = u64;
-
-/// Indicates the state of a proposed StatusUpdate.
-#[derive(Encode, Decode, Clone, PartialEq, Debug)]
-pub enum ProposalStatus {
-    /// StatusUpdate is current under review and is being voted upon
-    Pending = 0,
-    /// StatusUpdate has been accepted
-    Accepted = 1,
-    /// StatusUpdate has been rejected
-    Rejected = 2,
-}
-
-impl Default for ProposalStatus {
-    fn default() -> Self {
-        ProposalStatus::Pending
-    }
-}
-
-/// ## Structs
-/// Struct storing information on a proposed parachain status update
-#[derive(Encode, Decode, Default, Clone, PartialEq, Debug)]
-pub struct StatusUpdate<AccountId: Ord + Clone, BlockNumber, DOT: Clone + PartialOrd + Saturating> {
-    /// New status of the BTC Parachain.
-    pub new_status_code: StatusCode,
-    /// Previous status of the BTC Parachain.
-    pub old_status_code: StatusCode,
-    /// If new_status_code is Error, specifies which error is to be added to Errors
-    pub add_error: Option<ErrorCode>,
-    /// Indicates which ErrorCode is to be removed from Errors (recovery).
-    pub remove_error: Option<ErrorCode>,
-    /// Parachain block number at which this status update was suggested.
-    pub start: BlockNumber,
-    /// Parachain block number at which this status update will expire.
-    pub end: BlockNumber,
-    /// Status of the proposed status update. See ProposalStatus.
-    pub proposal_status: ProposalStatus,
-    /// LE Block hash of the Bitcoin block where the error was detected, if related to BTC-Relay.
-    pub btc_block_hash: Option<H256Le>,
-    /// Origin of this proposal.
-    pub proposer: AccountId,
-    /// Deposit paid to submit this proposal.
-    pub deposit: DOT,
-    /// Bookkeeping for this proposal.
-    pub tally: Tally<AccountId, DOT>,
-    /// Message providing more details on the change of status (detailed error message or recovery reason).
-    pub message: Vec<u8>,
-}
-
-#[derive(Encode, Decode, Default, Clone, PartialEq, Debug)]
-pub struct Votes<AccountId: Ord, Balance: Clone + Saturating> {
-    pub(crate) accounts: BTreeSet<AccountId>,
-    pub(crate) total_stake: Balance,
-}
-
-impl<AccountId: Ord, Balance: Clone + Saturating> Votes<AccountId, Balance> {
-    pub(crate) fn contains(&self, id: &AccountId) -> bool {
-        self.accounts.contains(id)
-    }
-
-    pub(crate) fn insert(&mut self, id: AccountId, stake: Balance) {
-        self.accounts.insert(id);
-        self.total_stake = self.total_stake.clone().saturating_add(stake);
-    }
-}
-
-/// Record keeping for yes and no votes. Based loosely on the
-/// democracy pallet in FRAME with restricted functionality.
-#[derive(Encode, Decode, Default, Clone, PartialEq, Debug)]
-pub struct Tally<AccountId: Ord, Balance: Clone + PartialOrd + Saturating> {
-    /// Set of accounts which have voted FOR this status update. This can be either Staked Relayers or the Governance
-    /// Mechanism.
-    pub(crate) aye: Votes<AccountId, Balance>,
-    /// Set of accounts which have voted AGAINST this status update. This can be either Staked Relayers or the
-    /// Governance Mechanism.
-    pub(crate) nay: Votes<AccountId, Balance>,
-}
-
-impl<AccountId: Ord + Clone, Balance: Clone + PartialOrd + Saturating> Tally<AccountId, Balance> {
-    /// Returns true if the majority of votes are in favour.
-    pub(crate) fn is_approved(&self) -> bool {
-        self.aye.total_stake > self.nay.total_stake
-    }
-
-    /// Checks if the account has already voted in this poll.
-    pub(crate) fn contains(&self, id: &AccountId) -> bool {
-        self.nay.contains(&id) || self.aye.contains(&id)
-    }
-
-    /// Casts a vote on the poll, returns true if successful.
-    /// Returns false if the account has already voted.
-    pub(crate) fn vote(&mut self, id: AccountId, stake: Balance, approve: bool) -> bool {
-        if self.contains(&id) {
-            false
-        } else if approve {
-            self.aye.insert(id, stake);
-            true
-        } else {
-            self.nay.insert(id, stake);
-            true
-        }
-    }
-}
 
 /// Bonded participant which can suggest and vote on proposals.
 #[derive(Encode, Decode, Default, Clone, PartialEq, Debug)]

--- a/parachain/runtime/src/lib.rs
+++ b/parachain/runtime/src/lib.rs
@@ -572,7 +572,7 @@ macro_rules! construct_polkabtc_runtime {
 
                 // Operational
                 Security: security::{Pallet, Call, Storage, Event<T>},
-                StakedRelayers: staked_relayers::{Pallet, Call, Config<T>, Storage, Event<T>},
+                StakedRelayers: staked_relayers::{Pallet, Call, Storage, Event<T>},
                 VaultRegistry: vault_registry::{Pallet, Call, Config<T>, Storage, Event<T>},
                 ExchangeRateOracle: exchange_rate_oracle::{Pallet, Call, Config<T>, Storage, Event<T>},
                 Issue: issue::{Pallet, Call, Config<T>, Storage, Event<T>},

--- a/parachain/runtime/tests/mock/mod.rs
+++ b/parachain/runtime/tests/mock/mod.rs
@@ -106,6 +106,7 @@ pub type SecurityError = security::Error<Runtime>;
 pub type SecurityPallet = security::Pallet<Runtime>;
 
 pub type SlaPallet = sla::Pallet<Runtime>;
+pub type SlaCall = sla::Call<Runtime>;
 
 pub type StakedRelayersCall = staked_relayers::Call<Runtime>;
 pub type StakedRelayersPallet = staked_relayers::Pallet<Runtime>;
@@ -924,12 +925,7 @@ impl ExtBuilder {
             relayer_target_sla: FixedI128::from(100),
             relayer_block_submission: FixedI128::from(1),
             relayer_duplicate_block_submission: FixedI128::from(1),
-            relayer_correct_no_data_vote_or_report: FixedI128::from(1),
-            relayer_correct_invalid_vote_or_report: FixedI128::from(10),
             relayer_correct_theft_report: FixedI128::from(1),
-            relayer_false_no_data_vote_or_report: FixedI128::from(-10),
-            relayer_false_invalid_vote_or_report: FixedI128::from(-100),
-            relayer_ignored_vote: FixedI128::from(-10),
         }
         .assimilate_storage(&mut storage)
         .unwrap();

--- a/parachain/runtime/tests/test_staked_relayers.rs
+++ b/parachain/runtime/tests/test_staked_relayers.rs
@@ -35,11 +35,6 @@ fn test_vault_theft(submit_by_relayer: bool) {
         assert_ok!(Call::StakedRelayers(StakedRelayersCall::register_staked_relayer(100))
             .dispatch(origin_of(account_of(user))));
 
-        SecurityPallet::set_active_block_number(StakedRelayersPallet::get_maturity_period() + 100);
-
-        // manually activate
-        assert_ok!(StakedRelayersPallet::activate_staked_relayer(&account_of(user)));
-
         let initial_sla = SlaPallet::relayer_sla(account_of(ALICE));
 
         let (_tx_id, _height, proof, raw_tx, _) = TransactionGenerator::new()

--- a/parachain/src/chain_spec.rs
+++ b/parachain/src/chain_spec.rs
@@ -1,8 +1,7 @@
 use btc_parachain_runtime::{
     AccountId, BTCRelayConfig, BlockNumber, DOTConfig, ExchangeRateOracleConfig, FeeConfig, GenesisConfig, IssueConfig,
-    NominationConfig, PolkaBTCConfig, RedeemConfig, RefundConfig, ReplaceConfig, Signature, SlaConfig,
-    StakedRelayersConfig, SudoConfig, SystemConfig, VaultRegistryConfig, DAYS, HOURS, MILLISECS_PER_BLOCK, MINUTES,
-    TARGET_SPACING, WASM_BINARY,
+    NominationConfig, PolkaBTCConfig, RedeemConfig, RefundConfig, ReplaceConfig, Signature, SlaConfig, SudoConfig,
+    SystemConfig, VaultRegistryConfig, DAYS, HOURS, MILLISECS_PER_BLOCK, TARGET_SPACING, WASM_BINARY,
 };
 
 const BITCOIN_SPACING_MS: u32 = TARGET_SPACING * 1000;
@@ -370,13 +369,6 @@ fn testnet_genesis(
             balances: endowed_accounts.iter().cloned().map(|k| (k, 1 << 60)).collect(),
         },
         pallet_balances_Instance2: PolkaBTCConfig { balances: vec![] },
-        staked_relayers: StakedRelayersConfig {
-            #[cfg(feature = "runtime-benchmarks")]
-            gov_id: account("Origin", 0, 0),
-            #[cfg(not(feature = "runtime-benchmarks"))]
-            gov_id: root_key,
-            maturity_period: 10 * MINUTES,
-        },
         exchange_rate_oracle: ExchangeRateOracleConfig {
             authorized_oracles,
             max_delay: 3600000, // one hour
@@ -433,12 +425,7 @@ fn testnet_genesis(
             relayer_target_sla: FixedI128::from(100),
             relayer_block_submission: FixedI128::from(1),
             relayer_duplicate_block_submission: FixedI128::from(1),
-            relayer_correct_no_data_vote_or_report: FixedI128::from(1),
-            relayer_correct_invalid_vote_or_report: FixedI128::from(10),
             relayer_correct_theft_report: FixedI128::from(1),
-            relayer_false_no_data_vote_or_report: FixedI128::from(-10),
-            relayer_false_invalid_vote_or_report: FixedI128::from(-100),
-            relayer_ignored_vote: FixedI128::from(-10),
         },
         refund: RefundConfig {
             refund_btc_dust_value: 1000,


### PR DESCRIPTION
Breaking changes:
- remove many storage items from staked-relayers
    - stake is now stored in `Stakes`
- removed many dispatchable functions 
- changed `RegisterStakedRelayer` event