### PR TITLE
Replace magic numbers with named constants

### DIFF
--- a/crates/bitcoin/src/script.rs
+++ b/crates/bitcoin/src/script.rs
@@ -39,16 +39,20 @@ impl Script {
 
     pub fn is_p2wpkh_v0(&self) -> bool {
         // first byte is version
-        self.len() == 22 && self.bytes[0] == OpCode::Op0 as u8 && self.bytes[1] == HASH160_SIZE_HEX
+        self.len() == P2WPKH_V0_SCRIPT_SIZE as usize
+            && self.bytes[0] == OpCode::Op0 as u8
+            && self.bytes[1] == HASH160_SIZE_HEX
     }
 
     pub fn is_p2wsh_v0(&self) -> bool {
         // first byte is version
-        self.len() == 34 && self.bytes[0] == OpCode::Op0 as u8 && self.bytes[1] == HASH256_SIZE_HEX
+        self.len() == P2WSH_V0_SCRIPT_SIZE as usize
+            && self.bytes[0] == OpCode::Op0 as u8
+            && self.bytes[1] == HASH256_SIZE_HEX
     }
 
     pub fn is_p2pkh(&self) -> bool {
-        self.len() == 25
+        self.len() == P2PKH_SCRIPT_SIZE as usize
             && self.bytes[0] == OpCode::OpDup as u8
             && self.bytes[1] == OpCode::OpHash160 as u8
             && self.bytes[2] == HASH160_SIZE_HEX
@@ -57,7 +61,7 @@ impl Script {
     }
 
     pub fn is_p2sh(&self) -> bool {
-        self.len() == 23
+        self.len() == P2SH_SCRIPT_SIZE as usize
             && self.bytes[0] == OpCode::OpHash160 as u8
             && self.bytes[1] == HASH160_SIZE_HEX
             && self.bytes[22] == OpCode::OpEqual as u8

--- a/crates/bitcoin/src/types.rs
+++ b/crates/bitcoin/src/types.rs
@@ -231,6 +231,8 @@ impl sp_std::fmt::Debug for RawBlockHeader {
 // Constants
 pub const P2PKH_SCRIPT_SIZE: u32 = 25;
 pub const P2SH_SCRIPT_SIZE: u32 = 23;
+pub const P2WPKH_V0_SCRIPT_SIZE: u32 = 22;
+pub const P2WSH_V0_SCRIPT_SIZE: u32 = 34;
 pub const HASH160_SIZE_HEX: u8 = 0x14;
 pub const HASH256_SIZE_HEX: u8 = 0x20;
 pub const MAX_OPRETURN_SIZE: usize = 83;


### PR DESCRIPTION
Uses named constants for script length checks instead of magic numbers.
Aims to improve readability and reduce chance of discrepancy.

Discussed in meeting last week.

Surfaced from @informalsystems' audit of interlay/btc-parachain at
e4cb057