### PR TITLE
[BREAKING] fix: correct txid calculation when there is witness data

### DIFF
--- a/crates/bitcoin/src/types.rs
+++ b/crates/bitcoin/src/types.rs
@@ -834,6 +834,42 @@ mod tests {
     }
 
     #[test]
+    fn test_transaction_txid_with_witness() {
+        // the witness data should not be included in the input of the hashfunction that calculates the txid  - check
+        // that we correctly exclude it.
+
+        // real tx with txinwitness. Look for the txid on https://chainquery.com/bitcoin-cli/getrawtransaction for details
+        let raw_tx = "0200000000010140d43a99926d43eb0e619bf0b3d83b4a31f60c176beecfb9d35bf45e54d0f7420100000017160014a4b4ca48de0b3fffc15404a1acdc8dbaae226955ffffffff0100e1f5050000000017a9144a1154d50b03292b3024370901711946cb7cccc387024830450221008604ef8f6d8afa892dee0f31259b6ce02dd70c545cfcfed8148179971876c54a022076d771d6e91bed212783c9b06e0de600fab2d518fad6f15a2b191d7fbd262a3e0121039d25ab79f41f75ceaf882411fd41fa670a4c672c23ffaf0e361a969cde0692e800000000";
+
+        let tx_bytes = hex::decode(&raw_tx).unwrap();
+        let transaction = parse_transaction(&tx_bytes).unwrap();
+        let txid = transaction.tx_id();
+        let expected_txid = H256Le::from_hex_be("c586389e5e4b3acb9d6c8be1c19ae8ab2795397633176f5a6442a261bbdefc3a");
+        assert_eq!(txid, expected_txid);
+
+        // txid of transaction without witness is NOT equal to the hash of all bytes
+        assert_ne!(sha256d_le(&tx_bytes), expected_txid);
+    }
+
+    #[test]
+    fn test_transaction_txid_without_witness() {
+        // the witness data should not be included in the input of the hashfunction that calculates the txid  - check
+        // that without witness, the txid is equal to the hash of the raw bytes
+
+        // real tx with txinwitness. Look for the txid on https://chainquery.com/bitcoin-cli/getrawtransaction for details
+        let raw_tx = "020000000210b8fbfb6e1a5d2d30677c4ce797b0520774a6a250c22192eacd63b2f8025970110000006b483045022100819b0bdc0568a549cb5230c4f5fc0561764dd95b2e191efe9ab154bb8a5a95820220021f3547cefe915a5bb2906a89bc7ec4e858077ec9b023b48f7929898207de91012102279da390217bff00f6dbae65c993c714e5cd6b7ea384ffb9d4a51f09f044fa30ffffffff43ac430a2b980dbd82911eed89ec70526ed33ac614137e310f2ca70fefaa8c29010000006a473044022069e74ad037fe7304f8545230a32eff39e8fc6133640ee4bc8eb1b9108d79cfa702206dee0ba9b9e0e329074d414bb92609a34e1ae3c7ef2d0658c29230f4b5e85a2b012103bb7b040b18c3ab6d6c4ea8f42e47cb8628ccbcad016804c327603d80951a5850ffffffff02b80581000000000017a914dfea03c60b988da73084af5c9c863d988ae99a18874c113b00000000001976a914c8b46a12370c76a1e382773a3d044fa17beea53288ac00000000";
+
+        let tx_bytes = hex::decode(&raw_tx).unwrap();
+        let transaction = parse_transaction(&tx_bytes).unwrap();
+        let txid = transaction.tx_id();
+        let expected_txid = H256Le::from_hex_be("c052ff9439346a70488f308b009501178be6bb8cb1ecb2ceac8e8a3a8143c687");
+        assert_eq!(txid, expected_txid);
+
+        // txid of transaction without witness is just the hash of all bytes
+        assert_eq!(sha256d_le(&tx_bytes), expected_txid);
+    }
+
+    #[test]
     fn test_script_height() {
         assert_eq!(Script::height(100).len(), 4);
     }

--- a/crates/btc-relay/src/benchmarking.rs
+++ b/crates/btc-relay/src/benchmarking.rs
@@ -91,7 +91,7 @@ benchmarks! {
 
         Security::<T>::set_active_block_number(100u32.into());
 
-    }: _(RawOrigin::Signed(origin), tx_id, proof, Some(0), raw_tx, value.into(), address, Some(op_return))
+    }: _(RawOrigin::Signed(origin), proof, Some(0), raw_tx, value.into(), address, Some(H256::zero()))
 
     verify_transaction_inclusion {
         let origin: T::AccountId = account("Origin", 0, 0);
@@ -125,7 +125,7 @@ benchmarks! {
 
         let raw_tx = transaction.format_with(true);
 
-    }: _(RawOrigin::Signed(origin), raw_tx, value.into(), address, Some(op_return))
+    }: _(RawOrigin::Signed(origin), raw_tx, value.into(), address, Some(H256::from_slice(&op_return)))
 
 }
 

