### PR TITLE
refactor!: remove staked relayers registration

### DIFF
--- a/crates/redeem/src/mock.rs
+++ b/crates/redeem/src/mock.rs
@@ -311,9 +311,8 @@ impl ExtBuilder {
             vault_submit_issue_proof: FixedI128::from(0),
             vault_refund: FixedI128::from(1),
             relayer_target_sla: FixedI128::from(100),
-            relayer_block_submission: FixedI128::from(1),
-            relayer_duplicate_block_submission: FixedI128::from(1),
-            relayer_correct_theft_report: FixedI128::from(1),
+            relayer_store_block: FixedI128::from(1),
+            relayer_theft_report: FixedI128::from(1),
         }
         .assimilate_storage(&mut storage)
         .unwrap();

--- a/crates/sla/src/lib.rs
+++ b/crates/sla/src/lib.rs
@@ -95,7 +95,6 @@ decl_storage! {
         AverageWithdraw: SignedFixedPoint<T>;
         AverageWithdrawCount: SignedFixedPoint<T>;
 
-
         // target (max) SLA scores
         VaultTargetSla get(fn vault_target_sla) config(): SignedFixedPoint<T>;
         RelayerTargetSla get(fn relayer_target_sla) config(): SignedFixedPoint<T>;
@@ -110,9 +109,8 @@ decl_storage! {
         VaultSubmitIssueProof get(fn vault_submit_issue_proof) config(): SignedFixedPoint<T>;
         VaultRefund get(fn vault_refund) config(): SignedFixedPoint<T>;
 
-        RelayerBlockSubmission get(fn relayer_block_submission) config(): SignedFixedPoint<T>;
-        RelayerDuplicateBlockSubmission get(fn relayer_duplicate_block_submission) config(): SignedFixedPoint<T>;
-        RelayerCorrectTheftReport get(fn relayer_correct_theft_report) config(): SignedFixedPoint<T>;
+        RelayerStoreBlock get(fn relayer_store_block) config(): SignedFixedPoint<T>;
+        RelayerTheftReport get(fn relayer_theft_report) config(): SignedFixedPoint<T>;
     }
 }
 
