### PR TITLE
Nomination withdrawal

### DIFF
--- a/crates/currency/src/lib.rs
+++ b/crates/currency/src/lib.rs
@@ -303,8 +303,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
     /// * `destination` - the account receiving tokens
     /// * `amount` - the amount to transfer
     pub fn unlock_and_transfer(
-        source: T::AccountId,
-        destination: T::AccountId,
+        source: &T::AccountId,
+        destination: &T::AccountId,
         amount: BalanceOf<T, I>,
     ) -> DispatchResult {
         // repatriate_reserved but create account

--- a/crates/nomination/src/default_weights.rs
+++ b/crates/nomination/src/default_weights.rs
@@ -24,19 +24,9 @@ impl crate::WeightInfo for () {
             .saturating_add(DbWeight::get().reads(10 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
-    fn request_collateral_withdrawal() -> Weight {
+    fn withdraw_collateral() -> Weight {
         (218_546_000 as Weight)
             .saturating_add(DbWeight::get().reads(12 as Weight))
-            .saturating_add(DbWeight::get().writes(3 as Weight))
-    }
-    fn execute_collateral_withdrawal() -> Weight {
-        (97_129_000 as Weight)
-            .saturating_add(DbWeight::get().reads(5 as Weight))
-            .saturating_add(DbWeight::get().writes(3 as Weight))
-    }
-    fn cancel_collateral_withdrawal() -> Weight {
-        (97_129_000 as Weight)
-            .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
 }

--- a/crates/nomination/src/ext.rs
+++ b/crates/nomination/src/ext.rs
@@ -27,11 +27,19 @@ pub(crate) mod collateral {
     type CollateralPallet<T> = currency::Pallet<T, currency::Backing>;
 
     pub fn transfer_and_lock<T: currency::Config<currency::Backing>>(
-        source: T::AccountId,
-        destination: T::AccountId,
+        source: &T::AccountId,
+        destination: &T::AccountId,
         amount: Backing<T>,
     ) -> DispatchResult {
-        CollateralPallet::<T>::transfer_and_lock(&source, &destination, amount)
+        CollateralPallet::<T>::transfer_and_lock(source, destination, amount)
+    }
+
+    pub fn unlock_and_transfer<T: currency::Config<currency::Backing>>(
+        source: &T::AccountId,
+        destination: &T::AccountId,
+        amount: Backing<T>,
+    ) -> DispatchResult {
+        CollateralPallet::<T>::unlock_and_transfer(source, destination, amount)
     }
 }
 

--- a/crates/nomination/src/ext.rs
+++ b/crates/nomination/src/ext.rs
@@ -82,6 +82,13 @@ pub(crate) mod vault_registry {
     pub fn compute_collateral<T: vault_registry::Config>(id: &T::AccountId) -> Result<Backing<T>, DispatchError> {
         <vault_registry::Pallet<T>>::compute_collateral(id)
     }
+
+    pub fn is_allowed_to_withdraw_collateral<T: vault_registry::Config>(
+        id: &T::AccountId,
+        amount: Backing<T>,
+    ) -> Result<bool, DispatchError> {
+        <vault_registry::Pallet<T>>::is_allowed_to_withdraw_collateral(id, amount)
+    }
 }
 
 #[cfg_attr(test, mockable)]

--- a/crates/nomination/src/ext.rs
+++ b/crates/nomination/src/ext.rs
@@ -46,7 +46,9 @@ pub(crate) mod collateral {
 #[cfg_attr(test, mockable)]
 pub(crate) mod vault_registry {
     use crate::Backing;
-    pub use ::vault_registry::{DefaultVault, SlashingError, TryDepositCollateral, TryWithdrawCollateral, VaultStatus};
+    pub use ::vault_registry::{
+        DefaultVault, Slashable, SlashingError, TryDepositCollateral, TryWithdrawCollateral, VaultStatus,
+    };
     pub use frame_support::dispatch::{DispatchError, DispatchResult};
 
     pub fn get_backing_collateral<T: vault_registry::Config>(

--- a/crates/nomination/src/tests.rs
+++ b/crates/nomination/src/tests.rs
@@ -1,31 +1,142 @@
-use crate::mock::*;
-use frame_support::assert_err;
-use vault_registry::{BtcPublicKey, VaultStatus, Wallet};
+use std::sync::{Arc, Mutex};
 
-fn dummy_public_key() -> BtcPublicKey {
-    BtcPublicKey([
-        2, 205, 114, 218, 156, 16, 235, 172, 106, 37, 18, 153, 202, 140, 176, 91, 207, 51, 187, 55, 18, 45, 222, 180,
-        119, 54, 243, 97, 173, 150, 161, 169, 230,
-    ])
+use crate::mock::*;
+use frame_support::{assert_err, assert_ok};
+use sp_arithmetic::FixedI128;
+use vault_registry::{Collateral, Slashable, SlashingError, TryDepositCollateral, TryWithdrawCollateral};
+
+#[derive(Default)]
+struct SimpleVault {
+    collateral: u128,
+    total_collateral: u128,
+    backing_collateral: u128,
+    slash_per_token: FixedI128,
+    slash_tally: FixedI128,
 }
 
-fn register_vault(id: u64) {
-    <vault_registry::Pallet<Test>>::insert_vault(
-        &id,
-        vault_registry::Vault {
-            id,
-            to_be_replaced_tokens: 0,
-            to_be_issued_tokens: 0,
-            issued_tokens: 10,
-            to_be_redeemed_tokens: 0,
-            replace_collateral: 0,
-            backing_collateral: 100,
-            wallet: Wallet::new(dummy_public_key()),
-            banned_until: None,
-            status: VaultStatus::Active(true),
-            ..Default::default()
-        },
-    );
+impl Slashable<u128, FixedI128, SlashingError> for SimpleVault {
+    fn mut_slash_per_token<F>(&mut self, func: F) -> Result<(), SlashingError>
+    where
+        F: Fn(&mut FixedI128) -> Result<(), SlashingError>,
+    {
+        func(&mut self.slash_per_token)
+    }
+}
+
+impl Collateral<u128, FixedI128, SlashingError> for SimpleVault {
+    fn get_slash_per_token(&self) -> Result<FixedI128, SlashingError> {
+        Ok(self.slash_per_token)
+    }
+
+    fn get_collateral(&self) -> u128 {
+        self.collateral
+    }
+
+    fn mut_collateral<F>(&mut self, func: F) -> Result<(), SlashingError>
+    where
+        F: Fn(&mut u128) -> Result<(), SlashingError>,
+    {
+        func(&mut self.collateral)
+    }
+
+    fn get_total_collateral(&self) -> Result<u128, SlashingError> {
+        Ok(self.total_collateral)
+    }
+
+    fn mut_total_collateral<F>(&mut self, func: F) -> Result<(), SlashingError>
+    where
+        F: Fn(&mut u128) -> Result<(), SlashingError>,
+    {
+        func(&mut self.total_collateral)
+    }
+
+    fn get_backing_collateral(&self) -> Result<u128, SlashingError> {
+        Ok(self.backing_collateral)
+    }
+
+    fn mut_backing_collateral<F>(&mut self, func: F) -> Result<(), SlashingError>
+    where
+        F: Fn(&mut u128) -> Result<(), SlashingError>,
+    {
+        func(&mut self.backing_collateral)
+    }
+
+    fn get_slash_tally(&self) -> FixedI128 {
+        self.slash_tally
+    }
+
+    fn mut_slash_tally<F>(&mut self, func: F) -> Result<(), SlashingError>
+    where
+        F: Fn(&mut FixedI128) -> Result<(), SlashingError>,
+    {
+        func(&mut self.slash_tally)
+    }
+}
+
+struct SimpleNominator {
+    collateral: u128,
+    slash_tally: FixedI128,
+    vault: Arc<Mutex<SimpleVault>>,
+}
+
+impl SimpleNominator {
+    pub fn new(arc_vault: Arc<Mutex<SimpleVault>>) -> Self {
+        SimpleNominator {
+            collateral: Default::default(),
+            slash_tally: Default::default(),
+            vault: arc_vault,
+        }
+    }
+}
+
+impl Collateral<u128, FixedI128, SlashingError> for SimpleNominator {
+    fn get_slash_per_token(&self) -> Result<FixedI128, SlashingError> {
+        self.vault.lock().unwrap().get_slash_per_token()
+    }
+
+    fn get_collateral(&self) -> u128 {
+        self.collateral
+    }
+
+    fn mut_collateral<F>(&mut self, func: F) -> Result<(), SlashingError>
+    where
+        F: Fn(&mut u128) -> Result<(), SlashingError>,
+    {
+        func(&mut self.collateral)
+    }
+
+    fn get_total_collateral(&self) -> Result<u128, SlashingError> {
+        self.vault.lock().unwrap().get_total_collateral()
+    }
+
+    fn mut_total_collateral<F>(&mut self, func: F) -> Result<(), SlashingError>
+    where
+        F: Fn(&mut u128) -> Result<(), SlashingError>,
+    {
+        self.vault.lock().unwrap().mut_total_collateral(func)
+    }
+
+    fn get_backing_collateral(&self) -> Result<u128, SlashingError> {
+        self.vault.lock().unwrap().get_backing_collateral()
+    }
+
+    fn mut_backing_collateral<F>(&mut self, func: F) -> Result<(), SlashingError>
+    where
+        F: Fn(&mut u128) -> Result<(), SlashingError>,
+    {
+        self.vault.lock().unwrap().mut_backing_collateral(func)
+    }
+
+    fn get_slash_tally(&self) -> FixedI128 {
+        self.slash_tally
+    }
+
+    fn mut_slash_tally<F>(&mut self, func: F) -> Result<(), SlashingError>
+    where
+        F: Fn(&mut FixedI128) -> Result<(), SlashingError>,
+    {
+        func(&mut self.slash_tally)
+    }
 }
 
 #[test]
@@ -38,14 +149,154 @@ fn test_non_vaults_cannot_become_operators() {
     })
 }
 
+fn nominate_slash_nominate(
+    arc_vault: Arc<Mutex<SimpleVault>>,
+    nominator1: &mut SimpleNominator,
+    nominator2: &mut SimpleNominator,
+    vault_deposit: u128,
+    nominator1_deposit: u128,
+    nominator2_deposit: u128,
+    slash: u128,
+) {
+    let backing_collateral_at_slash = vault_deposit + nominator1_deposit;
+    assert_ok!(arc_vault.lock().unwrap().try_deposit_collateral(vault_deposit));
+    assert_ok!(nominator1.try_deposit_collateral(nominator1_deposit));
+    assert_ok!(arc_vault.lock().unwrap().slash_collateral(slash));
+    assert_ok!(nominator2.try_deposit_collateral(nominator2_deposit));
+    assert_ok!(
+        arc_vault.lock().unwrap().get_backing_collateral(),
+        backing_collateral_at_slash - slash + nominator2_deposit
+    );
+    assert_ok!(
+        arc_vault.lock().unwrap().compute_collateral(),
+        vault_deposit - slash * vault_deposit / backing_collateral_at_slash - 1
+    );
+}
+
 #[test]
-fn test_regular_vaults_cannot_opt_out() {
-    run_test(|| {
-        register_vault(BOB);
-        assert_eq!(Nomination::is_operator(&BOB).unwrap(), false);
-        assert_err!(
-            Nomination::opt_out_of_nomination(Origin::signed(BOB)),
-            TestError::VaultNotOptedInToNomination
-        );
-    });
+fn test_nomination_slash_should_be_correct() {
+    let vault_deposit = 10000;
+    let nominator1_deposit = 5000;
+    let nominator2_deposit = 4000;
+    let slash = 100;
+    let backing_collateral_at_slash = vault_deposit + nominator1_deposit;
+
+    let vault = SimpleVault::default();
+    let arc_vault = Arc::new(Mutex::new(vault));
+    let mut nominator1 = SimpleNominator::new(arc_vault.clone());
+    let mut nominator2 = SimpleNominator::new(arc_vault.clone());
+
+    nominate_slash_nominate(
+        arc_vault.clone(),
+        &mut nominator1,
+        &mut nominator2,
+        vault_deposit,
+        nominator1_deposit,
+        nominator2_deposit,
+        slash,
+    );
+
+    assert_ok!(
+        nominator1.compute_collateral(),
+        nominator1_deposit - slash * nominator1_deposit / backing_collateral_at_slash - 1
+    );
+    assert_ok!(nominator2.compute_collateral(), nominator2_deposit);
+}
+
+#[test]
+fn test_nomination_nominator_withdrawal_after_slash() {
+    let vault_deposit = 10000;
+    let nominator1_deposit = 5000;
+    let nominator2_deposit = 4000;
+    let slash = 100;
+    let backing_collateral_at_slash = vault_deposit + nominator1_deposit;
+
+    let vault = SimpleVault::default();
+    let arc_vault = Arc::new(Mutex::new(vault));
+    let mut nominator1 = SimpleNominator::new(arc_vault.clone());
+    let mut nominator2 = SimpleNominator::new(arc_vault.clone());
+
+    nominate_slash_nominate(
+        arc_vault.clone(),
+        &mut nominator1,
+        &mut nominator2,
+        vault_deposit,
+        nominator1_deposit,
+        nominator2_deposit,
+        slash,
+    );
+
+    assert_ok!(nominator1
+        .try_withdraw_collateral(nominator1_deposit - slash * nominator1_deposit / backing_collateral_at_slash - 1));
+    assert_ok!(nominator2.compute_collateral(), nominator2_deposit);
+}
+
+#[test]
+fn test_nomination_vault_withdrawal_after_slash() {
+    let vault_deposit = 10000;
+    let nominator1_deposit = 5000;
+    let nominator2_deposit = 4000;
+    let slash = 100;
+    let backing_collateral_at_slash = vault_deposit + nominator1_deposit;
+
+    let vault = SimpleVault::default();
+    let arc_vault = Arc::new(Mutex::new(vault));
+    let mut nominator1 = SimpleNominator::new(arc_vault.clone());
+    let mut nominator2 = SimpleNominator::new(arc_vault.clone());
+
+    nominate_slash_nominate(
+        arc_vault.clone(),
+        &mut nominator1,
+        &mut nominator2,
+        vault_deposit,
+        nominator1_deposit,
+        nominator2_deposit,
+        slash,
+    );
+
+    assert_ok!(arc_vault
+        .lock()
+        .unwrap()
+        .try_withdraw_collateral(vault_deposit - slash * vault_deposit / backing_collateral_at_slash - 1));
+    assert_ok!(nominator2.compute_collateral(), nominator2_deposit);
+}
+
+#[test]
+fn test_nomination_slash_twice() {
+    let vault_deposit = 10000;
+    let nominator1_deposit = 5000;
+    let nominator2_deposit = 4000;
+    let slash = 100;
+    let backing_collateral_at_first_slash = vault_deposit + nominator1_deposit;
+    let backing_collateral_at_second_slash = backing_collateral_at_first_slash - slash + nominator2_deposit;
+
+    let vault = SimpleVault::default();
+    let arc_vault = Arc::new(Mutex::new(vault));
+    let mut nominator1 = SimpleNominator::new(arc_vault.clone());
+    let mut nominator2 = SimpleNominator::new(arc_vault.clone());
+
+    nominate_slash_nominate(
+        arc_vault.clone(),
+        &mut nominator1,
+        &mut nominator2,
+        vault_deposit,
+        nominator1_deposit,
+        nominator2_deposit,
+        slash,
+    );
+    let nominator1_collateral_after_first_slash = nominator1.compute_collateral().unwrap();
+    let nominator2_collateral_after_first_slash = nominator2.compute_collateral().unwrap();
+    assert_ok!(arc_vault.lock().unwrap().slash_collateral(slash));
+
+    assert_ok!(
+        nominator1.compute_collateral(),
+        nominator1_collateral_after_first_slash
+            - slash * nominator1_collateral_after_first_slash / backing_collateral_at_second_slash
+    );
+    assert_ok!(
+        nominator2.compute_collateral(),
+        nominator2_collateral_after_first_slash
+            - slash * nominator2_collateral_after_first_slash / backing_collateral_at_second_slash
+            - 1
+    );
 }

--- a/crates/nomination/src/types.rs
+++ b/crates/nomination/src/types.rs
@@ -124,11 +124,6 @@ impl<T: Config> RichOperator<T> {
         self.data.id.clone()
     }
 
-    pub fn has_nominated_collateral(&self) -> bool {
-        // TODO: implement
-        true
-    }
-
     // pub fn withdraw_nominated_collateral(
     //     &mut self,
     //     nominator_id: T::AccountId,

--- a/crates/redeem/src/ext.rs
+++ b/crates/redeem/src/ext.rs
@@ -199,8 +199,8 @@ pub(crate) mod treasury {
     }
 
     pub fn unlock_and_transfer<T: currency::Config<currency::Issuing>>(
-        source: T::AccountId,
-        destination: T::AccountId,
+        source: &T::AccountId,
+        destination: &T::AccountId,
         amount: Issuing<T>,
     ) -> DispatchResult {
         TreasuryPallet::<T>::unlock_and_transfer(source, destination, amount)

--- a/crates/redeem/src/lib.rs
+++ b/crates/redeem/src/lib.rs
@@ -377,11 +377,7 @@ impl<T: Config> Module<T> {
         ext::treasury::burn::<T>(redeem.redeemer.clone(), burn_amount)?;
 
         // send fees to pool
-        ext::treasury::unlock_and_transfer::<T>(
-            &redeem.redeemer,
-            &ext::fee::fee_pool_account_id::<T>(),
-            redeem.fee,
-        )?;
+        ext::treasury::unlock_and_transfer::<T>(&redeem.redeemer, &ext::fee::fee_pool_account_id::<T>(), redeem.fee)?;
         ext::fee::distribute_issuing_rewards::<T>(redeem.fee)?;
 
         ext::vault_registry::redeem_tokens::<T>(&redeem.vault, burn_amount, redeem.premium, &redeem.redeemer)?;
@@ -500,11 +496,7 @@ impl<T: Config> Module<T> {
                 Self::set_redeem_status(redeem_id, RedeemRequestStatus::Reimbursed(false));
             } else {
                 // Transfer the rest of the user's issued tokens (i.e. excluding fee) to the vault
-                ext::treasury::unlock_and_transfer::<T>(
-                    &redeem.redeemer,
-                    &redeem.vault,
-                    vault_to_be_burned_tokens,
-                )?;
+                ext::treasury::unlock_and_transfer::<T>(&redeem.redeemer, &redeem.vault, vault_to_be_burned_tokens)?;
                 ext::vault_registry::decrease_to_be_redeemed_tokens::<T>(&vault_id, vault_to_be_burned_tokens)?;
                 Self::set_redeem_status(redeem_id, RedeemRequestStatus::Reimbursed(true));
             }

--- a/crates/redeem/src/lib.rs
+++ b/crates/redeem/src/lib.rs
@@ -378,8 +378,8 @@ impl<T: Config> Module<T> {
 
         // send fees to pool
         ext::treasury::unlock_and_transfer::<T>(
-            redeem.redeemer.clone(),
-            ext::fee::fee_pool_account_id::<T>(),
+            &redeem.redeemer,
+            &ext::fee::fee_pool_account_id::<T>(),
             redeem.fee,
         )?;
         ext::fee::distribute_issuing_rewards::<T>(redeem.fee)?;
@@ -487,8 +487,8 @@ impl<T: Config> Module<T> {
             // Transfer the transaction fee to the pool. Even though the redeem was not
             // successful, the user receives a premium in collateral, so it's to take the fee.
             ext::treasury::unlock_and_transfer::<T>(
-                redeem.redeemer.clone(),
-                ext::fee::fee_pool_account_id::<T>(),
+                &redeem.redeemer,
+                &ext::fee::fee_pool_account_id::<T>(),
                 redeem.fee,
             )?;
             ext::fee::distribute_issuing_rewards::<T>(redeem.fee)?;
@@ -501,8 +501,8 @@ impl<T: Config> Module<T> {
             } else {
                 // Transfer the rest of the user's issued tokens (i.e. excluding fee) to the vault
                 ext::treasury::unlock_and_transfer::<T>(
-                    redeem.redeemer.clone(),
-                    redeem.vault.clone(),
+                    &redeem.redeemer,
+                    &redeem.vault,
                     vault_to_be_burned_tokens,
                 )?;
                 ext::vault_registry::decrease_to_be_redeemed_tokens::<T>(&vault_id, vault_to_be_burned_tokens)?;

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -1512,7 +1512,7 @@ impl<T: Config> Pallet<T> {
 
     /// Private getters and setters
 
-    pub fn get_rich_vault_from_id(vault_id: &T::AccountId) -> Result<RichVault<T>, DispatchError> {
+    fn get_rich_vault_from_id(vault_id: &T::AccountId) -> Result<RichVault<T>, DispatchError> {
         Ok(Self::get_vault_from_id(vault_id)?.into())
     }
 

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -28,16 +28,13 @@ extern crate mocktopus;
 #[cfg(test)]
 use mocktopus::macros::mockable;
 
-use crate::{
-    slash::Slashable,
-    types::{
-        Backing, BtcAddress, DefaultSystemVault, Inner, Issuing, RichSystemVault, RichVault, SignedFixedPoint,
-        UnsignedFixedPoint, UpdatableVault, Version,
-    },
+use crate::types::{
+    Backing, BtcAddress, DefaultSystemVault, Inner, Issuing, RichSystemVault, RichVault, SignedFixedPoint,
+    UnsignedFixedPoint, UpdatableVault, Version,
 };
 #[doc(inline)]
 pub use crate::{
-    slash::{TryDepositCollateral, TryWithdrawCollateral},
+    slash::{Slashable, TryDepositCollateral, TryWithdrawCollateral},
     types::{BtcPublicKey, CurrencySource, DefaultVault, SystemVault, Vault, VaultStatus, Wallet},
 };
 use codec::{Decode, Encode, EncodeLike};
@@ -1514,7 +1511,7 @@ impl<T: Config> Pallet<T> {
 
     /// Private getters and setters
 
-    fn get_rich_vault_from_id(vault_id: &T::AccountId) -> Result<RichVault<T>, DispatchError> {
+    pub fn get_rich_vault_from_id(vault_id: &T::AccountId) -> Result<RichVault<T>, DispatchError> {
         Ok(Self::get_vault_from_id(vault_id)?.into())
     }
 

--- a/crates/vault-registry/src/slash.rs
+++ b/crates/vault-registry/src/slash.rs
@@ -101,7 +101,7 @@ macro_rules! checked_sub_mut {
     };
 }
 
-pub(crate) trait Slashable<
+pub trait Slashable<
     Backing: TryInto<u128> + TryFrom<u128> + CheckedSub,
     SignedFixedPoint: FixedPointNumber,
     E: From<SlashingError>,

--- a/parachain/runtime/Cargo.toml
+++ b/parachain/runtime/Cargo.toml
@@ -106,7 +106,7 @@ substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", bran
 # https://github.com/paritytech/substrate/issues/8161
 
 [features]
-default = ["std", "aura-grandpa"]
+default = ["std"]
 std = [
   "serde",
   "codec/std",

--- a/parachain/runtime/Cargo.toml
+++ b/parachain/runtime/Cargo.toml
@@ -106,7 +106,7 @@ substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", bran
 # https://github.com/paritytech/substrate/issues/8161
 
 [features]
-default = ["std"]
+default = ["std", "aura-grandpa"]
 std = [
   "serde",
   "codec/std",

--- a/parachain/runtime/tests/mock/mod.rs
+++ b/parachain/runtime/tests/mock/mod.rs
@@ -430,36 +430,20 @@ impl CoreVaultData {
     }
 }
 
-// #[derive(Debug, PartialEq, Clone)]
-// pub struct CoreNominatorData {
-//     pub collateral_to_be_withdrawn: u128,
-// }
+#[derive(Debug, PartialEq, Clone)]
+pub struct CoreNominatorData {
+    pub collateral_to_be_withdrawn: u128,
+}
 
-// impl Default for CoreNominatorData {
-//     fn default() -> Self {
-//         CoreNominatorData {
-//             collateral_to_be_withdrawn: 0,
-//         }
-//     }
-// }
+impl Default for CoreNominatorData {
+    fn default() -> Self {
+        CoreNominatorData {
+            collateral_to_be_withdrawn: 0,
+        }
+    }
+}
 
-// impl CoreNominatorData {
-//     pub fn nominators(
-//         nominators: Vec<(AccountId, Nominator<AccountId, BlockNumber, u128, SignedFixedPoint>)>,
-//     ) -> BTreeMap<AccountId, CoreNominatorData> {
-//         let mut nominators_map: BTreeMap<AccountId, CoreNominatorData> = BTreeMap::new();
-//         for (_, nominator) in nominators {
-//             nominators_map.insert(
-//                 nominator.id.clone(),
-//                 CoreNominatorData {
-//                     collateral: nominator.collateral,
-//                     collateral_to_be_withdrawn: nominator.collateral_to_be_withdrawn,
-//                 },
-//             );
-//         }
-//         nominators_map
-//     }
-// }
+impl CoreNominatorData {}
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct CoreOperatorData {
@@ -489,7 +473,6 @@ impl CoreOperatorData {
 pub struct ParachainState {
     user: UserData,
     vault: CoreVaultData,
-    operator: CoreOperatorData,
     liquidation_vault: CoreVaultData,
     fee_pool: FeePool,
 }
@@ -499,7 +482,6 @@ impl Default for ParachainState {
         Self {
             user: default_user_state(),
             vault: default_vault_state(),
-            operator: default_operator_state(),
             liquidation_vault: CoreVaultData {
                 free_balance: INITIAL_LIQUIDATION_VAULT_BALANCE,
                 ..Default::default()
@@ -516,13 +498,12 @@ impl ParachainState {
             vault: CoreVaultData::vault(BOB),
             liquidation_vault: CoreVaultData::liquidation_vault(),
             fee_pool: FeePool::get(),
-            operator: CoreOperatorData::operator(BOB),
         }
     }
 
     pub fn with_changes(
         &self,
-        f: impl FnOnce(&mut UserData, &mut CoreVaultData, &mut CoreVaultData, &mut FeePool, &mut CoreOperatorData),
+        f: impl FnOnce(&mut UserData, &mut CoreVaultData, &mut CoreVaultData, &mut FeePool),
     ) -> Self {
         let mut state = self.clone();
         f(
@@ -530,7 +511,6 @@ impl ParachainState {
             &mut state.vault,
             &mut state.liquidation_vault,
             &mut state.fee_pool,
-            &mut state.operator,
         );
         state
     }

--- a/parachain/runtime/tests/mock/nomination_testing_utils.rs
+++ b/parachain/runtime/tests/mock/nomination_testing_utils.rs
@@ -5,7 +5,7 @@ pub const VAULT: [u8; 32] = BOB;
 
 pub const DEFAULT_GRIEFING_COLLATERAL: u128 = 5_000;
 pub const DEFAULT_BACKING_COLLATERAL: u128 = 1_000_000;
-pub const DEFAULT_NOMINATION: u128 = 100_000;
+pub const DEFAULT_NOMINATION: u128 = 20_000;
 
 pub const DEFAULT_OPERATOR_UNBONDING_PERIOD: u32 = 100;
 pub const DEFAULT_NOMINATOR_UNBONDING_PERIOD: u32 = 50;
@@ -154,4 +154,8 @@ pub fn assert_nominator_withdrawal_request_event() -> H256 {
 pub fn assert_total_nominated_collateral_is(operator: [u8; 32], amount_backing: u128) {
     let nominated_collateral = NominationPallet::get_total_nominated_collateral(&account_of(operator)).unwrap();
     assert_eq!(nominated_collateral, amount_backing);
+}
+
+pub fn get_nominator_collateral(nominator: [u8; 32], operator: [u8; 32]) -> u128 {
+    NominationPallet::get_nominator_collateral(&account_of(nominator), &account_of(operator)).unwrap()
 }

--- a/parachain/runtime/tests/mock/nomination_testing_utils.rs
+++ b/parachain/runtime/tests/mock/nomination_testing_utils.rs
@@ -60,32 +60,16 @@ pub fn assert_nominate_collateral(nominator: [u8; 32], operator: [u8; 32], amoun
     assert_ok!(nominate_collateral(nominator, operator, amount_collateral));
 }
 
-pub fn request_operator_collateral_withdrawal(
-    operator: [u8; 32],
-    amount_collateral: u128,
-) -> DispatchResultWithPostInfo {
-    Call::Nomination(NominationCall::request_collateral_withdrawal(
+pub fn withdraw_operator_collateral(operator: [u8; 32], amount_collateral: u128) -> DispatchResultWithPostInfo {
+    Call::Nomination(NominationCall::withdraw_collateral(
         account_of(operator),
         amount_collateral,
     ))
     .dispatch(origin_of(account_of(operator)))
 }
 
-pub fn execute_operator_collateral_withdrawal(operator: [u8; 32]) -> DispatchResultWithPostInfo {
-    Call::Nomination(NominationCall::execute_collateral_withdrawal(account_of(operator)))
-        .dispatch(origin_of(account_of(operator)))
-}
-
-pub fn assert_request_operator_collateral_withdrawal(operator: [u8; 32], amount_dot: u128) {
-    assert_ok!(request_operator_collateral_withdrawal(operator, amount_dot));
-}
-
-pub fn cancel_operator_collateral_withdrawal(operator: [u8; 32], request_id: H256) -> DispatchResultWithPostInfo {
-    Call::Nomination(NominationCall::cancel_collateral_withdrawal(
-        account_of(operator),
-        request_id,
-    ))
-    .dispatch(origin_of(account_of(operator)))
+pub fn assert_withdraw_operator_collateral(operator: [u8; 32], amount_dot: u128) {
+    assert_ok!(withdraw_operator_collateral(operator, amount_dot));
 }
 
 pub fn assert_operator_withdrawal_request_event() -> H256 {
@@ -104,37 +88,20 @@ pub fn assert_operator_withdrawal_request_event() -> H256 {
     }
 }
 
-pub fn request_nominator_collateral_withdrawal(
+pub fn withdraw_nominator_collateral(
     nominator: [u8; 32],
     operator: [u8; 32],
     amount_collateral: u128,
 ) -> DispatchResultWithPostInfo {
-    Call::Nomination(NominationCall::request_collateral_withdrawal(
+    Call::Nomination(NominationCall::withdraw_collateral(
         account_of(operator),
         amount_collateral,
     ))
     .dispatch(origin_of(account_of(nominator)))
 }
 
-pub fn execute_nominator_collateral_withdrawal(nominator: [u8; 32], operator: [u8; 32]) -> DispatchResultWithPostInfo {
-    Call::Nomination(NominationCall::execute_collateral_withdrawal(account_of(operator)))
-        .dispatch(origin_of(account_of(nominator)))
-}
-
-pub fn assert_request_nominator_collateral_withdrawal(nominator: [u8; 32], operator: [u8; 32], amount_dot: u128) {
-    assert_ok!(request_nominator_collateral_withdrawal(nominator, operator, amount_dot));
-}
-
-pub fn cancel_nominator_collateral_withdrawal(
-    nominator: [u8; 32],
-    operator: [u8; 32],
-    request_id: H256,
-) -> DispatchResultWithPostInfo {
-    Call::Nomination(NominationCall::cancel_collateral_withdrawal(
-        account_of(operator),
-        request_id,
-    ))
-    .dispatch(origin_of(account_of(nominator)))
+pub fn assert_withdraw_nominator_collateral(nominator: [u8; 32], operator: [u8; 32], amount_dot: u128) {
+    assert_ok!(withdraw_nominator_collateral(nominator, operator, amount_dot));
 }
 
 pub fn assert_nominator_withdrawal_request_event() -> H256 {

--- a/parachain/runtime/tests/test_issue.rs
+++ b/parachain/runtime/tests/test_issue.rs
@@ -278,7 +278,7 @@ fn integration_test_issue_issuing_execute_bookkeeping() {
 
         assert_eq!(
             ParachainState::get(),
-            ParachainState::default().with_changes(|user, vault, _, fee_pool, _| {
+            ParachainState::default().with_changes(|user, vault, _, fee_pool| {
                 user.free_tokens += issue.amount;
                 fee_pool.vault_issuing_rewards += vault_rewards(issue.fee);
                 vault.issued += issue.fee + issue.amount;
@@ -345,7 +345,7 @@ fn integration_test_issue_overpayment() {
 
         assert_eq!(
             ParachainState::get(),
-            ParachainState::default().with_changes(|user, vault, _, fee_pool, _| {
+            ParachainState::default().with_changes(|user, vault, _, fee_pool| {
                 user.free_tokens += 2 * issue.amount;
                 fee_pool.vault_issuing_rewards += 2 * vault_rewards(issue.fee);
                 vault.issued += sent_btc;
@@ -385,7 +385,7 @@ fn integration_test_issue_refund() {
         let post_redeem_state = ParachainState::get();
         assert_eq!(
             post_redeem_state,
-            initial_state.with_changes(|user, vault, _, fee_pool, _| {
+            initial_state.with_changes(|user, vault, _, fee_pool| {
                 user.free_tokens += issue.amount;
                 fee_pool.vault_issuing_rewards += vault_rewards(issue.fee);
                 vault.issued += issue.fee + issue.amount;
@@ -397,7 +397,7 @@ fn integration_test_issue_refund() {
 
         assert_eq!(
             ParachainState::get(),
-            post_redeem_state.with_changes(|_user, vault, _, _fee_pool, _| {
+            post_redeem_state.with_changes(|_user, vault, _, _fee_pool| {
                 vault.free_tokens += issue.fee * 3;
                 vault.issued += issue.fee * 3;
             })
@@ -427,7 +427,7 @@ fn integration_test_issue_underpayment_succeeds() {
 
         assert_eq!(
             ParachainState::get(),
-            ParachainState::default().with_changes(|user, vault, _, fee_pool, _| {
+            ParachainState::default().with_changes(|user, vault, _, fee_pool| {
                 // user loses 75% of griefing collateral for having only fulfilled 25%
                 user.free_balance -= slashed_griefing_collateral;
                 fee_pool.vault_backing_rewards += vault_rewards(slashed_griefing_collateral);
@@ -484,7 +484,7 @@ fn integration_test_issue_issuing_cancel() {
 
         assert_eq!(
             ParachainState::get(),
-            ParachainState::default().with_changes(|user, _vault, _, fee_pool, _| {
+            ParachainState::default().with_changes(|user, _vault, _, fee_pool| {
                 user.free_balance -= issue.griefing_collateral;
                 fee_pool.vault_backing_rewards += vault_rewards(issue.griefing_collateral);
             })
@@ -513,7 +513,7 @@ fn integration_test_issue_issuing_cancel_liquidated() {
 
         assert_eq!(
             ParachainState::get(),
-            post_liquidation_status.with_changes(|user, _vault, liquidation_vault, _fee_pool, _| {
+            post_liquidation_status.with_changes(|user, _vault, liquidation_vault, _fee_pool| {
                 // griefing collateral released instead of slashed
                 user.locked_balance -= issue.griefing_collateral;
                 user.free_balance += issue.griefing_collateral;
@@ -536,7 +536,7 @@ fn integration_test_issue_issuing_execute_liquidated() {
 
         assert_eq!(
             ParachainState::get(),
-            post_liquidation_status.with_changes(|user, _vault, liquidation_vault, fee_pool, _| {
+            post_liquidation_status.with_changes(|user, _vault, liquidation_vault, fee_pool| {
                 user.free_tokens += issue.amount;
                 fee_pool.vault_issuing_rewards += vault_rewards(issue.fee);
 

--- a/parachain/runtime/tests/test_nomination.rs
+++ b/parachain/runtime/tests/test_nomination.rs
@@ -90,7 +90,7 @@ fn integration_test_operators_cannot_withdraw_nominated_collateral() {
     test_with_nomination_enabled_and_operator_registered(|| {
         assert_nominate_collateral(USER, VAULT, DEFAULT_NOMINATION);
         assert_noop!(
-            request_operator_collateral_withdrawal(VAULT, DEFAULT_BACKING_COLLATERAL + 1),
+            withdraw_operator_collateral(VAULT, DEFAULT_BACKING_COLLATERAL + 1),
             NominationError::InsufficientCollateral
         );
     });
@@ -150,7 +150,7 @@ fn integration_test_nominator_withdrawal_request_reduces_issuable_tokens() {
         assert_nominate_collateral(USER, VAULT, DEFAULT_NOMINATION);
         let issuance_capacity_before_withdrawal_request =
             VaultRegistryPallet::get_issuable_tokens_from_vault(account_of(VAULT)).unwrap();
-        assert_ok!(request_nominator_collateral_withdrawal(USER, VAULT, DEFAULT_NOMINATION));
+        assert_ok!(withdraw_nominator_collateral(USER, VAULT, DEFAULT_NOMINATION));
         let issuance_capacity_after_withdrawal_request =
             VaultRegistryPallet::get_issuable_tokens_from_vault(account_of(VAULT)).unwrap();
         assert_eq!(issuance_capacity_before_withdrawal_request, 570000);
@@ -170,7 +170,7 @@ fn integration_test_nominator_withdrawal_below_collateralization_threshold_fails
             FixedU128::checked_from_integer(3).unwrap()
         ));
         assert_noop!(
-            request_nominator_collateral_withdrawal(USER, VAULT, DEFAULT_NOMINATION),
+            withdraw_nominator_collateral(USER, VAULT, DEFAULT_NOMINATION),
             NominationError::InsufficientCollateral
         );
     });

--- a/parachain/runtime/tests/test_redeem.rs
+++ b/parachain/runtime/tests/test_redeem.rs
@@ -112,7 +112,7 @@ mod request_redeem_tests {
 
             assert_eq!(
                 ParachainState::get(),
-                ParachainState::default().with_changes(|user, vault, _, _, _| {
+                ParachainState::default().with_changes(|user, vault, _, _| {
                     vault.to_be_redeemed += redeem.amount_btc + redeem.transfer_fee_btc;
                     user.free_tokens -= redeem.amount_btc + redeem.transfer_fee_btc + redeem.fee;
                     user.locked_tokens += redeem.amount_btc + redeem.transfer_fee_btc + redeem.fee;
@@ -297,7 +297,7 @@ fn integration_test_redeem_issuing_execute() {
 
         assert_eq!(
             ParachainState::get(),
-            ParachainState::default().with_changes(|user, vault, _, fee_pool, _| {
+            ParachainState::default().with_changes(|user, vault, _, fee_pool| {
                 vault.issued -= redeem.amount_btc + redeem.transfer_fee_btc;
                 user.free_tokens -= issued_tokens;
                 fee_pool.vault_issuing_rewards += vault_rewards(redeem.fee);
@@ -345,7 +345,7 @@ fn integration_test_premium_redeem_issuing_execute() {
 
         assert_eq!(
             ParachainState::get(),
-            ParachainState::default().with_changes(|user, vault, _, fee_pool, _| {
+            ParachainState::default().with_changes(|user, vault, _, fee_pool| {
                 // fee moves from user to fee_pool
                 user.free_tokens -= redeem.fee;
                 fee_pool.vault_issuing_rewards += vault_rewards(redeem.fee);
@@ -399,7 +399,7 @@ fn integration_test_redeem_issuing_liquidation_redeem() {
         // NOTE: changes are relative the the post liquidation state
         assert_eq!(
             ParachainState::get(),
-            post_liquidation_state.with_changes(|user, _vault, liquidation_vault, _fee_pool, _| {
+            post_liquidation_state.with_changes(|user, _vault, liquidation_vault, _fee_pool| {
                 let reward = (liquidation_vault.backing_collateral * liquidation_redeem_amount)
                     / (liquidation_vault.issued + liquidation_vault.to_be_issued);
 
@@ -432,7 +432,7 @@ fn integration_test_redeem_issuing_cancel_reimburse_sufficient_collateral_for_is
 
         assert_eq!(
             ParachainState::get(),
-            ParachainState::default().with_changes(|user, vault, _, fee_pool, _| {
+            ParachainState::default().with_changes(|user, vault, _, fee_pool| {
                 // with sla of 80, vault gets slashed for 115%: 110 to user, 5 to fee pool
 
                 fee_pool.vault_backing_rewards += vault_rewards(amount_without_fee_backing / 20);
@@ -483,7 +483,7 @@ fn integration_test_redeem_issuing_cancel_reimburse_insufficient_collateral_for_
 
         assert_eq!(
             ParachainState::get(),
-            initial_state.with_changes(|user, vault, _, fee_pool, _| {
+            initial_state.with_changes(|user, vault, _, fee_pool| {
                 // with sla of 80, vault gets slashed for 115%: 110 to user, 5 to fee pool
 
                 fee_pool.vault_backing_rewards += vault_rewards(amount_without_fee_as_backing / 20);
@@ -515,7 +515,7 @@ fn integration_test_redeem_issuing_cancel_reimburse_insufficient_collateral_for_
             .dispatch(origin_of(account_of(VAULT))));
         assert_eq!(
             ParachainState::get(),
-            pre_minting_state.with_changes(|_user, vault, _, _fee_pool, _| {
+            pre_minting_state.with_changes(|_user, vault, _, _fee_pool| {
                 vault.issued += redeem.amount_btc + redeem.transfer_fee_btc;
                 vault.free_tokens += redeem.amount_btc + redeem.transfer_fee_btc;
             })
@@ -542,7 +542,7 @@ fn integration_test_redeem_issuing_cancel_no_reimburse() {
 
         assert_eq!(
             ParachainState::get(),
-            ParachainState::default().with_changes(|user, vault, _, fee_pool, _| {
+            ParachainState::default().with_changes(|user, vault, _, fee_pool| {
                 // with sla of 80, vault gets slashed for 15%: punishment of 10 to user, 5 to fee pool
 
                 fee_pool.vault_backing_rewards += vault_rewards(amount_without_fee_backing / 20);
@@ -589,7 +589,7 @@ fn integration_test_redeem_issuing_cancel_liquidated_no_reimburse() {
         // NOTE: changes are relative the the post liquidation state
         assert_eq!(
             ParachainState::get(),
-            post_liquidation_state.with_changes(|user, vault, liquidation_vault, _fee_pool, _| {
+            post_liquidation_state.with_changes(|user, vault, liquidation_vault, _fee_pool| {
                 // to-be-redeemed decreased, forwarding to liquidation vault
                 vault.to_be_redeemed -= redeem.amount_btc + redeem.transfer_fee_btc;
                 liquidation_vault.to_be_redeemed -= redeem.amount_btc + redeem.transfer_fee_btc;
@@ -642,7 +642,7 @@ fn integration_test_redeem_issuing_cancel_liquidated_reimburse() {
         // NOTE: changes are relative the the post liquidation state
         assert_eq!(
             ParachainState::get(),
-            post_liquidation_state.with_changes(|user, vault, liquidation_vault, fee_pool, _| {
+            post_liquidation_state.with_changes(|user, vault, liquidation_vault, fee_pool| {
                 // to-be-redeemed decreased, forwarding to liquidation vault
                 vault.to_be_redeemed -= redeem.amount_btc + redeem.transfer_fee_btc;
                 liquidation_vault.to_be_redeemed -= redeem.amount_btc + redeem.transfer_fee_btc;
@@ -698,7 +698,7 @@ fn integration_test_redeem_issuing_execute_liquidated() {
         // NOTE: changes are relative the the post liquidation state
         assert_eq!(
             ParachainState::get(),
-            post_liquidation_state.with_changes(|user, vault, liquidation_vault, fee_pool, _| {
+            post_liquidation_state.with_changes(|user, vault, liquidation_vault, fee_pool| {
                 // fee given to fee pool
                 fee_pool.vault_issuing_rewards += vault_rewards(redeem.fee);
 

--- a/parachain/runtime/tests/test_vault_registry.rs
+++ b/parachain/runtime/tests/test_vault_registry.rs
@@ -26,7 +26,7 @@ mod deposit_collateral_test {
 
             assert_eq!(
                 ParachainState::get(),
-                ParachainState::default().with_changes(|_, vault, _, _, _| {
+                ParachainState::default().with_changes(|_, vault, _, _| {
                     vault.backing_collateral += amount;
                     vault.free_balance -= amount;
                 })
@@ -44,7 +44,7 @@ mod deposit_collateral_test {
 
             assert_eq!(
                 ParachainState::get(),
-                ParachainState::default().with_changes(|_, vault, _, _, _| {
+                ParachainState::default().with_changes(|_, vault, _, _| {
                     vault.backing_collateral += amount;
                     vault.free_balance -= amount;
                 })
@@ -82,7 +82,7 @@ mod withdraw_collateral_test {
 
             assert_eq!(
                 ParachainState::get(),
-                ParachainState::default().with_changes(|_, vault, _, _, _| {
+                ParachainState::default().with_changes(|_, vault, _, _| {
                     vault.backing_collateral -= amount;
                     vault.free_balance += amount;
                 })
@@ -100,7 +100,7 @@ mod withdraw_collateral_test {
 
             assert_eq!(
                 ParachainState::get(),
-                ParachainState::default().with_changes(|_, vault, _, _, _| {
+                ParachainState::default().with_changes(|_, vault, _, _| {
                     vault.backing_collateral -= amount;
                     vault.free_balance += amount;
                 })

--- a/parachain/runtime/tests/test_vault_registry.rs
+++ b/parachain/runtime/tests/test_vault_registry.rs
@@ -164,7 +164,7 @@ fn integration_test_vault_registry_undercollateralization_liquidation() {
 
         assert_eq!(
             ParachainState::get(),
-            ParachainState::default().with_changes(|_, vault, liquidation_vault, _, _| {
+            ParachainState::default().with_changes(|_, vault, liquidation_vault, _| {
                 liquidation_vault.backing_collateral = (DEFAULT_VAULT_BACKING_COLLATERAL
                     * (DEFAULT_VAULT_ISSUED + DEFAULT_VAULT_TO_BE_ISSUED - DEFAULT_VAULT_TO_BE_REDEEMED))
                     / (DEFAULT_VAULT_ISSUED + DEFAULT_VAULT_TO_BE_ISSUED);


### PR DESCRIPTION
At the moment, direct nominator withdrawals are made through the `request_collateral_withdrawal` dispatchable function.

Still need to implement/test the following:
- (implement) Liquidating vault for stealing minimizes nominator slashing
- (implement) Nominator reward distribution
- (implement) Vault withdrawal can force-refund nominators (related to reward distribution)
- (test) Non-operators cannot have collateral nominated
- (test) Nominations cannot exceed the max nomination ratio