--- a/crates/btc-relay/src/tests.rs
+++ b/crates/btc-relay/src/tests.rs
@@ -727,7 +727,7 @@ fn test_validate_transaction_succeeds_with_payment() {
             raw_tx,
             minimum_btc,
             recipient_btc_address,
-            Some(vec![])
+            None,
         ));
     });
 }
@@ -740,7 +740,7 @@ fn test_validate_transaction_succeeds_with_payment_and_op_return() {
         let recipient_btc_address =
             BtcAddress::P2SH(H160::from_str(&"66c7060feb882664ae62ffad0051fe843e318e85").unwrap());
         let op_return_id =
-            hex::decode("aa21a9ede5c17d15b8b1fa2811b7e6da66ffa5e1aaa05922c69068bf90cd585b95bb4675".to_owned()).unwrap();
+            hex::decode("e5c17d15b8b1fa2811b7e6da66ffa5e1aaa05922c69068bf90cd585b95bb4675".to_owned()).unwrap();
 
         let outputs = vec![sample_valid_payment_output(), sample_valid_data_output()];
 
@@ -751,7 +751,7 @@ fn test_validate_transaction_succeeds_with_payment_and_op_return() {
             raw_tx,
             minimum_btc,
             recipient_btc_address,
-            Some(op_return_id)
+            Some(H256::from_slice(&op_return_id))
         ));
     });
 }
@@ -764,7 +764,7 @@ fn test_validate_transaction_succeeds_with_op_return_and_payment() {
         let recipient_btc_address =
             BtcAddress::P2SH(H160::from_str(&"66c7060feb882664ae62ffad0051fe843e318e85").unwrap());
         let op_return_id =
-            hex::decode("aa21a9ede5c17d15b8b1fa2811b7e6da66ffa5e1aaa05922c69068bf90cd585b95bb4675".to_owned()).unwrap();
+            hex::decode("e5c17d15b8b1fa2811b7e6da66ffa5e1aaa05922c69068bf90cd585b95bb4675".to_owned()).unwrap();
 
         let outputs = vec![sample_valid_data_output(), sample_valid_payment_output()];
 
@@ -775,7 +775,7 @@ fn test_validate_transaction_succeeds_with_op_return_and_payment() {
             raw_tx,
             minimum_btc,
             recipient_btc_address,
-            Some(op_return_id)
+            Some(H256::from_slice(&op_return_id))
         ));
     });
 }
@@ -788,7 +788,7 @@ fn test_validate_transaction_succeeds_with_payment_and_refund_and_op_return() {
         let recipient_btc_address =
             BtcAddress::P2SH(H160::from_str(&"66c7060feb882664ae62ffad0051fe843e318e85").unwrap());
         let op_return_id =
-            hex::decode("aa21a9ede5c17d15b8b1fa2811b7e6da66ffa5e1aaa05922c69068bf90cd585b95bb4675".to_owned()).unwrap();
+            hex::decode("e5c17d15b8b1fa2811b7e6da66ffa5e1aaa05922c69068bf90cd585b95bb4675".to_owned()).unwrap();
 
         let outputs = vec![
             sample_valid_payment_output(),
@@ -803,7 +803,7 @@ fn test_validate_transaction_succeeds_with_payment_and_refund_and_op_return() {
             raw_tx,
             minimum_btc,
             recipient_btc_address,
-            Some(op_return_id)
+            Some(H256::from_slice(&op_return_id))
         ));
     });
 }
@@ -818,7 +818,7 @@ fn test_validate_transaction_invalid_no_outputs_fails() {
         let recipient_btc_address =
             BtcAddress::P2SH(H160::from_str(&"66c7060feb882664ae62ffad0051fe843e318e85").unwrap());
         let op_return_id =
-            hex::decode("aa21a9ede5c17d15b8b1fa2811b7e6da66ffa5e1aaa05922c69068bf90cd585b95bb4675".to_owned()).unwrap();
+            hex::decode("ede5c17d15b8b1fa2811b7e6da66ffa5e1aaa05922c69068bf90cd585b95bb46".to_owned()).unwrap();
         // missing required data output
         let outputs = vec![sample_valid_payment_output()];
 
@@ -830,7 +830,7 @@ fn test_validate_transaction_invalid_no_outputs_fails() {
                 raw_tx,
                 minimum_btc,
                 recipient_btc_address,
-                Some(op_return_id)
+                Some(H256::from_slice(&op_return_id))
             ),
             TestError::MalformedTransaction
         )