@@ -458,18 +456,16 @@ impl<T: Config> Module<T> {
     /// Gets the SLA change corresponding to the given event from storage
     fn _get_relayer_sla(event: RelayerEvent) -> SignedFixedPoint<T> {
         match event {
-            RelayerEvent::BlockSubmission => <RelayerBlockSubmission<T>>::get(),
-            RelayerEvent::DuplicateBlockSubmission => <RelayerDuplicateBlockSubmission<T>>::get(),
-            RelayerEvent::CorrectTheftReport => <RelayerCorrectTheftReport<T>>::get(),
+            RelayerEvent::StoreBlock => <RelayerStoreBlock<T>>::get(),
+            RelayerEvent::TheftReport => <RelayerTheftReport<T>>::get(),
         }
     }
 
     /// Updates the SLA change corresponding to the given event in storage
     fn _set_relayer_sla(event: RelayerEvent, value: SignedFixedPoint<T>) {
         match event {
-            RelayerEvent::BlockSubmission => <RelayerBlockSubmission<T>>::set(value),
-            RelayerEvent::DuplicateBlockSubmission => <RelayerDuplicateBlockSubmission<T>>::set(value),
-            RelayerEvent::CorrectTheftReport => <RelayerCorrectTheftReport<T>>::set(value),
+            RelayerEvent::StoreBlock => <RelayerStoreBlock<T>>::set(value),
+            RelayerEvent::TheftReport => <RelayerTheftReport<T>>::set(value),
         }
     }
 

--- a/crates/sla/src/mock.rs
+++ b/crates/sla/src/mock.rs
@@ -206,9 +206,8 @@ impl ExtBuilder {
             vault_submit_issue_proof: FixedI128::from(0),
             vault_refund: FixedI128::from(1),
             relayer_target_sla: FixedI128::from(100),
-            relayer_block_submission: FixedI128::from(1),
-            relayer_duplicate_block_submission: FixedI128::from(1),
-            relayer_correct_theft_report: FixedI128::from(1),
+            relayer_store_block: FixedI128::from(1),
+            relayer_theft_report: FixedI128::from(1),
         }
         .assimilate_storage(&mut storage)
         .unwrap();

--- a/crates/sla/src/tests.rs
+++ b/crates/sla/src/tests.rs
@@ -102,29 +102,22 @@ fn test_event_update_vault_sla_half_size_increase() {
 fn test_event_update_relayer_sla_succeeds() {
     run_test(|| {
         for i in 0..100 {
-            Sla::event_update_relayer_sla(&ALICE, RelayerEvent::BlockSubmission).unwrap();
+            Sla::event_update_relayer_sla(&ALICE, RelayerEvent::StoreBlock).unwrap();
             assert_eq!(<crate::RelayerSla<Test>>::get(ALICE), FixedI128::from(i + 1));
         }
 
         <crate::RelayerSla<Test>>::insert(ALICE, FixedI128::from(50));
-        Sla::event_update_relayer_sla(&ALICE, RelayerEvent::BlockSubmission).unwrap();
+        Sla::event_update_relayer_sla(&ALICE, RelayerEvent::StoreBlock).unwrap();
         assert_eq!(
             <crate::RelayerSla<Test>>::get(ALICE),
-            FixedI128::from(50) + <crate::RelayerBlockSubmission<Test>>::get(),
+            FixedI128::from(50) + <crate::RelayerStoreBlock<Test>>::get(),
         );
 
         <crate::RelayerSla<Test>>::insert(ALICE, FixedI128::from(50));
-        Sla::event_update_relayer_sla(&ALICE, RelayerEvent::DuplicateBlockSubmission).unwrap();
+        Sla::event_update_relayer_sla(&ALICE, RelayerEvent::TheftReport).unwrap();
         assert_eq!(
             <crate::RelayerSla<Test>>::get(ALICE),
-            FixedI128::from(50) + <crate::RelayerDuplicateBlockSubmission<Test>>::get(),
-        );
-
-        <crate::RelayerSla<Test>>::insert(ALICE, FixedI128::from(50));
-        Sla::event_update_relayer_sla(&ALICE, RelayerEvent::CorrectTheftReport).unwrap();
-        assert_eq!(
-            <crate::RelayerSla<Test>>::get(ALICE),
-            FixedI128::from(50) + <crate::RelayerCorrectTheftReport<Test>>::get(),
+            FixedI128::from(50) + <crate::RelayerTheftReport<Test>>::get(),
         );
     })
 }
@@ -134,7 +127,7 @@ fn test_event_update_relayer_sla_limits() {
     run_test(|| {
         // start at 99.5, add 1, result should be 100
         <RelayerSla<Test>>::insert(ALICE, FixedI128::checked_from_rational(9950, 100).unwrap());
-        Sla::event_update_relayer_sla(&ALICE, RelayerEvent::BlockSubmission).unwrap();
+        Sla::event_update_relayer_sla(&ALICE, RelayerEvent::StoreBlock).unwrap();
         assert_eq!(<RelayerSla<Test>>::get(ALICE), FixedI128::from(100));
     })
 }

--- a/crates/sla/src/types.rs
+++ b/crates/sla/src/types.rs
@@ -14,9 +14,8 @@ pub enum VaultEvent<Issuing, Backing> {
 
 #[derive(Encode, Decode, Clone, PartialEq, Debug)]
 pub enum RelayerEvent {
-    BlockSubmission,
-    DuplicateBlockSubmission,
-    CorrectTheftReport,
+    StoreBlock,
+    TheftReport,
 }
 
 pub(crate) type Backing<T> =

--- a/crates/staked-relayers/src/default_weights.rs
+++ b/crates/staked-relayers/src/default_weights.rs
@@ -7,10 +7,7 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 
 pub trait WeightInfo {
     fn initialize() -> Weight;
-    fn register_staked_relayer() -> Weight;
-    fn deregister_staked_relayer() -> Weight;
     fn report_vault_theft() -> Weight;
-    fn slash_staked_relayer() -> Weight;
     fn store_block_header() -> Weight;
 }
 
@@ -20,21 +17,6 @@ impl crate::WeightInfo for () {
         (52_558_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(7 as Weight))
-    }
-    fn register_staked_relayer() -> Weight {
-        (79_756_000 as Weight)
-            .saturating_add(DbWeight::get().reads(4 as Weight))
-            .saturating_add(DbWeight::get().writes(3 as Weight))
-    }
-    fn deregister_staked_relayer() -> Weight {
-        (93_929_000 as Weight)
-            .saturating_add(DbWeight::get().reads(5 as Weight))
-            .saturating_add(DbWeight::get().writes(4 as Weight))
-    }
-    fn slash_staked_relayer() -> Weight {
-        (109_555_000 as Weight)
-            .saturating_add(DbWeight::get().reads(6 as Weight))
-            .saturating_add(DbWeight::get().writes(5 as Weight))
     }
     fn report_vault_theft() -> Weight {
         (251_206_000 as Weight)

--- a/crates/staked-relayers/src/ext.rs
+++ b/crates/staked-relayers/src/ext.rs
@@ -2,36 +2,6 @@
 use mocktopus::macros::mockable;
 
 #[cfg_attr(test, mockable)]
-pub(crate) mod collateral {
-    use crate::types::Backing;
-    use frame_support::dispatch::{DispatchError, DispatchResult};
-
-    type CollateralPallet<T> = currency::Pallet<T, currency::Backing>;
-
-    pub(crate) fn lock_collateral<T: currency::Config<currency::Backing>>(
-        sender: &T::AccountId,
-        amount: Backing<T>,
-    ) -> Result<(), DispatchError> {
-        CollateralPallet::<T>::lock(sender, amount)
-    }
-
-    pub(crate) fn release_collateral<T: currency::Config<currency::Backing>>(
-        sender: &T::AccountId,
-        amount: Backing<T>,
-    ) -> Result<(), DispatchError> {
-        CollateralPallet::<T>::release(sender, amount)
-    }
-
-    pub fn slash_collateral<T: currency::Config<currency::Backing>>(
-        sender: T::AccountId,
-        receiver: T::AccountId,
-        amount: Backing<T>,
-    ) -> DispatchResult {
-        CollateralPallet::<T>::slash(sender, receiver, amount)
-    }
-}
-
-#[cfg_attr(test, mockable)]
 pub(crate) mod vault_registry {
     use crate::{Backing, Issuing};
     use ::vault_registry::VaultStatus;
@@ -66,13 +36,6 @@ pub(crate) mod security {
 
     pub fn ensure_parachain_status_not_shutdown<T: security::Config>() -> DispatchResult {
         <security::Pallet<T>>::ensure_parachain_status_not_shutdown()
-    }
-}
-
-#[cfg_attr(test, mockable)]
-pub(crate) mod fee {
-    pub fn fee_pool_account_id<T: fee::Config>() -> T::AccountId {
-        <fee::Pallet<T>>::fee_pool_account_id()
     }
 }
 

--- a/crates/staked-relayers/src/mock.rs
+++ b/crates/staked-relayers/src/mock.rs
@@ -267,20 +267,9 @@ impl nomination::Config for Test {
     type WeightInfo = ();
 }
 
-parameter_types! {
-    pub const MinimumDeposit: u64 = 10;
-    pub const MinimumStake: u64 = 10;
-    pub const VotingPeriod: u64 = 100;
-    pub const MaximumMessageSize: u32 = 32;
-}
-
 impl Config for Test {
     type Event = TestEvent;
     type WeightInfo = ();
-    type MinimumDeposit = MinimumDeposit;
-    type MinimumStake = MinimumStake;
-    type VotingPeriod = VotingPeriod;
-    type MaximumMessageSize = MaximumMessageSize;
 }
 
 pub type TestEvent = Event;

--- a/parachain/runtime/src/lib.rs
+++ b/parachain/runtime/src/lib.rs
@@ -600,22 +600,11 @@ impl security::Config for Runtime {
     type Event = Event;
 }
 
-parameter_types! {
-    pub const MinimumDeposit: u32 = 10;
-    pub const MinimumStake: u32 = 10;
-    pub const VotingPeriod: BlockNumber = DAYS;
-    pub const MaximumMessageSize: u32 = 256;
-}
-
 pub use staked_relayers::RawEvent as StakedRelayersEvent;
 
 impl staked_relayers::Config for Runtime {
     type Event = Event;
     type WeightInfo = ();
-    type MinimumDeposit = MinimumDeposit;
-    type MinimumStake = MinimumStake;
-    type VotingPeriod = VotingPeriod;
-    type MaximumMessageSize = MaximumMessageSize;
 }
 
 parameter_types! {

--- a/parachain/runtime/tests/mock/mod.rs
+++ b/parachain/runtime/tests/mock/mod.rs
@@ -775,10 +775,6 @@ impl TransactionGenerator {
         let bytes_proof = proof.try_format().unwrap();
         let raw_tx = transaction.format_with(true);
 
-        // let _ = Call::StakedRelayers(StakedRelayersCall::register_staked_relayer(
-        //     100,
-        // ))
-        // .dispatch(origin_of(account_of(self.relayer)));
         self.relay(height, &block, raw_block_header);
 
         // Mine six new blocks to get over required confirmations
@@ -807,9 +803,6 @@ impl TransactionGenerator {
 
     fn relay(&self, height: u32, block: &Block, raw_block_header: RawBlockHeader) {
         if let Some(relayer) = self.relayer {
-            let _ = Call::StakedRelayers(StakedRelayersCall::register_staked_relayer(100))
-                .dispatch(origin_of(account_of(relayer)));
-
             assert_ok!(
                 Call::StakedRelayers(StakedRelayersCall::store_block_header(raw_block_header))
                     .dispatch(origin_of(account_of(relayer)))
@@ -938,9 +931,8 @@ impl ExtBuilder {
             vault_submit_issue_proof: FixedI128::from(1),
             vault_refund: FixedI128::from(1),
             relayer_target_sla: FixedI128::from(100),
-            relayer_block_submission: FixedI128::from(1),
-            relayer_duplicate_block_submission: FixedI128::from(1),
-            relayer_correct_theft_report: FixedI128::from(1),
+            relayer_store_block: FixedI128::from(1),
+            relayer_theft_report: FixedI128::from(1),
         }
         .assimilate_storage(&mut storage)
         .unwrap();

--- a/parachain/runtime/tests/test_btc_relay.rs
+++ b/parachain/runtime/tests/test_btc_relay.rs
@@ -18,8 +18,6 @@ fn integration_test_submit_block_headers_and_verify_transaction_inclusion() {
         // known in the parachain. Any block before will be rejected
         let parachain_genesis_height = test_data[0].height;
         let parachain_genesis_header = test_data[0].get_raw_header();
-        assert_ok!(Call::StakedRelayers(StakedRelayersCall::register_staked_relayer(100))
-            .dispatch(origin_of(account_of(ALICE))));
 
         assert_ok!(Call::StakedRelayers(StakedRelayersCall::initialize(
             parachain_genesis_header,

--- a/parachain/runtime/tests/test_fee_pool.rs
+++ b/parachain/runtime/tests/test_fee_pool.rs
@@ -19,11 +19,9 @@ fn setup_relayer(relayer: [u8; 32], sla: u32, stake: u128) {
             ..Default::default()
         },
     );
-    // register as staked relayer
-    assert_ok!(Call::StakedRelayers(StakedRelayersCall::register_staked_relayer(stake))
-        .dispatch(origin_of(account_of(relayer))));
+    // increase sla for block submission
     for _ in 0..sla {
-        SlaPallet::event_update_relayer_sla(&account_of(relayer), sla::types::RelayerEvent::BlockSubmission).unwrap();
+        SlaPallet::event_update_relayer_sla(&account_of(relayer), sla::types::RelayerEvent::StoreBlock).unwrap();
     }
 }
 

--- a/parachain/runtime/tests/test_staked_relayers.rs
+++ b/parachain/runtime/tests/test_staked_relayers.rs
@@ -31,10 +31,6 @@ fn test_vault_theft(submit_by_relayer: bool) {
             vault_btc_address
         ));
 
-        // register as staked relayer
-        assert_ok!(Call::StakedRelayers(StakedRelayersCall::register_staked_relayer(100))
-            .dispatch(origin_of(account_of(user))));
-
         let initial_sla = SlaPallet::relayer_sla(account_of(ALICE));
 
         let (_tx_id, _height, proof, raw_tx, _) = TransactionGenerator::new()
@@ -49,7 +45,7 @@ fn test_vault_theft(submit_by_relayer: bool) {
         let mut expected_sla = initial_sla
             + FixedI128::checked_from_integer(7)
                 .unwrap()
-                .checked_mul(&SlaPallet::relayer_block_submission())
+                .checked_mul(&SlaPallet::relayer_store_block())
                 .unwrap();
         assert_eq!(SlaPallet::relayer_sla(account_of(ALICE)), expected_sla);
 
@@ -62,7 +58,7 @@ fn test_vault_theft(submit_by_relayer: bool) {
             );
 
             // check sla increase for the theft report
-            expected_sla = expected_sla + SlaPallet::relayer_correct_theft_report();
+            expected_sla = expected_sla + SlaPallet::relayer_theft_report();
             assert_eq!(SlaPallet::relayer_sla(account_of(ALICE)), expected_sla);
         } else {
             assert_ok!(
@@ -90,15 +86,6 @@ fn test_staked_relayer_parachain_status_check_fails() {
 
         assert_noop!(
             Call::StakedRelayers(StakedRelayersCall::initialize(Default::default(), 0))
-                .dispatch(origin_of(account_of(ALICE))),
-            SecurityError::ParachainShutdown
-        );
-        assert_noop!(
-            Call::StakedRelayers(StakedRelayersCall::register_staked_relayer(0)).dispatch(origin_of(account_of(ALICE))),
-            SecurityError::ParachainShutdown
-        );
-        assert_noop!(
-            Call::StakedRelayers(StakedRelayersCall::deregister_staked_relayer())
                 .dispatch(origin_of(account_of(ALICE))),
             SecurityError::ParachainShutdown
         );

--- a/parachain/src/chain_spec.rs
+++ b/parachain/src/chain_spec.rs
@@ -445,9 +445,8 @@ fn testnet_genesis(
             vault_submit_issue_proof: FixedI128::from(1),
             vault_refund: FixedI128::from(1),
             relayer_target_sla: FixedI128::from(100),
-            relayer_block_submission: FixedI128::from(1),
-            relayer_duplicate_block_submission: FixedI128::from(1),
-            relayer_correct_theft_report: FixedI128::from(1),
+            relayer_store_block: FixedI128::from(1),
+            relayer_theft_report: FixedI128::from(1),
         },
         refund: RefundConfig {
             refund_btc_dust_value: 1000,


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Remove the unnecessary storage fields and types from the staked-relayers pallet. Also removes the sla reward for duplicate block submission since there is no efficient way to prevent spamming.