### PR TITLE
Add rust-toolchain override file

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,16 +96,13 @@ Please also install the following dependencies:
 
 ### Installation
 
-Building requires `nightly`. Run the following commands to set it up:
+Building requires a specific rust toolchain and nightly compiler version. The
+requirements are specified in the [./rust-toolchain.toml](./rust-toolchain.toml)
+[override file][].
 
-```
-rustup toolchain install nightly-2021-03-15
-rustup default nightly-2021-03-15
-rustup component add rustfmt
-rustup component add rls
-rustup toolchain install nightly
-rustup target add wasm32-unknown-unknown --toolchain nightly-2021-03-15
-```
+Running `rustup show` from the root directory of this repo should be enough to
+set up the toolchain and you can inspect the output to verify that it matches
+the version specified in the override file.
 
 To build, run:
 
@@ -114,6 +111,8 @@ cargo build
 ```
 
 For more detailed development instructions [see here](./parachain/README.md).
+
+[override file]: https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
 
 ### Testing
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly-2021-03-15"
+components = [ "rustfmt", "rls" ]
+targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
This PR just suggests automating setup of the required toolchain for users and devs. We didn't discuss in our calls, but since this is as easy to suggest in a PR as it is in any other, form... :)

Feel free to close without comment if you'd rather not add this to your setup.

In our development, we have found that override files can help avoid time loss and productivity risks due to developer toolchains diverging after updates or users incorrectly following instructions.

Surfaced from @informalsystems' audit of interlay/btc-parachain at
e4cb057