@@ -847,7 +847,7 @@ fn test_validate_transaction_insufficient_payment_value_fails() {
         let recipient_btc_address =
             BtcAddress::P2SH(H160::from_str(&"66c7060feb882664ae62ffad0051fe843e318e85").unwrap());
         let op_return_id =
-            hex::decode("aa21a9ede5c17d15b8b1fa2811b7e6da66ffa5e1aaa05922c69068bf90cd585b95bb4675".to_owned()).unwrap();
+            hex::decode("e5c17d15b8b1fa2811b7e6da66ffa5e1aaa05922c69068bf90cd585b95bb4675".to_owned()).unwrap();
 
         let outputs = vec![sample_insufficient_value_payment_output(), sample_valid_data_output()];
 
@@ -859,7 +859,7 @@ fn test_validate_transaction_insufficient_payment_value_fails() {
                 raw_tx,
                 minimum_btc,
                 recipient_btc_address,
-                Some(op_return_id)
+                Some(H256::from_slice(&op_return_id))
             ),
             TestError::InsufficientValue
         )
@@ -876,7 +876,7 @@ fn test_validate_transaction_wrong_recipient_fails() {
         let recipient_btc_address =
             BtcAddress::P2SH(H160::from_str(&"66c7060feb882664ae62ffad0051fe843e318e85").unwrap());
         let op_return_id =
-            hex::decode("aa21a9ede5c17d15b8b1fa2811b7e6da66ffa5e1aaa05922c69068bf90cd585b95bb4675".to_owned()).unwrap();
+            hex::decode("e5c17d15b8b1fa2811b7e6da66ffa5e1aaa05922c69068bf90cd585b95bb4675".to_owned()).unwrap();
 
         let outputs = vec![
             sample_wrong_recipient_payment_output(),
@@ -892,7 +892,7 @@ fn test_validate_transaction_wrong_recipient_fails() {
                 raw_tx,
                 minimum_btc,
                 recipient_btc_address,
-                Some(op_return_id)
+                Some(H256::from_slice(&op_return_id))
             ),
             TestError::InvalidPayment
         )
@@ -909,8 +909,7 @@ fn test_validate_transaction_incorrect_opreturn_fails() {
         let recipient_btc_address =
             BtcAddress::P2SH(H160::from_str(&"66c7060feb882664ae62ffad0051fe843e318e85").unwrap());
         let op_return_id =
-            hex::decode("6a24aa21a9ede5c17d15b8b1fa2811b7e6da66ffa5e1aaa05922c69068bf90cd585b95bb4675".to_owned())
-                .unwrap();
+            hex::decode("0000000000000000000000000000000000000000000000000000000000000000".to_owned()).unwrap();
 
         let outputs = vec![sample_valid_payment_output(), sample_incorrect_data_output()];
 
@@ -922,7 +921,7 @@ fn test_validate_transaction_incorrect_opreturn_fails() {
                 raw_tx,
                 minimum_btc,
                 recipient_btc_address,
-                Some(op_return_id)
+                Some(H256::from_slice(&op_return_id))
             ),
             TestError::InvalidOpReturn
         )
@@ -952,19 +951,18 @@ fn test_verify_and_validate_transaction_succeeds() {
         let recipient_btc_address =
             BtcAddress::P2SH(H160::from_str(&"66c7060feb882664ae62ffad0051fe843e318e85").unwrap());
         let op_return_id =
-            hex::decode("aa21a9ede5c17d15b8b1fa2811b7e6da66ffa5e1aaa05922c69068bf90cd585b95bb4675".to_owned()).unwrap();
+            hex::decode("e5c17d15b8b1fa2811b7e6da66ffa5e1aaa05922c69068bf90cd585b95bb4675".to_owned()).unwrap();
         BTCRelay::_validate_transaction.mock_safe(move |_, _, _, _| MockResult::Return(Ok((recipient_btc_address, 0))));
         BTCRelay::_verify_transaction_inclusion.mock_safe(move |_, _, _| MockResult::Return(Ok(())));
 
         assert_ok!(BTCRelay::verify_and_validate_transaction(
             Origin::signed(3),
-            real_txid,
             raw_merkle_proof,
             confirmations,
             raw_tx,
             minimum_btc,
             recipient_btc_address,
-            Some(op_return_id)
+            Some(H256::from_slice(&op_return_id))
         ));
     });
 }
