### PR TITLE
[BREAKING] Fix: redeem events

### DIFF
--- a/crates/redeem/src/lib.rs
+++ b/crates/redeem/src/lib.rs
@@ -104,8 +104,8 @@ decl_event!(
         LiquidationRedeem(AccountId, Wrapped),
         // [redeem_id, redeemer, amount_wrapped, fee_wrapped, vault]
         ExecuteRedeem(H256, AccountId, Wrapped, Wrapped, AccountId),
-        // [redeem_id, redeemer, vault_id, slashing_amount_in_collateral, reimburse]
-        CancelRedeem(H256, AccountId, AccountId, Collateral, bool),
+        // [redeem_id, redeemer, vault_id, slashing_amount_in_collateral, status]
+        CancelRedeem(H256, AccountId, AccountId, Collateral, RedeemRequestStatus),
         // [vault_id, redeem_id, amount_minted]
         MintTokensForReimbursedRedeem(AccountId, H256, Wrapped),
     }
@@ -485,7 +485,7 @@ impl<T: Config> Module<T> {
         };
 
         // first update the issued tokens; this logic is the same regardless of whether or not the vault is liquidated
-        if reimburse {
+        let new_status = if reimburse {
             // Transfer the transaction fee to the pool. Even though the redeem was not
             // successful, the user receives a premium in collateral, so it's OK to take the fee.
             ext::treasury::unlock_and_transfer::<T>(
@@ -499,7 +499,7 @@ impl<T: Config> Module<T> {
                 // vault can not afford to back the tokens that he would receive, so we burn it
                 ext::treasury::burn::<T>(redeemer.clone(), vault_to_be_burned_tokens)?;
                 ext::vault_registry::decrease_tokens::<T>(&redeem.vault, &redeem.redeemer, vault_to_be_burned_tokens)?;
-                Self::set_redeem_status(redeem_id, RedeemRequestStatus::Reimbursed(false));
+                Self::set_redeem_status(redeem_id, RedeemRequestStatus::Reimbursed(false))
             } else {
                 // Transfer the rest of the user's issued tokens (i.e. excluding fee) to the vault
                 ext::treasury::unlock_and_transfer::<T>(
@@ -508,7 +508,7 @@ impl<T: Config> Module<T> {
                     vault_to_be_burned_tokens,
                 )?;
                 ext::vault_registry::decrease_to_be_redeemed_tokens::<T>(&vault_id, vault_to_be_burned_tokens)?;
-                Self::set_redeem_status(redeem_id, RedeemRequestStatus::Reimbursed(true));
+                Self::set_redeem_status(redeem_id, RedeemRequestStatus::Reimbursed(true))
             }
         } else {
             // unlock user's issued tokens, including fee
@@ -520,8 +520,8 @@ impl<T: Config> Module<T> {
                 .ok_or(Error::<T>::ArithmeticOverflow)?;
             ext::treasury::unlock::<T>(redeemer.clone(), total_wrapped)?;
             ext::vault_registry::decrease_to_be_redeemed_tokens::<T>(&vault_id, vault_to_be_burned_tokens)?;
-            Self::set_redeem_status(redeem_id, RedeemRequestStatus::Retried);
-        }
+            Self::set_redeem_status(redeem_id, RedeemRequestStatus::Retried)
+        };
 
         ext::sla::event_update_vault_sla::<T>(&vault_id, ext::sla::VaultEvent::RedeemFailure)?;
         Self::deposit_event(<Event<T>>::CancelRedeem(
@@ -529,7 +529,7 @@ impl<T: Config> Module<T> {
             redeemer,
             redeem.vault,
             slashed_amount,
-            reimburse,
+            new_status,
         ));
 
         Ok(())
@@ -561,9 +561,9 @@ impl<T: Config> Module<T> {
         Self::set_redeem_status(redeem_id, RedeemRequestStatus::Reimbursed(true));
 
         Self::deposit_event(<Event<T>>::MintTokensForReimbursedRedeem(
-            vault_id,
+            redeem.vault,
             redeem_id,
-            amount_wrapped,
+            reimbursed_amount,
         ));
 
         Ok(())
@@ -593,11 +593,12 @@ impl<T: Config> Module<T> {
         <RedeemRequests<T>>::insert(key, value)
     }
 
-    fn set_redeem_status(id: H256, status: RedeemRequestStatus) {
-        // TODO: delete redeem request from storage
+    fn set_redeem_status(id: H256, status: RedeemRequestStatus) -> RedeemRequestStatus {
         <RedeemRequests<T>>::mutate(id, |request| {
-            request.status = status;
+            request.status = status.clone();
         });
+
+        status
     }
 
     /// Fetch all redeem requests for the specified account.

--- a/crates/redeem/src/tests.rs
+++ b/crates/redeem/src/tests.rs
@@ -520,7 +520,13 @@ fn test_cancel_redeem_succeeds() {
             Redeem::get_open_redeem_request_from_id(&H256([0u8; 32])),
             TestError::RedeemCancelled,
         );
-        assert_emitted!(Event::CancelRedeem(H256([0; 32]), ALICE, BOB, 0, false));
+        assert_emitted!(Event::CancelRedeem(
+            H256([0; 32]),
+            ALICE,
+            BOB,
+            0,
+            RedeemRequestStatus::Retried
+        ));
     })
 }
 

--- a/crates/redeem/src/types.rs
+++ b/crates/redeem/src/types.rs
@@ -24,7 +24,7 @@ pub(crate) type Collateral<T> = <<T as currency::Config<currency::Collateral>>::
 pub(crate) type Wrapped<T> =
     <<T as currency::Config<currency::Wrapped>>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 
-#[derive(Encode, Decode, Clone, PartialEq)]
+#[derive(Encode, Decode, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
 pub enum RedeemRequestStatus {
     Pending,


### PR DESCRIPTION
The breaking change here is the `CancelRedeem` event - its last field is now of type `RedeemRequestStatus`.

Non-breaking change: added MintTokensForReimbursedRedeem event