### PR TITLE
fix: use an enum instead two separate options in Transaction

### DIFF
--- a/crates/bitcoin/src/formatter.rs
+++ b/crates/bitcoin/src/formatter.rs
@@ -196,10 +196,9 @@ impl Formattable<bool> for Transaction {
             }
         }
 
-        // only block_height or locktime should ever be Some
-        if let Some(b) = self.block_height.or(self.locktime) {
-            formatter.format(b)
-        }
+        match self.lock_at {
+            LockTime::BlockHeight(b) | LockTime::Time(b) => formatter.format(b),
+        };
 
         formatter.result()
     }

--- a/crates/bitcoin/src/parser.rs
+++ b/crates/bitcoin/src/parser.rs
@@ -323,10 +323,10 @@ pub fn parse_transaction(raw_transaction: &[u8]) -> Result<Transaction, Error> {
 
     // https://en.bitcoin.it/wiki/NLockTime
     let locktime_or_blockheight: u32 = parser.parse()?;
-    let (locktime, block_height) = if locktime_or_blockheight < LOCKTIME_THRESHOLD {
-        (None, Some(locktime_or_blockheight))
+    let lock_at = if locktime_or_blockheight < LOCKTIME_THRESHOLD {
+        LockTime::BlockHeight(locktime_or_blockheight)
     } else {
-        (Some(locktime_or_blockheight), None)
+        LockTime::Time(locktime_or_blockheight)
     };
 
     if flags != 0 {
@@ -337,8 +337,7 @@ pub fn parse_transaction(raw_transaction: &[u8]) -> Result<Transaction, Error> {
         version,
         inputs,
         outputs,
-        block_height,
-        locktime,
+        lock_at,
     })
 }
 
@@ -656,8 +655,7 @@ pub(crate) mod tests {
         assert_eq!(inputs[0].coinbase, true);
         assert_eq!(inputs[1].coinbase, false);
         assert_eq!(outputs.len(), 1);
-        assert_eq!(transaction.locktime, None);
-        assert_eq!(transaction.block_height, Some(0));
+        assert_eq!(transaction.lock_at, LockTime::BlockHeight(0));
     }
 
     #[test]
@@ -679,8 +677,7 @@ pub(crate) mod tests {
             &outputs[0].script.as_hex(),
             "a9144a1154d50b03292b3024370901711946cb7cccc387"
         );
-        assert_eq!(transaction.block_height, Some(0));
-        assert_eq!(transaction.locktime, None);
+        assert_eq!(transaction.lock_at, LockTime::BlockHeight(0));
     }
 
     #[test]

--- a/crates/bitcoin/src/types.rs
+++ b/crates/bitcoin/src/types.rs
@@ -323,8 +323,7 @@ pub struct Transaction {
     pub version: i32,
     pub inputs: Vec<TransactionInput>,
     pub outputs: Vec<TransactionOutput>,
-    pub block_height: Option<u32>, //FIXME: why is this optional?
-    pub locktime: Option<u32>,     //FIXME: why is this optional?
+    pub lock_at: LockTime,
 }
 
 #[cfg_attr(test, mockable)]
@@ -338,6 +337,13 @@ impl Transaction {
     }
 }
 
+// https://en.bitcoin.it/wiki/NLockTime
+#[derive(PartialEq, Debug, Clone)]
+pub enum LockTime {
+    /// time as unix timestamp
+    Time(u32),
+    BlockHeight(u32),
+}
 /// Bitcoin block: header and transactions
 #[derive(Default, Clone, PartialEq, Debug)]
 pub struct Block {
@@ -665,8 +671,7 @@ impl Default for TransactionBuilder {
                 version: 2,
                 inputs: vec![],
                 outputs: vec![],
-                block_height: Some(0),
-                locktime: None,
+                lock_at: LockTime::BlockHeight(0),
             },
         }
     }
@@ -683,14 +688,12 @@ impl TransactionBuilder {
     }
 
     pub fn with_block_height(&mut self, block_height: u32) -> &mut Self {
-        self.transaction.block_height = Some(block_height);
-        self.transaction.locktime = None;
+        self.transaction.lock_at = LockTime::BlockHeight(block_height);
         self
     }
 
     pub fn with_locktime(&mut self, locktime: u32) -> &mut Self {
-        self.transaction.locktime = Some(locktime);
-        self.transaction.block_height = None;
+        self.transaction.lock_at = LockTime::Time(locktime);
         self
     }
 

--- a/crates/btc-relay/src/tests.rs
+++ b/crates/btc-relay/src/tests.rs
@@ -2058,8 +2058,7 @@ fn sample_transaction_parsed(outputs: &Vec<TransactionOutput>) -> Transaction {
         version: 2,
         inputs,
         outputs: outputs.to_vec(),
-        block_height: Some(203),
-        locktime: Some(0),
+        lock_at: LockTime::BlockHeight(203),
     }
 }
 


### PR DESCRIPTION
Fixes [this report](https://www.notion.so/interlay/f207ebc861994e2988fcbd32895561f6?v=b4dc7a68fa584fabbabc646063b5d02e&p=982e022b44cc404aa11a58e6c491a1af)