@@ -2024,7 +2022,7 @@ fn sample_wrong_recipient_payment_output() -> TransactionOutput {
 fn sample_valid_data_output() -> TransactionOutput {
     TransactionOutput {
         value: 0,
-        script: "6a24aa21a9ede5c17d15b8b1fa2811b7e6da66ffa5e1aaa05922c69068bf90cd585b95bb4675"
+        script: "6a20e5c17d15b8b1fa2811b7e6da66ffa5e1aaa05922c69068bf90cd585b95bb4675"
             .try_into()
             .unwrap(),
     }

--- a/crates/issue/src/ext.rs
+++ b/crates/issue/src/ext.rs
@@ -14,6 +14,7 @@ pub(crate) mod btc_relay {
         recipient_btc_address: BtcAddress,
         minimum_btc: Option<i64>,
         op_return_id: Option<H256>,
+        confirmations: Option<u32>,
     ) -> Result<(BtcAddress, i64), DispatchError> {
         <btc_relay::Pallet<T>>::_verify_and_validate_transaction(
             raw_merkle_proof,
@@ -21,6 +22,7 @@ pub(crate) mod btc_relay {
             recipient_btc_address,
             minimum_btc,
             op_return_id,
+            confirmations,
         )
     }
 

--- a/crates/issue/src/ext.rs
+++ b/crates/issue/src/ext.rs
@@ -3,25 +3,25 @@ use mocktopus::macros::mockable;
 
 #[cfg_attr(test, mockable)]
 pub(crate) mod btc_relay {
-    use bitcoin::types::H256Le;
     use btc_relay::BtcAddress;
     use frame_support::dispatch::DispatchError;
+    use primitive_types::H256;
     use sp_std::vec::Vec;
 
-    pub fn verify_transaction_inclusion<T: btc_relay::Config>(
-        tx_id: H256Le,
-        merkle_proof: Vec<u8>,
-    ) -> Result<(), DispatchError> {
-        <btc_relay::Pallet<T>>::_verify_transaction_inclusion(tx_id, merkle_proof, None)
-    }
-
-    pub fn validate_transaction<T: btc_relay::Config>(
+    pub fn verify_and_validate_transaction<T: btc_relay::Config>(
+        raw_merkle_proof: Vec<u8>,
         raw_tx: Vec<u8>,
+        recipient_btc_address: BtcAddress,
         minimum_btc: Option<i64>,
-        btc_address: BtcAddress,
-        issue_id: Option<Vec<u8>>,
+        op_return_id: Option<H256>,
     ) -> Result<(BtcAddress, i64), DispatchError> {
-        <btc_relay::Pallet<T>>::_validate_transaction(raw_tx, minimum_btc, btc_address, issue_id)
+        <btc_relay::Pallet<T>>::_verify_and_validate_transaction(
+            raw_merkle_proof,
+            raw_tx,
+            recipient_btc_address,
+            minimum_btc,
+            op_return_id,
+        )
     }
 
     pub fn get_best_block_height<T: btc_relay::Config>() -> u32 {

--- a/crates/issue/src/lib.rs
+++ b/crates/issue/src/lib.rs
@@ -323,8 +323,14 @@ impl<T: Config> Module<T> {
             Error::<T>::CommitPeriodExpired
         );
 
-        let (refund_address, amount_transferred) =
-            ext::btc_relay::verify_and_validate_transaction::<T>(merkle_proof, raw_tx, issue.btc_address, None, None)?;
+        let (refund_address, amount_transferred) = ext::btc_relay::verify_and_validate_transaction::<T>(
+            merkle_proof,
+            raw_tx,
+            issue.btc_address,
+            None,
+            None,
+            None,
+        )?;
 
         let expected_total_amount = issue
             .amount

--- a/crates/issue/src/lib.rs
+++ b/crates/issue/src/lib.rs
@@ -30,7 +30,6 @@ pub mod types;
 pub use crate::types::{IssueRequest, IssueRequestStatus};
 
 use crate::types::{Backing, IssueRequestV2, Issuing, Version};
-use bitcoin::utils::sha256d_le;
 use btc_relay::{BtcAddress, BtcPublicKey};
 use frame_support::{
     decl_error, decl_event, decl_module, decl_storage,
@@ -324,10 +323,8 @@ impl<T: Config> Module<T> {
             Error::<T>::CommitPeriodExpired
         );
 
-        let tx_id = sha256d_le(&raw_tx);
-        ext::btc_relay::verify_transaction_inclusion::<T>(tx_id, merkle_proof)?;
         let (refund_address, amount_transferred) =
-            ext::btc_relay::validate_transaction::<T>(raw_tx, None, issue.btc_address, None)?;
+            ext::btc_relay::verify_and_validate_transaction::<T>(merkle_proof, raw_tx, issue.btc_address, None, None)?;
 
         let expected_total_amount = issue
             .amount

--- a/crates/issue/src/tests.rs
+++ b/crates/issue/src/tests.rs
@@ -166,9 +166,8 @@ fn test_execute_issue_succeeds() {
         <security::Pallet<Test>>::set_active_block_number(5);
 
         ext::security::ensure_parachain_status_not_shutdown::<Test>.mock_safe(|| MockResult::Return(Ok(())));
-        ext::btc_relay::verify_transaction_inclusion::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
-        ext::btc_relay::validate_transaction::<Test>
-            .mock_safe(|_, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 3))));
+        ext::btc_relay::verify_and_validate_transaction::<Test>
+            .mock_safe(|_, _, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 3))));
 
         assert_ok!(execute_issue(ALICE, &issue_id));
 
@@ -190,11 +189,8 @@ fn test_execute_issue_overpayment_succeeds() {
         <security::Pallet<Test>>::set_active_block_number(5);
         ext::security::ensure_parachain_status_not_shutdown::<Test>.mock_safe(|| MockResult::Return(Ok(())));
 
-        ext::btc_relay::verify_transaction_inclusion::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
-
-        // pay 5 instead of the expected 3
-        ext::btc_relay::validate_transaction::<Test>
-            .mock_safe(|_, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 5))));
+        ext::btc_relay::verify_and_validate_transaction::<Test>
+            .mock_safe(|_, _, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 5))));
 
         ext::vault_registry::is_vault_liquidated::<Test>.mock_safe(|_| MockResult::Return(Ok(false)));
 
@@ -232,11 +228,9 @@ fn test_execute_issue_refund_succeeds() {
         <security::Pallet<Test>>::set_active_block_number(5);
         ext::security::ensure_parachain_status_not_shutdown::<Test>.mock_safe(|| MockResult::Return(Ok(())));
 
-        ext::btc_relay::verify_transaction_inclusion::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
-
         // pay 103 instead of the expected 3
-        ext::btc_relay::validate_transaction::<Test>
-            .mock_safe(|_, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 103))));
+        ext::btc_relay::verify_and_validate_transaction::<Test>
+            .mock_safe(|_, _, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 103))));
 
         // return some arbitrary error
         ext::vault_registry::try_increase_to_be_issued_tokens::<Test>.mock_safe(|_, amount| {

--- a/crates/issue/src/tests.rs
+++ b/crates/issue/src/tests.rs
@@ -167,7 +167,7 @@ fn test_execute_issue_succeeds() {
 
         ext::security::ensure_parachain_status_not_shutdown::<Test>.mock_safe(|| MockResult::Return(Ok(())));
         ext::btc_relay::verify_and_validate_transaction::<Test>
-            .mock_safe(|_, _, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 3))));
+            .mock_safe(|_, _, _, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 3))));
 
         assert_ok!(execute_issue(ALICE, &issue_id));
 
@@ -190,7 +190,7 @@ fn test_execute_issue_overpayment_succeeds() {
         ext::security::ensure_parachain_status_not_shutdown::<Test>.mock_safe(|| MockResult::Return(Ok(())));
 
         ext::btc_relay::verify_and_validate_transaction::<Test>
-            .mock_safe(|_, _, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 5))));
+            .mock_safe(|_, _, _, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 5))));
 
         ext::vault_registry::is_vault_liquidated::<Test>.mock_safe(|_| MockResult::Return(Ok(false)));
 
@@ -230,7 +230,7 @@ fn test_execute_issue_refund_succeeds() {
 
         // pay 103 instead of the expected 3
         ext::btc_relay::verify_and_validate_transaction::<Test>
-            .mock_safe(|_, _, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 103))));
+            .mock_safe(|_, _, _, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 103))));
 
         // return some arbitrary error
         ext::vault_registry::try_increase_to_be_issued_tokens::<Test>.mock_safe(|_, amount| {

--- a/crates/redeem/src/ext.rs
+++ b/crates/redeem/src/ext.rs
@@ -14,6 +14,7 @@ pub(crate) mod btc_relay {
         recipient_btc_address: BtcAddress,
         minimum_btc: Option<i64>,
         op_return_id: Option<H256>,
+        confirmations: Option<u32>,
     ) -> Result<(BtcAddress, i64), DispatchError> {
         <btc_relay::Pallet<T>>::_verify_and_validate_transaction(
             raw_merkle_proof,
@@ -21,6 +22,7 @@ pub(crate) mod btc_relay {
             recipient_btc_address,
             minimum_btc,
             op_return_id,
+            confirmations,
         )
     }
 

--- a/crates/redeem/src/ext.rs
+++ b/crates/redeem/src/ext.rs
@@ -3,22 +3,25 @@ use mocktopus::macros::mockable;
 
 #[cfg_attr(test, mockable)]
 pub(crate) mod btc_relay {
-    use bitcoin::types::H256Le;
     use btc_relay::BtcAddress;
-    use frame_support::dispatch::{DispatchError, DispatchResult};
+    use frame_support::dispatch::DispatchError;
+    use primitive_types::H256;
     use sp_std::vec::Vec;
 
-    pub fn verify_transaction_inclusion<T: btc_relay::Config>(tx_id: H256Le, merkle_proof: Vec<u8>) -> DispatchResult {
-        <btc_relay::Pallet<T>>::_verify_transaction_inclusion(tx_id, merkle_proof, None)
-    }
-
-    pub fn validate_transaction<T: btc_relay::Config>(
+    pub fn verify_and_validate_transaction<T: btc_relay::Config>(
+        raw_merkle_proof: Vec<u8>,
         raw_tx: Vec<u8>,
+        recipient_btc_address: BtcAddress,
         minimum_btc: Option<i64>,
-        btc_address: BtcAddress,
-        redeem_id: Option<Vec<u8>>,
+        op_return_id: Option<H256>,
     ) -> Result<(BtcAddress, i64), DispatchError> {
-        <btc_relay::Pallet<T>>::_validate_transaction(raw_tx, minimum_btc, btc_address, redeem_id)
+        <btc_relay::Pallet<T>>::_verify_and_validate_transaction(
+            raw_merkle_proof,
+            raw_tx,
+            recipient_btc_address,
+            minimum_btc,
+            op_return_id,
+        )
     }
 
     pub fn get_best_block_height<T: btc_relay::Config>() -> u32 {

--- a/crates/redeem/src/lib.rs
+++ b/crates/redeem/src/lib.rs
@@ -400,6 +400,7 @@ impl<T: Config> Module<T> {
             redeem.btc_address,
             Some(amount as i64),
             Some(redeem_id),
+            None,
         )?;
 
         // burn amount (without parachain fee, but including transfer fee)

--- a/crates/redeem/src/tests.rs
+++ b/crates/redeem/src/tests.rs
@@ -264,9 +264,8 @@ fn test_execute_redeem_succeeds_with_another_account() {
                 status: VaultStatus::Active(true),
             },
         );
-        ext::btc_relay::verify_transaction_inclusion::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
-        ext::btc_relay::validate_transaction::<Test>
-            .mock_safe(|_, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 0))));
+        ext::btc_relay::verify_and_validate_transaction::<Test>
+            .mock_safe(|_, _, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 0))));
 
         inject_redeem_request(
             H256([0u8; 32]),
@@ -362,9 +361,8 @@ fn test_execute_redeem_succeeds() {
                 status: VaultStatus::Active(true),
             },
         );
-        ext::btc_relay::verify_transaction_inclusion::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
-        ext::btc_relay::validate_transaction::<Test>
-            .mock_safe(|_, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 0))));
+        ext::btc_relay::verify_and_validate_transaction::<Test>
+            .mock_safe(|_, _, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 0))));
 
         inject_redeem_request(
             H256([0u8; 32]),

--- a/crates/redeem/src/tests.rs
+++ b/crates/redeem/src/tests.rs
@@ -265,7 +265,7 @@ fn test_execute_redeem_succeeds_with_another_account() {
             },
         );
         ext::btc_relay::verify_and_validate_transaction::<Test>
-            .mock_safe(|_, _, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 0))));
+            .mock_safe(|_, _, _, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 0))));
 
         inject_redeem_request(
             H256([0u8; 32]),
@@ -362,7 +362,7 @@ fn test_execute_redeem_succeeds() {
             },
         );
         ext::btc_relay::verify_and_validate_transaction::<Test>
-            .mock_safe(|_, _, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 0))));
+            .mock_safe(|_, _, _, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 0))));
 
         inject_redeem_request(
             H256([0u8; 32]),

--- a/crates/refund/src/ext.rs
+++ b/crates/refund/src/ext.rs
@@ -27,21 +27,25 @@ pub(crate) mod sla {
 
 #[cfg_attr(test, mockable)]
 pub(crate) mod btc_relay {
-    use bitcoin::types::H256Le;
     use btc_relay::BtcAddress;
-    use frame_support::dispatch::{DispatchError, DispatchResult};
+    use frame_support::dispatch::DispatchError;
+    use primitive_types::H256;
     use sp_std::vec::Vec;
 
-    pub fn verify_transaction_inclusion<T: btc_relay::Config>(tx_id: H256Le, merkle_proof: Vec<u8>) -> DispatchResult {
-        <btc_relay::Pallet<T>>::_verify_transaction_inclusion(tx_id, merkle_proof, None)
-    }
-    pub fn validate_transaction<T: btc_relay::Config>(
+    pub fn verify_and_validate_transaction<T: btc_relay::Config>(
+        raw_merkle_proof: Vec<u8>,
         raw_tx: Vec<u8>,
+        recipient_btc_address: BtcAddress,
         minimum_btc: Option<i64>,
-        btc_address: BtcAddress,
-        refund_id: Option<Vec<u8>>,
+        op_return_id: Option<H256>,
     ) -> Result<(BtcAddress, i64), DispatchError> {
-        <btc_relay::Pallet<T>>::_validate_transaction(raw_tx, minimum_btc, btc_address, refund_id)
+        <btc_relay::Pallet<T>>::_verify_and_validate_transaction(
+            raw_merkle_proof,
+            raw_tx,
+            recipient_btc_address,
+            minimum_btc,
+            op_return_id,
+        )
     }
 }
 

--- a/crates/refund/src/ext.rs
+++ b/crates/refund/src/ext.rs
@@ -38,6 +38,7 @@ pub(crate) mod btc_relay {
         recipient_btc_address: BtcAddress,
         minimum_btc: Option<i64>,
         op_return_id: Option<H256>,
+        confirmations: Option<u32>,
     ) -> Result<(BtcAddress, i64), DispatchError> {
         <btc_relay::Pallet<T>>::_verify_and_validate_transaction(
             raw_merkle_proof,
@@ -45,6 +46,7 @@ pub(crate) mod btc_relay {
             recipient_btc_address,
             minimum_btc,
             op_return_id,
+            confirmations,
         )
     }
 }

--- a/crates/refund/src/lib.rs
+++ b/crates/refund/src/lib.rs
@@ -187,6 +187,7 @@ impl<T: Config> Module<T> {
             request.btc_address,
             Some(amount as i64),
             Some(refund_id),
+            None,
         )?;
 
         // mint issued tokens corresponding to the fee. Note that this can fail

--- a/crates/refund/src/tests.rs
+++ b/crates/refund/src/tests.rs
@@ -11,9 +11,8 @@ fn test_refund_succeeds() {
         ext::fee::get_refund_fee_from_total::<Test>.mock_safe(|_| MockResult::Return(Ok(5)));
         ext::vault_registry::try_increase_to_be_issued_tokens::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
         ext::vault_registry::issue_tokens::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
-        ext::btc_relay::verify_transaction_inclusion::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
-        ext::btc_relay::validate_transaction::<Test>
-            .mock_safe(|_, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 995))));
+        ext::btc_relay::verify_and_validate_transaction::<Test>
+            .mock_safe(|_, _, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 995))));
 
         let issue_id = H256::zero();
         assert_ok!(Refund::request_refund(

--- a/crates/refund/src/tests.rs
+++ b/crates/refund/src/tests.rs
@@ -12,7 +12,7 @@ fn test_refund_succeeds() {
         ext::vault_registry::try_increase_to_be_issued_tokens::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
         ext::vault_registry::issue_tokens::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
         ext::btc_relay::verify_and_validate_transaction::<Test>
-            .mock_safe(|_, _, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 995))));
+            .mock_safe(|_, _, _, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 995))));
 
         let issue_id = H256::zero();
         assert_ok!(Refund::request_refund(

--- a/crates/replace/src/ext.rs
+++ b/crates/replace/src/ext.rs
@@ -14,6 +14,7 @@ pub(crate) mod btc_relay {
         recipient_btc_address: BtcAddress,
         minimum_btc: Option<i64>,
         op_return_id: Option<H256>,
+        confirmations: Option<u32>,
     ) -> Result<(BtcAddress, i64), DispatchError> {
         <btc_relay::Pallet<T>>::_verify_and_validate_transaction(
             raw_merkle_proof,
@@ -21,6 +22,7 @@ pub(crate) mod btc_relay {
             recipient_btc_address,
             minimum_btc,
             op_return_id,
+            confirmations,
         )
     }
 

--- a/crates/replace/src/ext.rs
+++ b/crates/replace/src/ext.rs
@@ -3,22 +3,25 @@ use mocktopus::macros::mockable;
 
 #[cfg_attr(test, mockable)]
 pub(crate) mod btc_relay {
-    use bitcoin::types::H256Le;
     use btc_relay::BtcAddress;
-    use frame_support::dispatch::{DispatchError, DispatchResult};
+    use frame_support::dispatch::DispatchError;
+    use primitive_types::H256;
     use sp_std::vec::Vec;
 
-    pub fn verify_transaction_inclusion<T: btc_relay::Config>(tx_id: H256Le, merkle_proof: Vec<u8>) -> DispatchResult {
-        <btc_relay::Pallet<T>>::_verify_transaction_inclusion(tx_id, merkle_proof, None)
-    }
-
-    pub fn validate_transaction<T: btc_relay::Config>(
+    pub fn verify_and_validate_transaction<T: btc_relay::Config>(
+        raw_merkle_proof: Vec<u8>,
         raw_tx: Vec<u8>,
+        recipient_btc_address: BtcAddress,
         minimum_btc: Option<i64>,
-        btc_address: BtcAddress,
-        replace_id: Option<Vec<u8>>,
+        op_return_id: Option<H256>,
     ) -> Result<(BtcAddress, i64), DispatchError> {
-        <btc_relay::Pallet<T>>::_validate_transaction(raw_tx, minimum_btc, btc_address, replace_id)
+        <btc_relay::Pallet<T>>::_verify_and_validate_transaction(
+            raw_merkle_proof,
+            raw_tx,
+            recipient_btc_address,
+            minimum_btc,
+            op_return_id,
+        )
     }
 
     pub fn get_best_block_height<T: btc_relay::Config>() -> u32 {

--- a/crates/replace/src/lib.rs
+++ b/crates/replace/src/lib.rs
@@ -474,6 +474,7 @@ impl<T: Config> Module<T> {
             replace.btc_address,
             Some(amount),
             Some(replace_id),
+            None,
         )?;
 
         // decrease old-vault's issued & to-be-redeemed tokens, and

--- a/crates/replace/src/tests.rs
+++ b/crates/replace/src/tests.rs
@@ -264,9 +264,8 @@ mod execute_replace_test {
 
         Replace::replace_period.mock_safe(|| MockResult::Return(20));
         ext::security::has_expired::<Test>.mock_safe(|_, _| MockResult::Return(Ok(false)));
-        ext::btc_relay::verify_transaction_inclusion::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
-        ext::btc_relay::validate_transaction::<Test>
-            .mock_safe(|_, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 0))));
+        ext::btc_relay::verify_and_validate_transaction::<Test>
+            .mock_safe(|_, _, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 0))));
         ext::vault_registry::replace_tokens::<Test>.mock_safe(|_, _, _, _| MockResult::Return(Ok(())));
         ext::collateral::release_collateral::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
     }

--- a/crates/replace/src/tests.rs
+++ b/crates/replace/src/tests.rs
@@ -265,7 +265,7 @@ mod execute_replace_test {
         Replace::replace_period.mock_safe(|| MockResult::Return(20));
         ext::security::has_expired::<Test>.mock_safe(|_, _| MockResult::Return(Ok(false)));
         ext::btc_relay::verify_and_validate_transaction::<Test>
-            .mock_safe(|_, _, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 0))));
+            .mock_safe(|_, _, _, _, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 0))));
         ext::vault_registry::replace_tokens::<Test>.mock_safe(|_, _, _, _| MockResult::Return(Ok(())));
         ext::collateral::release_collateral::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
     }

--- a/crates/staked-relayers/src/tests.rs
+++ b/crates/staked-relayers/src/tests.rs
@@ -241,15 +241,13 @@ fn test_report_vault_theft_succeeds() {
         <Stakes<Test>>::insert(&ALICE, amount);
 
         ext::btc_relay::verify_transaction_inclusion::<Test>.mock_safe(move |_, _| MockResult::Return(Ok(())));
-        StakedRelayers::is_transaction_invalid.mock_safe(move |_, _| MockResult::Return(Ok(())));
+        StakedRelayers::_is_parsed_transaction_invalid.mock_safe(move |_, _| MockResult::Return(Ok(())));
         ext::vault_registry::liquidate_theft_vault::<Test>.mock_safe(move |_| MockResult::Return(Ok(())));
 
-        assert_ok!(StakedRelayers::report_vault_theft(
-            relayer,
-            BOB,
-            vec![0u8; 32],
-            vec![0u8; 32],
-        ));
+        let raw_proof = hex::decode("00000020ecf348128755dbeea5deb8eddf64566d9d4e59bc65d485000000000000000000901f0d92a66ee7dcefd02fa282ca63ce85288bab628253da31ef259b24abe8a0470a385a45960018e8d672f8a90a00000d0bdabada1fb6e3cef7f5c6e234621e3230a2f54efc1cba0b16375d9980ecbc023cbef3ba8d8632ea220927ec8f95190b30769eb35d87618f210382c9445f192504074f56951b772efa43b89320d9c430b0d156b93b7a1ff316471e715151a0619a39392657f25289eb713168818bd5b37476f1bc59b166deaa736d8a58756f9d7ce2aef46d8004c5fe3293d883838f87b5f1da03839878895b71530e9ff89338bb6d4578b3c3135ff3e8671f9a64d43b22e14c2893e8271cecd420f11d2359307403bb1f3128885b3912336045269ef909d64576b93e816fa522c8c027fe408700dd4bdee0254c069ccb728d3516fe1e27578b31d70695e3e35483da448f3a951273e018de7f2a8f657064b013c6ede75c74bbd7f98fdae1c2ac6789ee7b21a791aa29d60e89fff2d1d2b1ada50aa9f59f403823c8c58bb092dc58dc09b28158ca15447da9c3bedb0b160f3fe1668d5a27716e27661bcb75ddbf3468f5c76b7bed1004c6b4df4da2ce80b831a7c260b515e6355e1c306373d2233e8de6fda3674ed95d17a01a1f64b27ba88c3676024fbf8d5dd962ffc4d5e9f3b1700763ab88047f7d0000").unwrap();
+        let tx_bytes = hex::decode("0100000001c8cc2b56525e734ff63a13bc6ad06a9e5664df8c67632253a8e36017aee3ee40000000009000483045022100ad0851c69dd756b45190b5a8e97cb4ac3c2b0fa2f2aae23aed6ca97ab33bf88302200b248593abc1259512793e7dea61036c601775ebb23640a0120b0dba2c34b79001455141042f90074d7a5bf30c72cf3a8dfd1381bdbd30407010e878f3a11269d5f74a58788505cdca22ea6eab7cfb40dc0e07aba200424ab0d79122a653ad0c7ec9896bdf51aefeffffff0120f40e00000000001976a9141d30342095961d951d306845ef98ac08474b36a088aca7270400").unwrap();
+
+        assert_ok!(StakedRelayers::report_vault_theft(relayer, BOB, raw_proof, tx_bytes,));
         // check that the event has been emitted
         assert!(System::events()
             .iter()

--- a/parachain/runtime/tests/test_btc_relay.rs
+++ b/parachain/runtime/tests/test_btc_relay.rs
@@ -73,7 +73,6 @@ fn integration_test_btc_relay_with_parachain_shutdown_fails() {
                 Default::default(),
                 Default::default(),
                 Default::default(),
-                Default::default(),
                 Default::default()
             ))
             .dispatch(origin_of(account_of(ALICE))),


### PR DESCRIPTION
Breaking change is that the arguments of `verify_and_validate_transaction` and `validate_transaction` changed. As far as I know, we don't use these functions ourselves though, in which case we don't need to make any changes in the clients/lib